### PR TITLE
fix(api): Bad retrieving of openapi.json

### DIFF
--- a/src/pages/api.tsx
+++ b/src/pages/api.tsx
@@ -1,12 +1,35 @@
 import { API } from '@stoplight/elements';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import '@stoplight/elements/styles.min.css';
 
+async function getOpenapiDocument(): Promise<string> {
+  try {
+    const response = await window.fetch('https://api.mergify.com/v1/openapi.json');
+
+    if (response.ok) {
+      return await response.json();
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to fetch openapi.json.');
+  }
+
+  return '';
+}
+
 export default function APISpecifications() {
+  const [openapiDocument, setOpenapiDocument] = useState<string | null>(null);
+
+  useEffect(() => {
+    getOpenapiDocument().then((doc) => {
+      setOpenapiDocument(doc);
+    });
+  }, []);
+
   return (
     <div>
-      <API apiDescriptionDocument="https://api.mergify.com/v1/openapi.json" basePath="/api" router={typeof window === 'undefined' ? 'memory' : 'history'} />
+      {!!openapiDocument && <API apiDescriptionDocument={openapiDocument} basePath="/api" router={typeof window === 'undefined' ? 'memory' : 'history'} />}
     </div>
   );
 }


### PR DESCRIPTION
There is a `apiDescriptionUrl` which is meant for specifying the url of the `openapi.json` in the stoplight component. But it is not working. So instead I am manually fetching the json and passing it to the component.