### PR TITLE
ci: add reopened to semantic check

### DIFF
--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -5,6 +5,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - reopened
       - edited
       - synchronize
 


### PR DESCRIPTION
This ensures this is retriggered when closing/reopening a PR because GitHub did not run the job.