### PR TITLE
fix(openapi): Override dark mode colors in api reference

### DIFF
--- a/src/pages/api.tsx
+++ b/src/pages/api.tsx
@@ -2,7 +2,7 @@ import { API } from '@stoplight/elements';
 import React from 'react';
 
 import '@stoplight/elements/styles.min.css';
-
+import './dark-mode-override.css';
 import ApiSchemas from './api-schemas.json';
 
 export default function APISpecifications() {

--- a/src/pages/dark-mode-override.css
+++ b/src/pages/dark-mode-override.css
@@ -1,0 +1,124 @@
+/**
+ * okaidia theme for JavaScript, CSS and HTML
+ * Loosely based on Monokai textmate theme by http://www.monokai.nl/
+ * @author ocodia
+ */
+
+[data-theme="dark"] code[class*="language-"],
+pre[class*="language-"] {
+  color: #f8f8f2 !important;
+  background: none !important;
+  text-shadow: 0 1px rgba(0, 0, 0, 0.3) !important;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace !important;
+  font-size: 1em !important;
+  text-align: left !important;
+  white-space: pre !important;
+  word-spacing: normal !important;
+  word-break: normal !important;
+  word-wrap: normal !important;
+  line-height: 1.5 !important;
+
+  -moz-tab-size: 4 !important;
+  -o-tab-size: 4 !important;
+  tab-size: 4 !important;
+
+  -webkit-hyphens: none !important;
+  -moz-hyphens: none !important;
+  -ms-hyphens: none !important;
+  hyphens: none !important;
+}
+
+/* Code blocks */
+[data-theme="dark"] pre[class*="language-"] {
+  padding: 1em !important;
+  margin: .5em 0 !important;
+  overflow: auto !important;
+  border-radius: 0.3em !important;
+}
+
+[data-theme="dark"] :not(pre)>code[class*="language-"],
+pre[class*="language-"] {
+  background: #272822 !important;
+}
+
+/* Inline code */
+[data-theme="dark"] :not(pre)>code[class*="language-"] {
+  padding: .1em !important;
+  border-radius: .3em !important;
+  white-space: normal !important;
+}
+
+[data-theme="dark"] .token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #8292a2 !important;
+}
+
+[data-theme="dark"] .token.punctuation {
+  color: #f8f8f2 !important;
+}
+
+[data-theme="dark"] .token.namespace {
+  opacity: .7 !important;
+}
+
+[data-theme="dark"] .token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #f92672 !important;
+}
+
+[data-theme="dark"] .token.boolean,
+.token.number {
+  color: #ae81ff !important;
+}
+
+[data-theme="dark"] .token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #a6e22e !important;
+}
+
+[data-theme="dark"] .token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+  color: #f8f8f2 !important;
+}
+
+[data-theme="dark"] .token.atrule,
+.token.attr-value,
+.token.function,
+.token.class-name {
+  color: #e6db74 !important;
+}
+
+[data-theme="dark"] .token.keyword {
+  color: #66d9ef !important;
+}
+
+[data-theme="dark"] .token.regex,
+.token.important {
+  color: #fd971f !important;
+}
+
+[data-theme="dark"] .token.important,
+.token.bold {
+  font-weight: bold !important;
+}
+
+[data-theme="dark"] .token.italic {
+  font-style: italic !important;
+}
+
+[data-theme="dark"] .token.entity {
+  cursor: help !important;
+}


### PR DESCRIPTION
Code blocks in dark mode are not readable. Hacky solution is to extract dark theme CSS file from Prism and to override the API reference styles with it.