### PR TITLE
fix: Page title is wrong sometimes

### DIFF
--- a/src/content/config.tsx
+++ b/src/content/config.tsx
@@ -21,6 +21,7 @@ const navItems: NavItem[] = [
   {
     title: 'Workflow Automation',
     icon: <BsGear />,
+    path: '/workflow',
     children: [
       { title: 'Writing Your First Rule', path: '/workflow/writing-your-first-rule' },
       {
@@ -33,6 +34,7 @@ const navItems: NavItem[] = [
       {
         title: 'Actions',
         icon: <BsRocket />,
+        path: '/workflow/actions',
         children: [
           { title: 'Assign', path: '/workflow/actions/assign' },
           { title: 'Backport', path: '/workflow/actions/backport' },
@@ -103,6 +105,7 @@ const navItems: NavItem[] = [
   {
     title: 'Integrations',
     icon: <BsPlugin />,
+    path: '/integrations',
     children: [
       { title: 'GitHub Actions', path: '/integrations/gha' },
       { title: 'Dependabot', path: '/integrations/dependabot' },


### PR DESCRIPTION
Some sidebar groups in the `config.tsx` don't have `path` but they still have a page displayed. Just adding the `path` so the sidebar can retrieve which item is active and add its title to the tab title 