### PR TITLE
fix: Add line-height to all table's cells

### DIFF
--- a/src/components/ActionOptionsTable.tsx
+++ b/src/components/ActionOptionsTable.tsx
@@ -50,14 +50,14 @@ export default function ActionOptionsTable({ action }: Props) {
                 <InlineCode>{optionKey}</InlineCode>
               </Td>
               <Td>{valueTypeLink ? <Link color="primary" textDecoration="underline" href={valueTypeLink}>{definition.valueType}</Link> : definition.valueType}</Td>
-              <Td>
+              <Td lineHeight="7">
                 {hasDefaultValue(definition) && (
                   <InlineCode>
                     {String(definition.default)}
                   </InlineCode>
                 )}
               </Td>
-              <Td>
+              <Td lineHeight="7">
                 <ReactMarkdown components={mdxComponents as any}>
                   {definition.description}
                 </ReactMarkdown>

--- a/src/components/PullRequestAttributesTable.jsx
+++ b/src/components/PullRequestAttributesTable.jsx
@@ -39,7 +39,7 @@ export default function PullRequestAttributesTable() {
                 <InlineCode>{attr.key}</InlineCode>
               </Td>
               <Td>{dataTypeLink ? <Link color="primary" textDecoration="underline" href={dataTypeLink}>{attr.dataType}</Link> : attr.dataType}</Td>
-              <Td>
+              <Td lineHeight="7">
                 <ReactMarkdown components={mdxComponents}>
                   {attr.description}
                 </ReactMarkdown>

--- a/src/content/configuration/conditions.mdx
+++ b/src/content/configuration/conditions.mdx
@@ -108,21 +108,21 @@ Here is a list of the available operators:
     <Tr>
       <Td>Equal</Td>
       <Td>``=`` or ``:``</Td>
-      <Td>This operator checks for strict equality. If the target attribute
+      <Td lineHeight='7'>This operator checks for strict equality. If the target attribute
        type is a list, each element of the list is compared against the value
        and the condition is true if **any** value matches.</Td>
     </Tr>
     <Tr>
       <Td>Not Equal</Td>
       <Td>``!=`` or ``≠``</Td>
-      <Td>This operator checks for non equality. If the target attribute type
+      <Td lineHeight='7'>This operator checks for non equality. If the target attribute type
        is a list, each element of the list is compared against the value and
        the condition is true if no value matches.</Td>
     </Tr>
     <Tr>
       <Td>Match</Td>
       <Td>`~=`</Td>
-      <Td>This operator checks for [regular
+      <Td lineHeight='7'>This operator checks for [regular
        expressions](data-types#regular-expressions)
        matching. If the target attribute type is a list, each
        element of the list is matched against the value and the condition is
@@ -131,28 +131,28 @@ Here is a list of the available operators:
     <Tr>
       <Td>Greater Than or Equal</Td>
       <Td>`>=` or `≥`</Td>
-      <Td>This operator checks for the value to be greater than or equal to the
+      <Td lineHeight='7'>This operator checks for the value to be greater than or equal to the
           provided value. It's usually used to compare against the length of a
           list using the ``#`` prefix.</Td>
     </Tr>
     <Tr>
       <Td>Greater Than</Td>
       <Td>`>`</Td>
-      <Td>This operator checks for the value to be greater than the provided
+      <Td lineHeight='7'>This operator checks for the value to be greater than the provided
        value. It's usually used to compare against the length of a list using
        the `#` prefix.</Td>
     </Tr>
     <Tr>
       <Td>Lesser Than or Equal</Td>
       <Td>`<=` or `≤`</Td>
-      <Td>This operator checks for the value to be lesser then or equal to the
+      <Td lineHeight='7'>This operator checks for the value to be lesser then or equal to the
        provided value. It's usually used to compare against the length of a
        list using the ``#`` prefix.</Td>
     </Tr>
     <Tr>
       <Td>Lesser Than</Td>
       <Td>``<``</Td>
-      <Td>
+      <Td lineHeight='7'>
        This operator checks for the value to be lesser than the provided value. It's
         usually used to compare against the length of a list using the `#` prefix.
       </Td>


### PR DESCRIPTION
Adding `line-height` to all table's cells for more readability