### PR TITLE
fix: Prism code colors are missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "parse-numeric-range": "^1.3.0",
         "path-browserify": "^1.0.1",
         "polished": "^4.2.2",
-        "prism-react-renderer": "^1.3.5",
+        "prism-react-renderer": "^2.0.4",
         "prismjs": "^1.29.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -6145,8 +6145,7 @@
     "node_modules/@types/prismjs": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
-      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==",
-      "dev": true
+      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -8464,6 +8463,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color": {
@@ -20275,11 +20282,15 @@
       }
     },
     "node_modules/prism-react-renderer": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.0.4.tgz",
+      "integrity": "sha512-1fcayBPhlGWLjKHeZMA2eJbvLsq1YJsoP3CUOF0BNlobw4knAYS6EWHYawywaZ5zoIxYkgxuqrrkCj7b+135ow==",
+      "dependencies": {
+        "@types/prismjs": "^1.26.0",
+        "clsx": "^1.2.1"
+      },
       "peerDependencies": {
-        "react": ">=0.14.9"
+        "react": ">=16.0.0"
       }
     },
     "node_modules/prismjs": {
@@ -30174,8 +30185,7 @@
     "@types/prismjs": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
-      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==",
-      "dev": true
+      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ=="
     },
     "@types/prop-types": {
       "version": "15.7.5",
@@ -31906,6 +31916,11 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "color": {
       "version": "4.2.3",
@@ -40361,10 +40376,13 @@
       }
     },
     "prism-react-renderer": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-      "requires": {}
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.0.4.tgz",
+      "integrity": "sha512-1fcayBPhlGWLjKHeZMA2eJbvLsq1YJsoP3CUOF0BNlobw4knAYS6EWHYawywaZ5zoIxYkgxuqrrkCj7b+135ow==",
+      "requires": {
+        "@types/prismjs": "^1.26.0",
+        "clsx": "^1.2.1"
+      }
     },
     "prismjs": {
       "version": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mdast-util-to-string": "^3.2.0",
     "path-browserify": "^1.0.1",
     "prismjs": "^1.29.0",
-    "prism-react-renderer": "^1.3.5",
+    "prism-react-renderer": "^2.0.4",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-icons": "^4.8.0",

--- a/src/chakra-helpers/CodeBlock.tsx
+++ b/src/chakra-helpers/CodeBlock.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/named
-import Highlight, {Language} from 'prism-react-renderer';
+import {Highlight, themes} from 'prism-react-renderer';
 import Prism from 'prismjs';
 import React, {ReactNode, createContext, useContext, useState} from 'react';
 import fenceparser from 'fenceparser';
@@ -92,7 +92,7 @@ export const MarkdownCodeBlock = ({
 };
 
 export type CodeBlockProps = {
-  language?: Language;
+  language?: string;
   title?: string;
   linesToHighlight?: number[];
   disableCopy?: boolean;
@@ -126,6 +126,7 @@ export const CodeBlock = ({
   );
 
   const blockLanguage = getNormalizedLanguage(language);
+  const theme = useColorModeValue(themes.github, themes.duotoneDark);
 
   return (
     <Box>
@@ -140,7 +141,8 @@ export const CodeBlock = ({
         // @ts-ignore
         Prism={Prism}
         code={code}
-        language={language}
+        language={language as string}
+        theme={theme}
       >
         {({className, style, tokens, getLineProps, getTokenProps}) => {
           // length of longest line number
@@ -149,7 +151,7 @@ export const CodeBlock = ({
 
           // create an array of lines highlighted by "highlight-start" and
           // "highlight-end" comments
-          const highlightRange = [];
+          const highlightRange: number[] = [];
           let isHighlighting = false;
           let highlightOffset = 0;
           for (let i = 0; i < tokens.length; i++) {
@@ -226,7 +228,7 @@ export const CodeBlock = ({
                             // for line highlighting to go all the way across code block
                             minW="full"
                             w="fit-content"
-                            bg={shouldHighlight && highlightColor}
+                            bg={shouldHighlight ? highlightColor : 'none'}
                           >
                             {showLineNumbers && (
                               <Box


### PR DESCRIPTION
Colors for code blocks was broken. I had to update `prism-react-renderer` to its latest version. With this, I was able to specify a theme for `prism` wich contains all styles for code colors. I've picked two themes one light and one dark, but the can be changed easily now.

`github` theme
<img width="832" alt="image" src="https://github.com/Mergifyio/docs/assets/40125772/3ea1f7e3-fc73-4cd3-965f-29c48d7dcf64">

`duotoneDark` theme
<img width="817" alt="image" src="https://github.com/Mergifyio/docs/assets/40125772/1a8078dc-20e3-4cd2-899b-6b682bd5aa60">
