### PR TITLE
chore: remove gatsby-plugin-loadable-components-ssr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@theowenyoung/gatsby-source-git": "^2.3.1",
         "framer-motion": "^4.1.17",
         "gatsby": "^4.6.1",
-        "gatsby-plugin-loadable-components-ssr": "^4.2.0",
         "gatsby-plugin-manifest": "^4.3.0",
         "gatsby-plugin-mdx": "^2.14.0",
         "gatsby-plugin-next-seo": "^1.9.0",
@@ -4754,23 +4753,6 @@
         "win32"
       ]
     },
-    "node_modules/@loadable/babel-plugin": {
-      "version": "5.13.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-syntax-dynamic-import": "^7.7.4"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@loadable/component": {
       "version": "5.15.2",
       "license": "MIT",
@@ -4788,41 +4770,6 @@
       },
       "peerDependencies": {
         "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@loadable/server": {
-      "version": "5.15.2",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@loadable/component": "^5.0.1",
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@loadable/webpack-plugin": {
-      "version": "5.15.2",
-      "license": "MIT",
-      "dependencies": {
-        "make-dir": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "webpack": ">=4.6.0"
       }
     },
     "node_modules/@manypkg/find-root": {
@@ -13549,24 +13496,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/gatsby-plugin-loadable-components-ssr": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.6",
-        "@loadable/babel-plugin": "^5.13.2",
-        "@loadable/server": "^5.15.0",
-        "@loadable/webpack-plugin": "^5.15.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@loadable/component": "^5.15.0",
-        "gatsby": "^2.12.1 || ^3.0.0 || ^4.0.0",
-        "react-dom": "^16.12.0 || ^17.0.1"
       }
     },
     "node_modules/gatsby-plugin-manifest": {
@@ -32632,30 +32561,12 @@
       "integrity": "sha512-cK+Elf3RjEzrm3SerAhrFWL5oQAsZSJ/LmjL1joIpTfEP1etJJ9CTRvdaV6XLYAxaEkfdhk/9hOvHLbR9yIhCA==",
       "optional": true
     },
-    "@loadable/babel-plugin": {
-      "version": "5.13.2",
-      "requires": {
-        "@babel/plugin-syntax-dynamic-import": "^7.7.4"
-      }
-    },
     "@loadable/component": {
       "version": "5.15.2",
       "requires": {
         "@babel/runtime": "^7.7.7",
         "hoist-non-react-statics": "^3.3.1",
         "react-is": "^16.12.0"
-      }
-    },
-    "@loadable/server": {
-      "version": "5.15.2",
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
-    "@loadable/webpack-plugin": {
-      "version": "5.15.2",
-      "requires": {
-        "make-dir": "^3.0.2"
       }
     },
     "@manypkg/find-root": {
@@ -38613,15 +38524,6 @@
           "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
           "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ=="
         }
-      }
-    },
-    "gatsby-plugin-loadable-components-ssr": {
-      "version": "4.2.0",
-      "requires": {
-        "@babel/runtime": "^7.9.6",
-        "@loadable/babel-plugin": "^5.13.2",
-        "@loadable/server": "^5.15.0",
-        "@loadable/webpack-plugin": "^5.15.0"
       }
     },
     "gatsby-plugin-manifest": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@theowenyoung/gatsby-source-git": "^2.3.1",
     "framer-motion": "^4.1.17",
     "gatsby": "^4.6.1",
-    "gatsby-plugin-loadable-components-ssr": "^4.2.0",
     "gatsby-plugin-manifest": "^4.3.0",
     "gatsby-plugin-mdx": "^2.14.0",
     "gatsby-plugin-next-seo": "^1.9.0",


### PR DESCRIPTION
This is not compatible with React 18 and Gatsby 5