### PR TITLE
chore(gatsby): remove gatsby-remark-copy-linked-files

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,12 +7,6 @@ const {
 const gatsbyRemarkPlugins = [
   '@fec/remark-a11y-emoji/gatsby',
   {
-    resolve: 'gatsby-remark-copy-linked-files',
-    options: {
-      ignoreFileExtensions: []
-    }
-  },
-  {
     resolve: 'gatsby-remark-autolink-headers',
     options: {
       icon: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "gatsby-plugin-svgr": "^3.0.0-beta.0",
         "gatsby-plugin-webfonts": "^2.3.2",
         "gatsby-remark-autolink-headers": "^6.7.0",
-        "gatsby-remark-copy-linked-files": "^6.7.0",
         "gatsby-remark-images": "^7.7.0",
         "gatsby-source-filesystem": "^5.7.0",
         "gatsby-transformer-json": "^5.7.0",
@@ -12584,27 +12583,6 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
       "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
     },
-    "node_modules/gatsby-remark-copy-linked-files": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-6.7.0.tgz",
-      "integrity": "sha512-UF85A7kpnY7gqBH2kvvU88VbTmsXH6vcrKo8cQvgwR1wodk6mX1zvsR5hmKUfkAoR8yRhkuZho8frg6Zts56Hw==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "cheerio": "^1.0.0-rc.10",
-        "fs-extra": "^11.1.0",
-        "is-relative-url": "^3.0.0",
-        "lodash": "^4.17.21",
-        "path-is-inside": "^1.0.2",
-        "probe-image-size": "^7.2.3",
-        "unist-util-visit": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "gatsby": "^5.0.0-next"
-      }
-    },
     "node_modules/gatsby-remark-images": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-7.7.0.tgz",
@@ -18125,6 +18103,7 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
       "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -18141,6 +18120,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -19161,11 +19141,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w=="
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -20041,6 +20016,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
       "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "peer": true,
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",
@@ -23071,6 +23047,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
       "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "peer": true,
       "dependencies": {
         "debug": "2"
       }
@@ -23079,6 +23056,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -23086,7 +23064,8 @@
     "node_modules/stream-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "peer": true
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -34934,21 +34913,6 @@
         }
       }
     },
-    "gatsby-remark-copy-linked-files": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-6.7.0.tgz",
-      "integrity": "sha512-UF85A7kpnY7gqBH2kvvU88VbTmsXH6vcrKo8cQvgwR1wodk6mX1zvsR5hmKUfkAoR8yRhkuZho8frg6Zts56Hw==",
-      "requires": {
-        "@babel/runtime": "^7.20.13",
-        "cheerio": "^1.0.0-rc.10",
-        "fs-extra": "^11.1.0",
-        "is-relative-url": "^3.0.0",
-        "lodash": "^4.17.21",
-        "path-is-inside": "^1.0.2",
-        "probe-image-size": "^7.2.3",
-        "unist-util-visit": "^2.0.3"
-      }
-    },
     "gatsby-remark-images": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-7.7.0.tgz",
@@ -38450,6 +38414,7 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
       "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "peer": true,
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -38460,6 +38425,7 @@
           "version": "3.2.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "peer": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -39186,11 +39152,6 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w=="
-    },
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -39750,6 +39711,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
       "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "peer": true,
       "requires": {
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",
@@ -41975,6 +41937,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
       "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "peer": true,
       "requires": {
         "debug": "2"
       },
@@ -41983,6 +41946,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "peer": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -41990,7 +41954,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "gatsby-plugin-svgr": "^3.0.0-beta.0",
     "gatsby-plugin-webfonts": "^2.3.2",
     "gatsby-remark-autolink-headers": "^6.7.0",
-    "gatsby-remark-copy-linked-files": "^6.7.0",
     "gatsby-remark-images": "^7.7.0",
     "gatsby-source-filesystem": "^5.7.0",
     "gatsby-transformer-json": "^5.7.0",


### PR DESCRIPTION
We don't need this.