### PR TITLE
feat(search): Search and display pages tables

### DIFF
--- a/gatsby-config.mjs
+++ b/gatsby-config.mjs
@@ -133,6 +133,11 @@ const algoliaPagesQuery = `
         fields {
           slug
         }
+        tables {
+          node
+          data
+          content
+        }
         excerpt(pruneLength: 1000)
         frontmatter {
           title

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "react-use": "^17.4.0",
         "rehype": "^12.0.1",
         "rehype-autolink-headings": "^7.0.0",
+        "rehype-raw": "^7.0.0",
         "rehype-react": "^8.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-typescript": "^0.6.1",
@@ -24726,6 +24727,333 @@
     "node_modules/rehype-parse/node_modules/web-namespaces": {
       "version": "2.0.1",
       "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/@types/hast": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.1.tgz",
+      "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/@types/mdast": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.1.tgz",
+      "integrity": "sha512-IlKct1rUTJ1T81d8OHzyop15kGv9A/ff7Gz7IJgrk6jDb4Udw77pCJ+vq8oxZf4Ghpm+616+i1s/LNg/Vh7d+g==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/@types/unist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
+    },
+    "node_modules/rehype-raw/node_modules/hast-util-from-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz",
+      "integrity": "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^8.0.0",
+        "property-information": "^6.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/hast-util-raw": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.1.tgz",
+      "integrity": "sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/hast-util-to-parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
+      "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/hastscript": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
+      "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/mdast-util-to-hast": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.0.2.tgz",
+      "integrity": "sha512-U5I+500EOOw9e3ZrclN3Is3fRpw8c19SMyNZlZ2IS+7vLsNzb2Om11VpIVOR+/0137GhZsFEF6YiKD5+0Hr2Og==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/micromark-util-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
+      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/micromark-util-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
+      "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/rehype-raw/node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
+      "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/micromark-util-symbol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
+      "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/rehype-raw/node_modules/micromark-util-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
+      "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/rehype-raw/node_modules/property-information": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.3.0.tgz",
+      "integrity": "sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/vfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+      "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/vfile-location": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.2.tgz",
+      "integrity": "sha512-NXPYyxyBSH7zB5U6+3uDdd6Nybz6o6/od9rk8bp9H8GR3L+cm/fC0uUTbqBmUTnMCUDslAGBOIKNfvvb+gGlDg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react-use": "^17.4.0",
     "rehype": "^12.0.1",
     "rehype-autolink-headings": "^7.0.0",
+    "rehype-raw": "^7.0.0",
     "rehype-react": "^8.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-typescript": "^0.6.1",

--- a/remark-headings-plugin.mjs
+++ b/remark-headings-plugin.mjs
@@ -1,5 +1,8 @@
 import {visit} from 'unist-util-visit'
 import {toString} from 'mdast-util-to-string'
+import configSchema from './static/mergify-configuration-openapi.json' assert {
+  type: "json",
+}
 
 export function remarkHeadingsPlugin() {
   return async function transformer(tree, file) {
@@ -18,5 +21,61 @@ export function remarkHeadingsPlugin() {
     }
 
     mdxFile.data.meta.headings = headings
+  }
+}
+
+export function remarkTablePlugin() {
+  return async function transformer(tree, file) {
+    const tables = []
+    visit(tree, 'mdxJsxFlowElement', element => {
+      switch(element.name) {
+        case 'OptionsTable':
+          const name = element.attributes.find(attr => attr.type === 'mdxJsxAttribute' && attr.name === 'name').value
+          const optionsTableData = configSchema?.definitions?.[name]?.properties
+          
+          tables.push({
+            node: JSON.stringify(element),
+            data: JSON.stringify(optionsTableData),
+            content: null
+          })
+          break;
+
+        case 'PullRequestAttributesTable':
+          const pullRequestAttributes = configSchema?.definitions?.PullRequestAttribute?.enum
+          
+          tables.push({
+            node: JSON.stringify(element),
+            data: JSON.stringify(pullRequestAttributes),
+            content: null
+          })       
+          break;
+          
+        case 'ActionOptionsTable':
+          const action = element.attributes.find(attr => attr.type === 'mdxJsxAttribute' && attr.name === 'action').value
+          const actionOptions = configSchema?.definitions?.Actions?.properties?.[action]?.properties
+          
+          tables.push({
+            node: JSON.stringify(element),
+            data: JSON.stringify(actionOptions),
+            content: null
+          })
+          break;   
+        case 'Table':
+          tables.push({
+            node: JSON.stringify(element),
+            // For raw tables, we need the content as string
+            // for algolia to search into
+            content: toString(element),
+            data: null
+          })
+          break;
+      }
+    })
+
+    const mdxFile = file
+    if (!mdxFile.data.meta) {
+      mdxFile.data.meta = {}
+    }
+    mdxFile.data.meta.tables = tables
   }
 }

--- a/src/@types/mdxast.ts
+++ b/src/@types/mdxast.ts
@@ -1,0 +1,28 @@
+export interface BaseMdxNode {
+  type: string;
+  name: string;
+  children: BaseMdxNode[]
+  value: string;
+  position: {
+    start:{
+      line:number,
+      column:number,
+      offset:number
+    },
+    end:{
+      line:number,
+      column:number,
+      offset:number
+    }
+  }
+}
+
+export interface MdxNodeJsxElement extends BaseMdxNode {
+  type: 'mdxJsxFlowElement';
+  attributes: Array<{
+    type: string,
+    name: string,
+    value: unknown
+  }>
+  children: BaseMdxNode[] | MdxNodeJsxElement[]
+}

--- a/src/components/OptionsTable.tsx
+++ b/src/components/OptionsTable.tsx
@@ -5,16 +5,19 @@ import * as yaml from 'js-yaml';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
+import rehypeRaw from 'rehype-raw';
+
 import configSchema from '../../static/mergify-configuration-openapi.json';
 
-import { getValueType, OptionDefinition } from './ConfigOptions';
+import { getValueType, HighlightCode, OptionDefinition } from './ConfigOptions';
 
 import InlineCode from './InlineCode';
-import { mdxComponents } from './Page';
+import { mdxComponents } from './mdxComponents';
 
 interface Props {
   /** Name to retrieve its options */
   name: keyof typeof configSchema.definitions;
+  options?: { [optionKey: string]: OptionDefinition }
 }
 
 interface RootProps {
@@ -73,11 +76,13 @@ export function OptionsTableBase(options: OptionDefinition) {
                 {!shouldHideDefaultColumn && (
                   <Td lineHeight="7">
                     {hasDefaultValue(definition) && (
-                      <InlineCode>
-                        {yaml.dump(definition.default, {
-                          noCompatMode: true, lineWidth: -1, quotingType: '"', noRefs: true,
-                        })}
-                      </InlineCode>
+                      <InlineCode
+                        dangerouslySetInnerHTML={{
+                          __html: yaml.dump(definition.default, {
+                            noCompatMode: true, lineWidth: -1, quotingType: '"', noRefs: true,
+                          }),
+                        }}
+                      />
                     )}
                   </Td>
                 )}
@@ -92,7 +97,10 @@ export function OptionsTableBase(options: OptionDefinition) {
                 <Tr>
                   {/* FIXME: don't hardcode the border color like that */}
                   <Td lineHeight="7" colSpan={shouldHideDefaultColumn ? '3' : '4'} style={{ borderBottom: '2px solid #eee' }}>
-                    <ReactMarkdown components={mdxComponents as any}>
+                    <ReactMarkdown
+                      rehypePlugins={[rehypeRaw as any]}
+                      components={{ ...mdxComponents, code: HighlightCode } as any}
+                    >
                       {definition.description}
                     </ReactMarkdown>
                   </Td>

--- a/src/components/Page.jsx
+++ b/src/components/Page.jsx
@@ -2,17 +2,7 @@ import {
   Box,
   Button,
   Heading,
-  ListItem,
-  OrderedList,
   Stack,
-  Table,
-  Tbody,
-  Td,
-  Text,
-  Th,
-  Thead,
-  Tr,
-  UnorderedList,
   chakra,
 } from '@chakra-ui/react';
 import { MDXProvider } from '@mdx-js/react';
@@ -29,29 +19,17 @@ import autolinkHeadings from 'rehype-autolink-headings';
 import rehypeReact from 'rehype-react';
 
 import {
-  MarkdownCodeBlock,
-} from '../chakra-helpers/CodeBlock';
-
-import {
-  MultiCodeBlock,
   MultiCodeBlockContext,
 } from '../chakra-helpers/MultiCodeBlock';
 
 import { PathContext } from '../utils';
 
-import Blockquote from './Blockquote';
-import CodeColumns from './CodeColumns';
-import ExpansionPanel, {
-  ExpansionPanelList,
-  ExpansionPanelListItem,
-} from './ExpansionPanel';
-
 import { TOTAL_HEADER_HEIGHT } from './Header';
 import InlineCode from './InlineCode';
 import PageLayout, { usePageLayoutProps } from './PageLayout';
-import RelativeLink, { ButtonLink } from './RelativeLink';
 
 import TableOfContents from './TableOfContents';
+import { components, mdxComponents } from './mdxComponents';
 
 // these must be imported after MarkdownCodeBlock
 import 'prismjs/components/prism-bash';
@@ -61,92 +39,7 @@ import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-yaml';
 
-const LIST_SPACING = 4;
 const HEADINGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
-
-const NESTED_LIST_STYLES = {
-  [['ul', 'ol']]: {
-    mt: 3,
-    fontSize: 'md',
-    lineHeight: 'normal',
-  },
-};
-
-const components = {
-  h1: (props) => <Heading as="h1" size="2xl" {...props} />,
-  h2: (props) => <Heading as="h2" size="xl" {...props} />,
-  h3: (props) => <Heading as="h3" size="lg" {...props} />,
-  h4: (props) => <Heading as="h4" size="md" {...props} />,
-  h5: (props) => <Heading as="h5" size="sm" {...props} />,
-  h6: (props) => <Heading as="h6" size="xs" {...props} />,
-  ul: (props) => (
-    <UnorderedList
-      spacing={LIST_SPACING}
-      sx={{
-        ...NESTED_LIST_STYLES,
-        ul: {
-          listStyleType: 'circle',
-        },
-      }}
-      {...props}
-    />
-  ),
-  ol: (props) => (
-    <OrderedList spacing={LIST_SPACING} sx={NESTED_LIST_STYLES} {...props} />
-  ),
-  li: (props) => (
-    <ListItem
-      sx={{
-        '>': {
-          ':not(:last-child)': {
-            mb: 3,
-          },
-        },
-      }}
-      {...props}
-    />
-  ),
-  p: Text,
-  a: RelativeLink,
-  pre: MarkdownCodeBlock,
-  table: (props) => (
-    <Box
-      rounded="md"
-      borderWidth={1}
-      overflow="auto"
-      sx={{ table: { borderWidth: 0 } }}
-    >
-      <Table {...props} />
-    </Box>
-  ),
-  thead: Thead,
-  tbody: Tbody,
-  tr: Tr,
-  th: Th,
-  td: (props) => (
-    <Td
-      sx={{
-        fontSize: 'md',
-      }}
-      {...props}
-    />
-  ),
-  blockquote: Blockquote,
-  undefined: Fragment, // because remark-a11y-emoji adds <undefined> around stuff
-};
-
-export const mdxComponents = {
-  ...components,
-  inlineCode: InlineCode,
-  code: InlineCode,
-  Button, // TODO: consider making pages import this from @chakra-ui/react
-  ExpansionPanel,
-  ExpansionPanelList,
-  ExpansionPanelListItem,
-  MultiCodeBlock,
-  CodeColumns,
-  ButtonLink,
-};
 
 const { processSync } = rehype()
   .data('settings', { fragment: true })

--- a/src/components/PullRequestAttributesTable.jsx
+++ b/src/components/PullRequestAttributesTable.jsx
@@ -5,16 +5,20 @@ import React from 'react';
 
 import ReactMarkdown from 'react-markdown';
 
+import rehypeRaw from 'rehype-raw';
+
 import configSchema from '../../static/mergify-configuration-openapi.json';
 
-import { getValueType } from './ConfigOptions';
+import { getValueType, HighlightCode } from './ConfigOptions';
 
 import InlineCode from './InlineCode';
 
-import { mdxComponents } from './Page';
+import { mdxComponents } from './mdxComponents';
 
-export default function PullRequestAttributesTable() {
-  const attributes = configSchema?.definitions?.PullRequestAttribute?.enum ?? [];
+// eslint-disable-next-line react/prop-types
+export default function PullRequestAttributesTable({ staticAttributes }) {
+  const attributes = staticAttributes
+  ?? configSchema?.definitions?.PullRequestAttribute?.enum ?? [];
 
   return (
     <Table>
@@ -33,11 +37,16 @@ export default function PullRequestAttributesTable() {
           return (
             <Tr>
               <Td sx={{ whiteSpace: 'nowrap' }}>
-                <InlineCode>{attr.key}</InlineCode>
+                <InlineCode dangerouslySetInnerHTML={{ __html: attr.key }} />
               </Td>
               <Td lineHeight="7">{valueType}</Td>
               <Td lineHeight="7">
-                <ReactMarkdown components={mdxComponents}>
+                <ReactMarkdown
+                  // Need that rehype-raw plugin to render HTML tags.
+                  // It allows <em> tags from algolia to render
+                  rehypePlugins={[rehypeRaw]}
+                  components={{ ...mdxComponents, code: HighlightCode }}
+                >
                   {attr.description}
                 </ReactMarkdown>
               </Td>

--- a/src/components/SearchEngine/PageDetails.tsx
+++ b/src/components/SearchEngine/PageDetails.tsx
@@ -4,6 +4,8 @@ import {
 import { Link } from 'gatsby';
 import React from 'react';
 
+import { renderMdxTable } from '../../utils/mdxast';
+
 import { AlgoliaResult } from './types';
 
 type HighlightHeading = NonNullable<NonNullable<AlgoliaResult['_highlightResult']>['tableOfContents']>;
@@ -55,10 +57,10 @@ function TableOfContents({ tableOfContents, slug }: TableOfContentsProps) {
 interface Props extends AlgoliaResult {}
 
 export default function Preview({
-  fields, _highlightResult, tableOfContents, _snippetResult,
+  fields, _highlightResult, _snippetResult, tables,
 }: Props) {
   return (
-    <VStack padding={4} justifyContent="flex-start" alignItems="start" flex={1} height="100%" overflow="auto">
+    <VStack padding={4} justifyContent="flex-start" alignItems="start" flex={2} height="100%" overflow="auto">
       <Text
         as={Link}
         to={fields.slug}
@@ -73,9 +75,16 @@ export default function Preview({
       />
       <Text
         fontSize="md"
-        marginTop={2}
+        marginY={2}
         dangerouslySetInnerHTML={{ __html: _snippetResult?.excerpt?.value ?? '' }}
       />
+      {_highlightResult?.tables?.filter((el) => el?.data?.matchLevel !== 'none' || (el?.content && el.content.matchLevel !== 'none')).map(
+        (table, index) => renderMdxTable({
+          data: table?.data?.value,
+          node: tables[index].node,
+          content: table?.content?.value,
+        }),
+      )}
       {_highlightResult?.tableOfContents && (
         <>
           <Divider marginY={2} />

--- a/src/components/SearchEngine/Results.tsx
+++ b/src/components/SearchEngine/Results.tsx
@@ -1,5 +1,5 @@
 import {
-  Box, VStack, Text, useColorModeValue, HStack, Divider, Show, theme,
+  Box, VStack, Text, useColorModeValue, HStack, Divider, Show,
 } from '@chakra-ui/react';
 import { Link, navigate } from 'gatsby';
 import React, { useEffect, useState } from 'react';
@@ -125,7 +125,7 @@ export default function Results({ results }: ResultsProps) {
     <HStack
       css={{
         em: {
-          color: theme.colors.linkedin[700],
+          color: '#003dff',
           fontStyle: 'normal',
           fontWeight: '500',
         },

--- a/src/components/SearchEngine/SearchBar.tsx
+++ b/src/components/SearchEngine/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { SearchResponse } from '@algolia/client-search';
 import {
   Divider, Input, InputGroup, InputLeftAddon, Modal,
-  ModalBody, ModalContent, ModalHeader, ModalOverlay,
+  ModalBody, ModalContent, ModalHeader, ModalOverlay, useColorModeValue,
 } from '@chakra-ui/react';
 import algoliasearch from 'algoliasearch/lite';
 import React, { useEffect, useState } from 'react';
@@ -21,7 +21,7 @@ function useAlgoliaSearch(query: string, open: boolean) {
       );
       const pagesIndex = searchClient.initIndex('docs-pages');
       const response = await pagesIndex.search<Page>(query, {
-        attributesToHighlight: ['excerpt', 'frontmatter', 'tableOfContents'],
+        attributesToHighlight: ['excerpt', 'frontmatter', 'tableOfContents', 'tables.data', 'tables.content'],
         attributesToSnippet: ['excerpt:40'],
       });
       setResults(response);
@@ -51,6 +51,7 @@ export default function SearchBar() {
     setOpen(false);
     setSearch('');
   };
+  const bgColor = useColorModeValue('white', 'blue.800');
 
   return (
     <>
@@ -58,9 +59,9 @@ export default function SearchBar() {
         <InputLeftAddon><BsSearch /></InputLeftAddon>
         <Input placeholder="Search Mergify" size="md" />
       </InputGroup>
-      <Modal scrollBehavior="inside" isOpen={open} onClose={handleClose} size="4xl">
+      <Modal scrollBehavior="inside" isOpen={open} onClose={handleClose}>
         <ModalOverlay />
-        <ModalContent height="100%">
+        <ModalContent background={bgColor} height="100%" maxWidth="90vw">
           <ModalHeader padding={0}>
             <InputGroup padding={1} onClick={handleOpen}>
               <InputLeftAddon background="none" border="none"><BsSearch /></InputLeftAddon>

--- a/src/components/SearchEngine/types.ts
+++ b/src/components/SearchEngine/types.ts
@@ -13,6 +13,11 @@ export type Page = {
   }
   excerpt: string;
   tableOfContents: Heading,
+  tables: {
+    node: string;
+    data: string | null;
+    content: string | null;
+  }[]
   frontmatter: {
     title: string;
     description: string;

--- a/src/components/mdxComponents.jsx
+++ b/src/components/mdxComponents.jsx
@@ -1,0 +1,122 @@
+import {
+  Box,
+  Button,
+  Heading,
+  ListItem,
+  OrderedList,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  UnorderedList,
+} from '@chakra-ui/react';
+import React, {
+  Fragment,
+} from 'react';
+
+import {
+  MarkdownCodeBlock,
+} from '../chakra-helpers/CodeBlock';
+
+import {
+  MultiCodeBlock,
+} from '../chakra-helpers/MultiCodeBlock';
+
+import Blockquote from './Blockquote';
+import CodeColumns from './CodeColumns';
+import ExpansionPanel, {
+  ExpansionPanelList,
+  ExpansionPanelListItem,
+} from './ExpansionPanel';
+
+import InlineCode from './InlineCode';
+import RelativeLink, { ButtonLink } from './RelativeLink';
+
+const LIST_SPACING = 4;
+
+const NESTED_LIST_STYLES = {
+  [['ul', 'ol']]: {
+    mt: 3,
+    fontSize: 'md',
+    lineHeight: 'normal',
+  },
+};
+
+export const components = {
+  h1: (props) => <Heading as="h1" size="2xl" {...props} />,
+  h2: (props) => <Heading as="h2" size="xl" {...props} />,
+  h3: (props) => <Heading as="h3" size="lg" {...props} />,
+  h4: (props) => <Heading as="h4" size="md" {...props} />,
+  h5: (props) => <Heading as="h5" size="sm" {...props} />,
+  h6: (props) => <Heading as="h6" size="xs" {...props} />,
+  ul: (props) => (
+    <UnorderedList
+      spacing={LIST_SPACING}
+      sx={{
+        ...NESTED_LIST_STYLES,
+        ul: {
+          listStyleType: 'circle',
+        },
+      }}
+      {...props}
+    />
+  ),
+  ol: (props) => (
+    <OrderedList spacing={LIST_SPACING} sx={NESTED_LIST_STYLES} {...props} />
+  ),
+  li: (props) => (
+    <ListItem
+      sx={{
+        '>': {
+          ':not(:last-child)': {
+            mb: 3,
+          },
+        },
+      }}
+      {...props}
+    />
+  ),
+  p: Text,
+  a: RelativeLink,
+  pre: MarkdownCodeBlock,
+  table: (props) => (
+    <Box
+      rounded="md"
+      borderWidth={1}
+      overflow="auto"
+      sx={{ table: { borderWidth: 0 } }}
+    >
+      <Table {...props} />
+    </Box>
+  ),
+  thead: Thead,
+  tbody: Tbody,
+  tr: Tr,
+  th: Th,
+  td: (props) => (
+    <Td
+      sx={{
+        fontSize: 'md',
+      }}
+      {...props}
+    />
+  ),
+  blockquote: Blockquote,
+  undefined: Fragment, // because remark-a11y-emoji adds <undefined> around stuff
+};
+
+export const mdxComponents = {
+  ...components,
+  inlineCode: InlineCode,
+  code: InlineCode,
+  Button, // TODO: consider making pages import this from @chakra-ui/react
+  ExpansionPanel,
+  ExpansionPanelList,
+  ExpansionPanelListItem,
+  MultiCodeBlock,
+  CodeColumns,
+  ButtonLink,
+};

--- a/src/utils/mdxast.tsx
+++ b/src/utils/mdxast.tsx
@@ -1,0 +1,247 @@
+import {
+  Td, Thead, Th, Tr, Tbody, Table,
+} from '@chakra-ui/react';
+import React from 'react';
+
+import { MdxNodeJsxElement } from '../@types/mdxast';
+import { OptionDefinition } from '../components/ConfigOptions';
+import InlineCode from '../components/InlineCode';
+import { OptionsTableBase } from '../components/OptionsTable';
+import PullRequestAttributesTable from '../components/PullRequestAttributesTable';
+import RelativeLink from '../components/RelativeLink';
+
+interface TableType {
+  node: string;
+  data: string | null;
+  content: string | null;
+}
+
+export function stripHtmlFromkeys(jsonObject: any) {
+  let stripped: any = {};
+  if (typeof jsonObject === 'string') {
+    return jsonObject;
+  }
+
+  if (Array.isArray(jsonObject)) {
+    stripped = jsonObject.map(stripHtmlFromkeys);
+  } else {
+    Object.entries(jsonObject).forEach(([key, value]) => {
+      const strippedKey = key.replace(/<\/?em>/g, '');
+
+      if (Array.isArray(value)) {
+        stripped[strippedKey] = value.map(stripHtmlFromkeys);
+      } else if (typeof value === 'object') {
+        stripped[strippedKey] = stripHtmlFromkeys(value);
+      } else {
+        stripped[strippedKey] = value;
+      }
+    });
+  }
+
+  return stripped;
+}
+
+function removeOptionsWithoutHighlight(
+  options:
+  | {
+    [optionKey: string]: OptionDefinition;
+  }
+  | OptionDefinition[],
+) {
+  let cleanOptions = {};
+
+  if (Array.isArray(options)) {
+    cleanOptions = options.filter((option) => JSON.stringify(option).includes('<em>'));
+  } else {
+    Object.entries(options).forEach(([key, definition]) => {
+      if (JSON.stringify(definition).includes('<em>')) {
+        cleanOptions[key] = definition;
+      }
+    });
+  }
+
+  return cleanOptions;
+}
+
+function extractHighlightsFromText(text: string | null) {
+  if (!text) return [];
+
+  const highlights = [];
+
+  const regex = /<em>(.*?)<\/em>/g;
+  let match;
+
+  while ((match = regex.exec(text)) !== null) {
+    highlights.push(match[1]);
+  }
+
+  return highlights;
+}
+
+/**
+ * Sometimes, Algolia will add <em> tags aroung escaped characters like: \n ==> \<em>n</em>.
+ * We need to prevent this, otherwise JSON.parse will throw an error
+ */
+function unhighlightEscapedCharacters(str: string): string {
+  return str.replaceAll(/\\<em>(.*?)<\/em>/g, '\\$1');
+}
+
+export function renderMdxTable(table: TableType) {
+  const node = JSON.parse(unhighlightEscapedCharacters(table.node)) as MdxNodeJsxElement;
+  const highlights = [...new Set(extractHighlightsFromText(table.content))];
+
+  const data = table.data
+    ? (stripHtmlFromkeys(JSON.parse(unhighlightEscapedCharacters(table.data))) as {
+      [optionKey: string]: OptionDefinition;
+    })
+    : {};
+  const onlyHighlightedOptions = removeOptionsWithoutHighlight(data) as any;
+
+  if (node.name === 'Table') { return renderMdxRawTable(node, highlights).element; }
+  if (Object.keys(onlyHighlightedOptions).length === 0) {
+    // return nothing if table is empty
+    return '';
+  }
+
+  switch (node.name) {
+    case 'OptionsTable': {
+      return OptionsTableBase(onlyHighlightedOptions);
+    }
+
+    case 'PullRequestAttributesTable': {
+      return <PullRequestAttributesTable staticAttributes={onlyHighlightedOptions} />;
+    }
+
+    case 'ActionOptionsTable': {
+      return OptionsTableBase(onlyHighlightedOptions);
+    }
+  }
+
+  return '';
+}
+
+const components = {
+  Td,
+  Thead,
+  Th,
+  Tr,
+  Table,
+  Tbody,
+  paragraph: 'p',
+  strong: 'strong',
+  inlineCode: InlineCode,
+  link: (props: any) => (
+    <RelativeLink href={props.node.url} title={props.node.title}>
+      {props.children}
+    </RelativeLink>
+  ),
+};
+
+const highlightText = (text: string, highlights: string[]) => {
+  let highlightedText = text;
+
+  highlights.forEach((highlight) => {
+    highlightedText = highlightedText.replaceAll(highlight, `<em>${highlight}</em>`);
+  });
+
+  return highlightedText;
+};
+
+function renderHighlightText(text: string) {
+  const splitText = [];
+  let lastMatchIndex = 0;
+
+  for (const match of text.matchAll(/<em>(.*?)<\/em>/g)) {
+    if (match) {
+      // Add the text between the last match and the current match to the split text array.
+      splitText.push(text.substring(lastMatchIndex, match.index));
+
+      // Add the matched text to the split text array, surrounded by <em> tags.
+      splitText.push(<em>{match[1]}</em>);
+
+      // Update the last match index to the index after the current match.
+      lastMatchIndex = (match.index ?? 0) + match[0].length;
+    }
+  }
+
+  // Add the remaining text to the split text array.
+  splitText.push(text.substring(lastMatchIndex));
+  return splitText;
+}
+
+export const renderMdxRawTable = (node: MdxNodeJsxElement, highlights: string[]):
+{ element: React.ReactElement | string, isHighlight: boolean } => {
+  const children = node.children?.map(
+    (child) => renderMdxRawTable(child as MdxNodeJsxElement, highlights),
+  ) ?? [];
+
+  if (node.type === 'mdxJsxFlowElement') {
+    const attributes = {};
+
+    node.attributes
+      .filter((attr) => attr.type === 'mdxJsxAttribute')
+      .forEach((attr) => { attributes[attr.name] = attr.value; });
+
+    if (!(components as any)[node.name]) {
+      // Don't throw on unknown component
+      return { element: '', isHighlight: false };
+    }
+    const isHighlight = children.some((child) => child.isHighlight);
+
+    if (node.name === 'Tr' && !isHighlight) {
+      return {
+        element: '',
+        isHighlight: false,
+      };
+    }
+
+    return {
+      element: React.createElement(
+        (components as any)[node.name],
+        { ...attributes },
+        children.map((child) => child.element),
+      ),
+      isHighlight,
+    };
+  }
+
+  if (node.type === 'text') {
+    // eslint-disable-next-line react/no-danger
+    const highlightedText = highlightText(node.value, highlights);
+    const isHighlight = highlightedText.includes('<em>');
+
+    return ({
+      element: (
+        <>
+          {renderHighlightText(highlightedText)}
+        </>
+      ),
+      isHighlight,
+    });
+  }
+  if (node.value) {
+    const isHighlight = node.value.includes('<em>');
+
+    return ({
+      element: React.createElement((components as any)[node.type], {}, node.value),
+      isHighlight,
+    });
+  }
+
+  if (!(components as any)[node.type]) {
+    // Don't throw on unknown component
+    return {
+      element: '',
+      isHighlight: false,
+    };
+  }
+
+  return ({
+    element: React.createElement(
+      (components as any)[node.type],
+      { node },
+      ...children.map((el) => el.element),
+    ),
+    isHighlight: children.some((el) => el.isHighlight),
+  });
+};


### PR DESCRIPTION
Adding ability to search through page's tables (options, PR attributes, operators, etc). If matched, tables are rendered within the page preview of the search modal.