### PR TITLE
fix(search): Don't query algolia if search is not opened

### DIFF
--- a/src/components/SearchEngine/SearchBar.tsx
+++ b/src/components/SearchEngine/SearchBar.tsx
@@ -10,7 +10,7 @@ import { BsSearch } from 'react-icons/bs';
 import Results from './Results';
 import { Page } from './types';
 
-function useAlgoliaSearch(query: string) {
+function useAlgoliaSearch(query: string, open: boolean) {
   const [results, setResults] = useState<SearchResponse<Page>>();
 
   useEffect(() => {
@@ -27,8 +27,8 @@ function useAlgoliaSearch(query: string) {
       setResults(response);
     };
 
-    search();
-  }, [query]);
+    open && search();
+  }, [query, open]);
 
   return results;
 }
@@ -37,7 +37,7 @@ export default function SearchBar() {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
 
-  const searchResults = useAlgoliaSearch(search);
+  const searchResults = useAlgoliaSearch(search, open);
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(e.target.value);


### PR DESCRIPTION
Algolia is called once when the docs mount, we should make a query only if the search modal is opened 