### PR TITLE
chore: set cache-control for GCP

### DIFF
--- a/.github/workflows/docs-upload-gcp-prod.yaml
+++ b/.github/workflows/docs-upload-gcp-prod.yaml
@@ -47,10 +47,10 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v1'
 
       - name: Deploy 🚀
-        run: 'gsutil -m rsync -r ./public gs://mergify-docs-prod'
+        run: 'gsutil -m rsync -h "Cache-Control: public, max-age=600" -r ./public gs://mergify-docs-prod'
 
       - name: Cleanup
-        run: 'gsutil -m rsync -d -r ./public gs://mergify-docs-prod'
+        run: 'gsutil -m rsync -h "Cache-Control: public, max-age=600" -d -r ./public gs://mergify-docs-prod'
 
       - name: Deployment finish
         if: always()


### PR DESCRIPTION
The default expiration is 1 hours, reduces it to 10 minutes

Related INC-87