### PR TITLE
fix(ci): Don't run prod build with prefix-paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           npm ci
-          npm run build
+          npm run build -- --prefix-paths
 
       # NOTE(sileht): workflow run on/pull_request doesn't have access to
       # secrets

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "docs",
   "private": true,
   "scripts": {
-    "build": "gatsby build --prefix-paths",
+    "build": "gatsby build",
     "serve": "gatsby serve",
     "develop": "gatsby develop",
     "eslint": "eslint src",


### PR DESCRIPTION
Don't append prefix to assets path in production