### PR TITLE
docs: fix monitoring links

### DIFF
--- a/src/content/integrations/_monitoring.mdx
+++ b/src/content/integrations/_monitoring.mdx
@@ -11,7 +11,7 @@ import {
   <Docset
     title="Datadog"
     description="Monitor your merge queues with Mergify Datadog integration."
-    path="datadog"
+    path="/integrations/datadog"
     icon={<SiDatadog/>}
   />
 </DocsetGrid>


### PR DESCRIPTION
Use absolute path since this is included in different places.

Change-Id: I6c5345722f09ef060f2dd28640c4cd72fe7c4e97