### PR TITLE
fix: Bug on stoplight list of strings

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -19,3 +19,7 @@ figcaption {
     margin-left: auto;   /* These two lines will center the caption if it's shorter than the image */
     margin-right: auto;
 }
+
+.sl-flex-wrap-wrap {
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
There is a really odd css bug with `@stoplight/elements` which is used to render the openapi specs.
When it renders a list of strings, every string renders in columns (see screenshot below, hard to describe)

The problem is that the container of the list's classname get prepend with an additional `-wrap` which is `sl-flex-wrap-wrap` instead of just `sl-flex-wrap`.

Cannot say why it's happening, so as a quick fix I add the missing css for that classname.
