### PR TITLE
chore(gatsby): remove unknown options

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -64,20 +64,6 @@ const plugins = [
     options: {
       extensions: ['.mdx', '.md'],
       gatsbyRemarkPlugins,
-      remarkPlugins: [
-        [
-          remarkTypescript,
-          {
-            filter: isWrapped({wrapperComponent: 'MultiCodeBlock'}),
-            customTransformations: [highlightPreservation()],
-            prettierOptions: {
-              trailingComma: 'all',
-              singleQuote: true
-            }
-          }
-        ]
-      ],
-      rehypePlugins: [[import('rehype-autolink-headings'), {behavior: 'wrap'}]]
     },
   },
   {


### PR DESCRIPTION
Fixes:
  warn Warning: there are unknown plugin options for "gatsby-plugin-mdx": remarkPlugins, rehypePlugins