### PR TITLE
fix: Default value of options not displayed sometimes

### DIFF
--- a/src/components/ActionOptionsTable.tsx
+++ b/src/components/ActionOptionsTable.tsx
@@ -14,12 +14,16 @@ interface Props {
 interface OptionDefinition {
   valueType: string;
   description: string;
-  default: string;
+  default: string | boolean;
   $ref: any;
 }
 
 export default function ActionOptionsTable({ action }: Props) {
   const options = configSchema.definitions.Actions.properties[action].properties as {[optionKey: string]: OptionDefinition};
+
+  const hasDefaultValue = (definition: OptionDefinition) => {
+    return definition.default !== undefined && String(definition.default).length > 0
+  }
 
   return (
     <Table>
@@ -42,9 +46,9 @@ export default function ActionOptionsTable({ action }: Props) {
               </Td>
               <Td>{valueTypeLink ? <Link color='primary' textDecoration='underline' href={valueTypeLink}>{definition.valueType}</Link> : definition.valueType}</Td>
               <Td>
-                {!!definition.default && (
+                {hasDefaultValue(definition) && (
                   <InlineCode>
-                    {definition.default}
+                    {String(definition.default)}
                   </InlineCode>
                 )}
               </Td>


### PR DESCRIPTION
Default value display was not correct in some cases:
- The value can be a boolean, and when it's false, it's not rendered because of the rendering condition.
- We have empty string as default value sometimes, which renders a empty square, it seems to be a mistake in the config specification that I will address later. But for now I'm checking the length of the default value.