### PR TITLE
ci(eslint): load babel preset react

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,12 @@ module.exports = {
       }
     }
   },
+  parserOptions: {
+    "requireConfigFile": false,
+    "babelOptions": {
+      "presets": ["@babel/preset-react"]
+   },
+  },
   extends: ['plugin:mdx/recommended', 'eslint:recommended', 'plugin:import/recommended'],
   globals: {
     "window": true,


### PR DESCRIPTION
This is required for future versions of eslint.