### PR TITLE
chore: remove gatsby-remark-check-links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,9 +19,6 @@ const gatsbyRemarkPlugins = [
     }
   },
   {
-    resolve: 'gatsby-remark-check-links'
-  },
-  {
     resolve: `gatsby-remark-images`,
     options: {
       maxWidth: 1200,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "gatsby-plugin-svgr": "^3.0.0-beta.0",
         "gatsby-plugin-webfonts": "^2.3.2",
         "gatsby-remark-autolink-headers": "^6.10.0",
-        "gatsby-remark-check-links": "^2.1.0",
         "gatsby-remark-copy-linked-files": "^6.10.0",
         "gatsby-remark-images": "^7.9.0",
         "gatsby-source-filesystem": "^5.9.0",
@@ -13364,35 +13363,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
       "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
-    },
-    "node_modules/gatsby-remark-check-links": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-check-links/-/gatsby-remark-check-links-2.1.0.tgz",
-      "integrity": "sha512-TbhT8oVlAgJfxe0WUQWDOb0kLkMUYo1N4AfFstejClPWO4OjRlznt3IMW3weQkwuweiovF5cxVpQcFrkCGVFBw==",
-      "dependencies": {
-        "unist-util-visit": "^1.4.1"
-      }
-    },
-    "node_modules/gatsby-remark-check-links/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-    },
-    "node_modules/gatsby-remark-check-links/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/gatsby-remark-check-links/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
-      }
     },
     "node_modules/gatsby-remark-copy-linked-files": {
       "version": "6.10.0",
@@ -36787,37 +36757,6 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
           "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
-        }
-      }
-    },
-    "gatsby-remark-check-links": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-check-links/-/gatsby-remark-check-links-2.1.0.tgz",
-      "integrity": "sha512-TbhT8oVlAgJfxe0WUQWDOb0kLkMUYo1N4AfFstejClPWO4OjRlznt3IMW3weQkwuweiovF5cxVpQcFrkCGVFBw==",
-      "requires": {
-        "unist-util-visit": "^1.4.1"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "gatsby-plugin-svgr": "^3.0.0-beta.0",
     "gatsby-plugin-webfonts": "^2.3.2",
     "gatsby-remark-autolink-headers": "^6.10.0",
-    "gatsby-remark-check-links": "^2.1.0",
     "gatsby-remark-copy-linked-files": "^6.10.0",
     "gatsby-remark-images": "^7.9.0",
     "gatsby-source-filesystem": "^5.9.0",


### PR DESCRIPTION
This works poorly and does not catch real errors.