### PR TITLE
ci: change Slack channels for reporting deployments (#7109)

### DIFF
--- a/.github/workflows/docs-upload-gcp-prod.yaml
+++ b/.github/workflows/docs-upload-gcp-prod.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           type: deploy-start
           project: "documentation (gatsby)"
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENT_WEBHOOK_URL_RELEASES }}
 
       - name: Build 🔧
         run: |
@@ -56,4 +56,5 @@ jobs:
         with:
           type: deploy-finish
           project: "documentation (gatsby)"
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENT_WEBHOOK_URL_RELEASES }}
+          FAILURE_ONLY_SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENT_WEBHOOK_URL_PROD }}


### PR DESCRIPTION
Slack channel #prod is becoming very noisy, this aims to reduce the
noise by reporting deployments in #releases and only deployments
failures in #prod.