### PR TITLE
ci: increase timeout of docs-upload-to-gcp-prod

### DIFF
--- a/.github/workflows/docs-upload-gcp-prod.yaml
+++ b/.github/workflows/docs-upload-gcp-prod.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   docs-upload-to-gcp-prod:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
This can be long: https://github.com/Mergifyio/docs/actions/runs/6274582932/job/17051380264

Fixes INC-90