### PR TITLE
fix: Show ToC only from xl displays

### DIFF
--- a/src/components/Page.jsx
+++ b/src/components/Page.jsx
@@ -239,7 +239,7 @@ export default function Page({
             toc !== false ? (
               // hide the table of contents on the home page
               <chakra.aside
-                display={{ base: 'none', lg: 'flex' }}
+                display={{ base: 'none', xl: 'flex' }}
                 flexDirection="column"
                 ml={{ base: 10, xl: 16 }}
                 w={250}


### PR DESCRIPTION
Simply making the Table of Contents show if the display is large enough (`xl` starts from about 1300px width). This is exactly what Apollo does in their current docs