### PR TITLE
fix: Don't display default value of action option if there is nothing…

### DIFF
--- a/src/components/ActionOptionsTable.tsx
+++ b/src/components/ActionOptionsTable.tsx
@@ -42,9 +42,11 @@ export default function ActionOptionsTable({ action }: Props) {
               </Td>
               <Td>{valueTypeLink ? <Link color='primary' textDecoration='underline' href={valueTypeLink}>{definition.valueType}</Link> : definition.valueType}</Td>
               <Td>
-                <InlineCode>
-                  {definition.default}
-                </InlineCode>
+                {!!definition.default && (
+                  <InlineCode>
+                    {definition.default}
+                  </InlineCode>
+                )}
               </Td>
               <Td>
                 <ReactMarkdown components={mdxComponents as any}>


### PR DESCRIPTION
In action's options table, if an option has no default value, the `InlineCode` component is still displayed with empty value which renders a little square without anything inside.