### PR TITLE
chore(webpack): Add options to speed up local build

### DIFF
--- a/gatsby-node.mjs
+++ b/gatsby-node.mjs
@@ -12,6 +12,12 @@ import redirects from './redirects.json' assert {
 
 export const onCreateWebpackConfig = ({ actions, stage, plugins }) => {
   actions.setWebpackConfig({
+    devtool: "cheap-module-source-map",
+    cache: true,
+    watchOptions: {
+      poll: 500,
+      aggregateTimeout: 300,
+    },
     resolve: {
       fallback: {
         "stream": false,


### PR DESCRIPTION
Adding some webpack options that speeds up local builds a little. The most important is the `devtool: "cheap-module-source-map"` that should provide cheaper source map to reduce build time. 