### PR TITLE
fix(algolia): Replace `gatsby-plugin-algolia` by own integration

### DIFF
--- a/gatsby-config.mjs
+++ b/gatsby-config.mjs
@@ -90,7 +90,6 @@ const plugins = [
     }
   },
   'gatsby-plugin-local-docs', // local plugin
-  'algolia-plugin', // local plugin
   {
     resolve: 'gatsby-source-filesystem',
     options: {
@@ -120,6 +119,9 @@ const plugins = [
     },
   },
 ];
+
+/** Custom plugin to push records on algolia */
+Boolean(process.env.ALGOLIA_WRITE_KEY) && plugins.push('algolia-plugin')
 
 const config = {
   pathPrefix: '/' + process.env.PR_NUMBER + '/docs',

--- a/gatsby-config.mjs
+++ b/gatsby-config.mjs
@@ -90,6 +90,7 @@ const plugins = [
     }
   },
   'gatsby-plugin-local-docs', // local plugin
+  'algolia-plugin', // local plugin
   {
     resolve: 'gatsby-source-filesystem',
     options: {
@@ -117,69 +118,8 @@ const plugins = [
       transformHeaders: (headers, path) => headers,
       generateMatchPathRewrites: true,
     },
-  }
-];
-
-const algoliaPagesQuery = `
-{
-  pages: allFile(filter: {extension: {in: ["md", "mdx"]}}) {
-    nodes {
-      id
-      internal {
-        contentDigest
-      }
-      childMdx {
-        tableOfContents
-        fields {
-          slug
-        }
-        tables {
-          node
-          data
-          content
-        }
-        excerpt(pruneLength: 1000)
-        frontmatter {
-          title
-          description
-          toc
-          tags
-        }
-      }
-    }
-  }
-}
-`;
-
-const queries = [
-  {
-    query: algoliaPagesQuery,
-    transformer: ({ data }) => data.pages.nodes.map(node => {
-      const { childMdx, ...rest} = node;
-      delete rest.childMdx;
-      return {
-        ...childMdx,
-        ...rest
-      }
-    })
   },
 ];
-
-const algoliaPlugin = {
-  resolve: `gatsby-plugin-algolia`,
-  options: {
-    appId: process.env.GATSBY_ALGOLIA_APP_ID,
-    apiKey: process.env.ALGOLIA_WRITE_KEY,
-    indexName: 'docs-pages',
-    queries,
-    chunkSize: 20000,
-    dryRun: !process.env.ALGOLIA_WRITE_KEY,
-    mergeSettings: true, // Merge settings with the ones defined on Algolia dashboard
-    continueOnFailure: false,
-  },
-}
-
-Boolean(process.env.ALGOLIA_WRITE_KEY) && plugins.push(algoliaPlugin)
 
 const config = {
   pathPrefix: '/' + process.env.PR_NUMBER + '/docs',

--- a/plugins/algolia-plugin/gatsby-node.js
+++ b/plugins/algolia-plugin/gatsby-node.js
@@ -44,7 +44,7 @@ function transformRecords({data}) {
 exports.onPostBuild = async ({ graphql, reporter }) => {
   reporter.info('Starting indexing on algolia...')
   const client = algoliasearch(process.env.GATSBY_ALGOLIA_APP_ID, process.env.ALGOLIA_WRITE_KEY);
-  const index = client.initIndex('docs-pages-dev')
+  const index = client.initIndex('docs-pages')
   const data = await graphql(algoliaPagesQuery);
   const pages = transformRecords(data);
   

--- a/plugins/algolia-plugin/gatsby-node.js
+++ b/plugins/algolia-plugin/gatsby-node.js
@@ -1,0 +1,56 @@
+const algoliasearch = require('algoliasearch');
+
+const algoliaPagesQuery = `
+{
+  pages: allFile(filter: {extension: {in: ["md", "mdx"]}}) {
+    nodes {
+      id
+      childMdx {
+        tableOfContents
+        fields {
+          slug
+        }
+        tables {
+          node
+          data
+          content
+        }
+        excerpt(pruneLength: 1000)
+        frontmatter {
+          title
+          description
+          toc
+          tags
+        }
+      }
+    }
+  }
+}
+`;
+
+function transformRecords({data}) {
+  return data.pages.nodes.map(node => {
+    const { childMdx, id, ...rest} = node;
+    delete rest.childMdx;
+
+    return {
+      ...childMdx,
+      ...rest,
+      objectID: id,
+    }
+  })
+}
+
+exports.onPostBuild = async ({ graphql, reporter }) => {
+  reporter.info('Starting indexing on algolia...')
+  const client = algoliasearch(process.env.GATSBY_ALGOLIA_APP_ID, process.env.ALGOLIA_WRITE_KEY);
+  const index = client.initIndex('docs-pages-dev')
+  const data = await graphql(algoliaPagesQuery);
+  const pages = transformRecords(data);
+  
+  reporter.info(`Indexing ${pages.length} records`)
+
+  await index.saveObjects(pages)
+
+  reporter.success('Done indexing records on algolia.')
+};

--- a/plugins/algolia-plugin/package.json
+++ b/plugins/algolia-plugin/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "algolia-plugin"
+}

--- a/src/components/SearchEngine/Results.tsx
+++ b/src/components/SearchEngine/Results.tsx
@@ -15,7 +15,7 @@ interface PageResultProps extends AlgoliaResult {
 }
 
 function PageResult({
-  id, frontmatter, _highlightResult, fields, onHover, active,
+  objectID, frontmatter, _highlightResult, fields, onHover, active,
 }: PageResultProps) {
   const activeBackground = useColorModeValue('blue.100', 'blue.700');
 
@@ -31,7 +31,7 @@ function PageResult({
       as={Link}
       to={fields.slug}
       _focus={{ outline: 'auto' }}
-      id={id}
+      id={objectID}
     >
       <Box>
         <Text
@@ -63,13 +63,12 @@ export default function Results({ results }: ResultsProps) {
   };
 
   const handleKeysNavigation = (e: KeyboardEvent) => {
-    const getCurrentFocusedIndex = (current: AlgoliaResult | null) => (
-      results.findIndex((el) => el.id === current?.id)
-    );
+    const getCurrentFocusedIndex = (current: AlgoliaResult | null) => results
+      .findIndex((el) => el.objectID === current?.objectID);
 
     const scrollToFocusedPage = (page: AlgoliaResult | null) => {
       if (page) {
-        const element = document.getElementById(page.id);
+        const element = document.getElementById(page.objectID);
         const container = element?.parentElement;
 
         if (element && container) {
@@ -136,16 +135,16 @@ export default function Results({ results }: ResultsProps) {
       <VStack flex={1} alignItems="flex-start" height="100%" overflow="auto" position="relative">
         {results.map((page) => (
           <PageResult
-            active={focusedPage?.id === page.id}
+            active={focusedPage?.objectID === page.objectID}
             onHover={changeFocusedPage(page)}
             {...page}
-            key={page.id}
+            key={page.objectID}
           />
         ))}
       </VStack>
       <Divider orientation="vertical" />
       <Show above="md">
-        {focusedPage && <Preview key={focusedPage.id} {...focusedPage} />}
+        {focusedPage && <Preview key={focusedPage.objectID} {...focusedPage} />}
       </Show>
     </HStack>
   );

--- a/src/components/SearchEngine/types.ts
+++ b/src/components/SearchEngine/types.ts
@@ -1,29 +1,29 @@
 import { SearchResponse } from '@algolia/client-search';
 
 export type Heading = {
-  items?: Heading[]
+  items?: Heading[];
   url: string; // sluggish url of the heading
   title: string;
 };
 
 export type Page = {
-  id: string;
+  objectID: string;
   fields: {
-    slug: string
-  }
+    slug: string;
+  };
   excerpt: string;
-  tableOfContents: Heading,
+  tableOfContents: Heading;
   tables: {
     node: string;
     data: string | null;
     content: string | null;
-  }[]
+  }[];
   frontmatter: {
     title: string;
     description: string;
     toc: boolean;
     tags: string;
-  }
+  };
 };
 
 export type AlgoliaResult = SearchResponse<Page>['hits'][number];


### PR DESCRIPTION
Replacing `gatsby-plugin-algolia` for indexing on algolia by our own plugin. The previous one had issues updating the index: when you update the structure of a record it won't update it because it is based on an id which change only if the page's content changes.

Now we use `saveObjects` from algolia API which does a delete and replace, which makes more sense for us.