### PR TITLE
fix(cf): ensure Cloudflare doesn't touch the generated page

### DIFF
--- a/.github/workflows/docs-upload-gcp-prod.yaml
+++ b/.github/workflows/docs-upload-gcp-prod.yaml
@@ -53,7 +53,7 @@ jobs:
         run: 'gsutil -m rsync -d -r ./public gs://mergify-docs-prod'
 
       - name: Set header
-        run: 'gsutil -m setmeta -r -h "Cache-control:public, max-age=600" gs://mergify-docs-prod'
+        run: 'gsutil -m setmeta -r -h "Cache-control:public, max-age=600, no-transform" gs://mergify-docs-prod'
 
 
 


### PR DESCRIPTION
Cloudflare injects some javascripts into static website by default.

We should avoid that to be able to remove unsafe-inline from CSP.