### PR TITLE
fix: Color for inline code blocks

### DIFF
--- a/src/components/ActionOptionsTable.tsx
+++ b/src/components/ActionOptionsTable.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import ReactMarkdown from 'react-markdown';
 import configSchema from '../content/mergify-configuration-openapi.json';
 import InlineCode from './InlineCode';
+import { mdxComponents } from './Page';
 
 interface Props {
   /** Action's name to retrieve its options */
@@ -33,18 +34,16 @@ export default function ActionOptionsTable({ action }: Props) {
         {Object.entries(options).map(([optionKey, definition]) => (
           <Tr>
             <Td sx={{whiteSpace: 'nowrap'}}>
-              <code>{optionKey}</code>
+              <InlineCode>{optionKey}</InlineCode>
             </Td>
             <Td>{definition.valueType}</Td>
             <Td>
-              <ReactMarkdown components={{
-                code: InlineCode
-              }}>
+              <InlineCode>
                 {definition.default}
-              </ReactMarkdown>
+              </InlineCode>
             </Td>
             <Td>
-              <ReactMarkdown>
+              <ReactMarkdown components={mdxComponents as any}>
                 {definition.description}
               </ReactMarkdown>
             </Td>

--- a/src/components/Page.jsx
+++ b/src/components/Page.jsx
@@ -40,7 +40,6 @@ import {
   chakra
 } from '@chakra-ui/react';
 import {FaComment, FaGithub} from 'react-icons/fa';
-import {FiStar} from 'react-icons/fi';
 import {MDXProvider} from '@mdx-js/react';
 import {PathContext, useFieldTableStyles} from '../utils';
 import {TOTAL_HEADER_HEIGHT} from './Header';
@@ -129,9 +128,10 @@ const components = {
   undefined: Fragment // because remark-a11y-emoji adds <undefined> around stuff
 };
 
-const mdxComponents = {
+export const mdxComponents = {
   ...components,
   inlineCode: InlineCode,
+  code: InlineCode,
   Button, // TODO: consider making pages import this from @chakra-ui/react
   ExpansionPanel,
   ExpansionPanelList,


### PR DESCRIPTION
We now have good looking inline `code` components

<img width="225" alt="image" src="https://github.com/Mergifyio/docs/assets/40125772/8fe741da-d28e-44b1-8053-81130214a584">
<img width="852" alt="image" src="https://github.com/Mergifyio/docs/assets/40125772/69ed50ef-780d-4fab-8344-f6296aafaa92">
