### PR TITLE
fix: always add trailing Slash

### DIFF
--- a/gatsby-config.mjs
+++ b/gatsby-config.mjs
@@ -178,7 +178,7 @@ Boolean(process.env.ALGOLIA_WRITE_KEY) && plugins.push(algoliaPlugin)
 
 const config = {
   pathPrefix: '/' + process.env.PR_NUMBER + '/docs',
-  trailingSlash: 'ignore',
+  trailingSlash: 'always',
   siteMetadata: {
     title: 'Mergify Documentation',
     description: 'Learn how to use Mergify, the powerful pull request automation tool that helps teams merge code faster and more safely. Automate your entire pull request workflow, from code review to deployment, and save time and frustration.',


### PR DESCRIPTION
Using `trailingSlash: 'ignore'` will not generates redirect with page ending or not by `/`

For Cloudflare, if no page found, `/foo` == `/foo/` == `/foo/index.html`. And no redirect occurs foo/index.html will be serve for all of them.

We need to be explicit and choose which type of URL we prefer, and Gatsby will generate the appropriate pages/code to redirect all others to our prefered one.

So we need to set `trailingSlash` to `always` or `never`.
I pick `always` like we did for the old documentation.

Fixes MRGFY-2702