### PR TITLE
fix: Increasing main scroller width

### DIFF
--- a/src/components/PageLayout.jsx
+++ b/src/components/PageLayout.jsx
@@ -88,7 +88,7 @@ export default function Page({
       >
         {banner}
         <Flex
-          maxW="6xl"
+          maxW="8xl"
           mx="auto"
           align="flex-start"
           px={{base: 6, md: 10}}


### PR DESCRIPTION
Increasing the main scroller width to fill available space. This fix some tables that overflows.