### PR TITLE
fix: Add line height to value type column

### DIFF
--- a/src/components/OptionsTable.tsx
+++ b/src/components/OptionsTable.tsx
@@ -62,7 +62,7 @@ export function OptionsTableBase(options: OptionDefinition) {
                 <Td>
                   <InlineCode>{optionKey}</InlineCode>
                 </Td>
-                <Td>
+                <Td lineHeight="7">
                   {valueType}
                 </Td>
                 <Td lineHeight="7">

--- a/src/components/PullRequestAttributesTable.jsx
+++ b/src/components/PullRequestAttributesTable.jsx
@@ -35,7 +35,7 @@ export default function PullRequestAttributesTable() {
               <Td sx={{ whiteSpace: 'nowrap' }}>
                 <InlineCode>{attr.key}</InlineCode>
               </Td>
-              <Td>{valueType}</Td>
+              <Td lineHeight="7">{valueType}</Td>
               <Td lineHeight="7">
                 <ReactMarkdown components={mdxComponents}>
                   {attr.description}


### PR DESCRIPTION
Adding line height to the value type columns so `InlineCode` component won't overlap on text