### PR TITLE
docs: remove RST strings and convert in markdown

### DIFF
--- a/src/content/mergify-configuration-openapi.json
+++ b/src/content/mergify-configuration-openapi.json
@@ -677,7 +677,7 @@
           "properties": {
             "assignees": {
               "default": "",
-              "description": "Users to assign the newly created pull request. As the type is :ref:`data type template`, you could use, e.g., ``{{author}}`` to assign the pull request to its original author.",
+              "description": "Users to assign the newly created pull request. As the type is a data type template, you could use, e.g., `{{author}}` to assign the pull request to its original author.",
               "valueType": "list of Template",
               "$ref": "#/definitions/TemplateArray"
             },
@@ -688,7 +688,7 @@
               "$ref": "#/definitions/Template"
             },
             "bot_account": {
-              "description": "Mergify can impersonate a GitHub user to backport a pull request. If no ``bot_account`` is set, Mergify backports the pull request itself.",
+              "description": "Mergify can impersonate a GitHub user to backport a pull request. If no `bot_account` is set, Mergify backports the pull request itself.",
               "valueType": "Template",
               "default": "",
               "$ref": "#/definitions/Template"
@@ -714,7 +714,7 @@
             "label_conflicts": {
               "valueType": "string",
               "default": "conflicts",
-              "description": "The label to add to the created pull request if it has conflicts and ``ignore_conflicts`` is set to ``true``.",
+              "description": "The label to add to the created pull request if it has conflicts and `ignore_conflicts` is set to `true`.",
               "type": "string"
             },
             "regexes": {
@@ -737,7 +737,7 @@
             "message": {
               "valueType": "Template",
               "default": "This pull request has been automatically closed by Mergify.",
-              "description": "The ``message`` to write as a comment after closing the pull request.",
+              "description": "The `message` to write as a comment after closing the pull request.",
               "$ref": "#/definitions/Template"
             }
           }
@@ -805,7 +805,7 @@
           "properties": {
             "bot_account": {
               "valueType": "Template",
-              "description": "Mergify can impersonate a GitHub user to comment a pull request. If no ``bot_account`` is set, Mergify will comment the pull request itself.",
+              "description": "Mergify can impersonate a GitHub user to comment a pull request. If no `bot_account` is set, Mergify will comment the pull request itself.",
               "$ref": "#/definitions/Template"
             },
             "message": {
@@ -822,7 +822,7 @@
               "type": "boolean",
               "valueType": "Boolean",
               "default": false,
-              "description": "If set to ``true``, the branch will be deleted even if another pull request depends on the head branch. GitHub will therefore close the dependent pull requests."
+              "description": "If set to `true`, the branch will be deleted even if another pull request depends on the head branch. GitHub will therefore close the dependent pull requests."
             }
           }
         },
@@ -831,7 +831,7 @@
           "properties": {
             "approved": {
               "valueType": "Boolean or list of string",
-              "description": "If set to ``true``, all the approving reviews will be removed when the pull request is updated. If set to ``false``, nothing will be done. If set to a list, each item should be the GitHub login of a user whose review will be removed. If set to ``from_requested_reviewers``, the list of requested reviewers will be used to get whose review will be removed.",
+              "description": "If set to `true`, all the approving reviews will be removed when the pull request is updated. If set to `false`, nothing will be done. If set to a list, each item should be the GitHub login of a user whose review will be removed. If set to `from_requested_reviewers`, the list of requested reviewers will be used to get whose review will be removed.",
               "default": true,
               "anyOf": [
                 {
@@ -847,7 +847,7 @@
             },
             "changes_requested": {
               "valueType": "Boolean or list of string",
-              "description": "If set to ``true``, all the reviews requesting changes will be removed when the pull request is updated. If set to ``false``, nothing will be done. If set to a list, each item should be the GitHub login of a user whose review will be removed. If set to ``from_requested_reviewers``, the list of requested reviewers will be used to get whose review will be removed.",
+              "description": "If set to `true`, all the reviews requesting changes will be removed when the pull request is updated. If set to `false`, nothing will be done. If set to a list, each item should be the GitHub login of a user whose review will be removed. If set to `from_requested_reviewers`, the list of requested reviewers will be used to get whose review will be removed.",
               "default": true,
               "anyOf": [
                 {
@@ -869,7 +869,7 @@
             },
             "when": {
               "valueType": "synchronize or always",
-              "description": "If set to ``synchronize``, the action will run only if the pull request commits changed. Otherwise, it will run each time the rule matches.",
+              "description": "If set to `synchronize`, the action will run only if the pull request commits changed. Otherwise, it will run each time the rule matches.",
               "default": "synchronize",
               "enum": [
                 "synchronize",
@@ -883,7 +883,7 @@
           "properties": {
             "draft": {
               "valueType": "Boolean",
-              "description": "If the pull request should be a draft (``true``) or the other way around (``false``).",
+              "description": "If the pull request should be a draft (`true`) or the other way around (`false`).",
               "default": "None",
               "type": "boolean"
             }
@@ -923,17 +923,17 @@
           "properties": {
             "commit_message_template": {
               "valueType": "Template",
-              "description": "Template to use as the commit message when using the ``merge`` or ``squash`` merge method. Template can also be defined in the pull request body (see :ref:`commit message`).",
+              "description": "Template to use as the commit message when using the `merge` or `squash` merge method.",
               "$ref": "#/definitions/Template"
             },
             "merge_bot_account": {
               "valueType": "Template",
-              "description": "Mergify can impersonate a GitHub user to merge pull request. If no ``merge_bot_account`` is set, Mergify will merge the pull request itself. The user account **must** have already been logged in Mergify dashboard once and have **write** or **maintain** permission.",
+              "description": "Mergify can impersonate a GitHub user to merge pull request. If no `merge_bot_account` is set, Mergify will merge the pull request itself. The user account **must** have already been logged in Mergify dashboard once and have **write** or **maintain** permission.",
               "$ref": "#/definitions/Template"
             },
             "method": {
               "valueType": "string",
-              "description": "Merge method to use. Possible values are ``merge``, ``squash``, ``rebase`` or ``fast-forward``.",
+              "description": "Merge method to use. Possible values are `merge`, `squash`, `rebase` or `fast-forward`.",
               "$ref": "#/definitions/MergeMethod",
               "default": "merge"
             },
@@ -981,22 +981,22 @@
               "valueType": "Boolean",
               "type": "boolean",
               "default": true,
-              "description": "This option is relevant only if you do inplace checks and if you use the ``rebase`` option of the ``update_method``. It will automatically squash your commits beginning by ``squash!``, ``fixup!`` or ``amend!``, just like the option with the same name when doing a ``git rebase``.",
+              "description": "This option is relevant only if you do inplace checks and if you use the `rebase` option of the `update_method`. It will automatically squash your commits beginning by `squash!`, `fixup!` or `amend!`, just like the option with the same name when doing a `git rebase`.",
               "$ref": "#/definitions/Template"
             },
             "commit_message_template": {
-              "description": "Template to use as the commit message when using the ``merge`` or ``squash`` merge method. Template can also be defined in the pull request body (see :ref:`commit message`).\n This option has been moved under the :ref:`queue rules` section of the configuration and will be removed from this section in the future.",
+              "description": "Template to use as the commit message when using the `merge` or `squash` merge method. This option has been moved under the queue rules section of the configuration and will be removed from this section in the future.",
               "valueType": "Template",
               "$ref": "#/definitions/Template"
             },
             "merge_bot_account": {
               "valueType": "Template",
-              "description": "Mergify can impersonate a GitHub user to merge pull request. If no ``merge_bot_account`` is set, Mergify will merge the pull request itself. The user account **must** have already been logged in Mergify dashboard once and have **write** or **maintain** permission.\n This option overrides the value defined in the :ref:`queue rules` section of the configuration.",
+              "description": "Mergify can impersonate a GitHub user to merge pull request. If no `merge_bot_account` is set, Mergify will merge the pull request itself. The user account **must** have already been logged in Mergify dashboard once and have **write** or **maintain** permission.\n This option overrides the value defined in the queue rules section of the configuration.",
               "$ref": "#/definitions/Template"
             },
             "method": {
               "valueType": "string",
-              "description": "Merge method to use. Possible values are ``merge``, ``squash``, ``rebase`` or ``fast-forward``. ``fast-forward`` is not supported on queues with ``speculative_checks > 1``, ``batch_size > 1``, or with ``allow_inplace_checks`` set to ``false``.\n This option overrides the value defined in the :ref:`queue rules` section of the configuration.",
+              "description": "Merge method to use. Possible values are `merge`, `squash`, `rebase` or `fast-forward`. `fast-forward` is not supported on queues with `speculative_checks > 1`, `batch_size > 1`, or with `allow_inplace_checks` set to `false`.\n This option overrides the value defined in the queue rules section of the configuration.",
               "enum": [
                 "merge",
                 "squash",
@@ -1007,14 +1007,14 @@
             "name": {
               "type": "string",
               "default": "default",
-              "description": "The name of the queue where the pull request should be added. If no name is set, ``routing_conditions`` will be applied instead."
+              "description": "The name of the queue where the pull request should be added. If no name is set, `routing_conditions` will be applied instead."
             },
             "priority": {
               "$ref": "#/definitions/Priority",
               "default": "medium",
-              "valueType": "1 <= integer <= 10000 or ``low`` or ``medium`` or ``high``",
+              "valueType": "1 <= integer <= 10000 or `low` or `medium` or `high`",
               "deprecated": true,
-              "description": "To set your priorities, you should now use :ref:`priority_rules`. This sets the priority of the pull request in the queue. The pull request with the highest priority is merged first. ``low``, ``medium``, ``high`` are aliases for ``1000``, ``2000``, ``3000``."
+              "description": "To set your priorities, you should now use `priority_rules`. This sets the priority of the pull request in the queue. The pull request with the highest priority is merged first. `low`, `medium`, `high` are aliases for `1000`, `2000`, `3000`."
             },
             "allow_merging_configuration_change": {
               "valueType": "Boolean",
@@ -1040,11 +1040,11 @@
             "update_bot_account": {
               "valueType": "Template",
               "$ref": "#/definitions/Template",
-              "description": "For certain actions, such as rebasing branches, Mergify has to impersonate a GitHub user. You can specify the account to use with this option. If no ``update_bot_account`` is set, Mergify picks randomly one of the organization users instead. The user account **must** have already been logged in Mergify dashboard once.\n\n This option overrides the value defined in the :ref:`queue rules` section of the configuration."
+              "description": "For certain actions, such as rebasing branches, Mergify has to impersonate a GitHub user. You can specify the account to use with this option. If no `update_bot_account` is set, Mergify picks randomly one of the organization users instead. The user account **must** have already been logged in Mergify dashboard once.\n\n This option overrides the value defined in the queue rules section of the configuration."
             },
             "update_method": {
               "valueType": "string",
-              "description": "``merge`` for all merge methods except ``fast-forward`` where ``rebase`` is used Method to use to update the pull request with its base branch when the speculative check is done in-place. Possible values: \n * ``merge`` to merge the base branch into the pull request. * ``rebase`` to rebase the pull request against its base branch. \n Note that the ``rebase`` method has some drawbacks, see :ref:`update method rebase`. \n This option overrides the value defined in the :ref:`queue rules` section of the configuration.",
+              "description": "`merge` for all merge methods except `fast-forward` where `rebase` is used Method to use to update the pull request with its base branch when the speculative check is done in-place. Possible values: \n * `merge` to merge the base branch into the pull request. * `rebase` to rebase the pull request against its base branch. \n This option overrides the value defined in the queue rules section of the configuration.",
               "enum": [
                 "merge",
                 "rebase"
@@ -1059,12 +1059,12 @@
               "valueType": "Boolean",
               "type": "boolean",
               "default": true,
-              "description": "When set to ``True``, commits starting with ``fixup!``, ``squash!`` and ``amend!``are squashed during the rebase."
+              "description": "When set to `True`, commits starting with `fixup!`, `squash!` and `amend!`are squashed during the rebase."
             },
             "bot_account": {
               "valueType": "Template",
               "$ref": "#/definitions/Template",
-              "description": "To rebase, Mergify needs to impersonate a GitHub user. You can specify the account to use with this option. If no ``bot_account`` is set, Mergify picks the pull request author. The user account **must** have already been logged in Mergify dashboard once."
+              "description": "To rebase, Mergify needs to impersonate a GitHub user. You can specify the account to use with this option. If no `bot_account` is set, Mergify picks the pull request author. The user account **must** have already been logged in Mergify dashboard once."
             }
           }
         },
@@ -1087,12 +1087,12 @@
               "valueType": "list of string or dictionary of login and weight"
             },
             "bot_account": {
-              "description": "Mergify can impersonate a GitHub user to request a review on a pull request. If no ``bot_account`` is set, Mergify will request the review itself.",
+              "description": "Mergify can impersonate a GitHub user to request a review on a pull request. If no `bot_account` is set, Mergify will request the review itself.",
               "valueType": "Template",
               "$ref": "#/definitions/Template"
             },
             "random_count": {
-              "description": "Pick random users and teams from the provided lists. When ``random_count`` is specified, ``users`` and ``teams`` can be a dictionary where the key is the login and the value is the weight to use. Weight must be between 1 and 65535 included.",
+              "description": "Pick random users and teams from the provided lists. When `random_count` is specified, `users` and `teams` can be a dictionary where the key is the login and the value is the weight to use. Weight must be between 1 and 65535 included.",
               "valueType": "integer between 1 and 15",
               "type": "number",
               "minimum": 1,
@@ -1105,7 +1105,7 @@
           "properties": {
             "bot_account": {
               "valueType": "Template",
-              "description": "Mergify can impersonate a GitHub user to review a pull request. If no ``bot_account`` is set, Mergify will review the pull request itself.",
+              "description": "Mergify can impersonate a GitHub user to review a pull request. If no `bot_account` is set, Mergify will review the pull request itself.",
               "$ref": "#/definitions/Template"
             },
             "message": {
@@ -1116,7 +1116,7 @@
             "type": {
               "default": "APPROVE",
               "valueType": "string",
-              "description": "The kind of review, can be ``APPROVE``, ``REQUEST_CHANGES``, ``COMMENT``",
+              "description": "The kind of review, can be `APPROVE`, `REQUEST_CHANGES`, `COMMENT`",
               "enum": [
                 "APPROVE",
                 "REQUEST_CHANGES",
@@ -1129,7 +1129,7 @@
           "type": "object",
           "properties": {
             "bot_account": {
-              "description": "Mergify can impersonate a GitHub user to review a pull request. If no ``bot_account`` is set, Mergify will update the pull request itself.",
+              "description": "Mergify can impersonate a GitHub user to review a pull request. If no `bot_account` is set, Mergify will update the pull request itself.",
               "valueType": "Template",
               "$ref": "#/definitions/Template"
             }
@@ -1139,13 +1139,13 @@
           "type": "object",
           "properties": {
             "bot_account": {
-              "description": "Mergify can impersonate a GitHub user to review a pull request. If no ``bot_account`` is set, Mergify will squash the pull request itself.",
+              "description": "Mergify can impersonate a GitHub user to review a pull request. If no `bot_account` is set, Mergify will squash the pull request itself.",
               "valueType": "Template",
               "$ref": "#/definitions/Template"
             },
             "commit_message": {
               "valueType": "string",
-              "description": "Defines what commit message to use for the squashed commit if no commit message is defined in the pull request body (see :ref:`commit message`). Possible values are:\n- ``all-commits`` to use the same format as GitHub squashed merge commit.\n- ``first-commit`` to use the message of the first commit of the pull request.\n- ``title+body`` means to use the title and body from the pull request   itself as the commit message. The pull request number will be added to   end of the title.",
+              "description": "Defines what commit message to use for the squashed commit if no commit message is defined in the pull request body. Possible values are:\n- `all-commits` to use the same format as GitHub squashed merge commit.\n- `first-commit` to use the message of the first commit of the pull request.\n- `title+body` means to use the title and body from the pull request itself as the commit message. The pull request number will be added to end of the title.",
               "enum": [
                 "all-commits",
                 "first-commit",


### PR DESCRIPTION
There was some formatting coming from the old rst docs.