### PR TITLE
docs(mq): reorganize a bit spec/batch and add troubleshooting

### DIFF
--- a/src/content/config.tsx
+++ b/src/content/config.tsx
@@ -11,7 +11,7 @@ import {
 import { FaShieldAlt, FaHome, FaRegListAlt } from 'react-icons/fa';
 import {
   FaStairs, FaCirclePlay, FaRegLightbulb, FaGear, FaTrafficLight,
-  FaSnowflake, FaMoneyBill1, FaRegCirclePause, FaUserShield,
+  FaSnowflake, FaMoneyBill1, FaRegCirclePause, FaUserShield, FaBug,
 } from 'react-icons/fa6';
 import { FiType } from 'react-icons/fi';
 import { GoGitMerge, GoCodeReview } from 'react-icons/go';
@@ -106,6 +106,7 @@ const navItems: NavItem[] = [
       { title: 'Partitions', path: '/merge-queue/partitions', icon: <AiOutlinePartition /> },
       { title: 'Deployment', path: '/merge-queue/deploy', icon: <AiOutlineDeploymentUnit /> },
       { title: 'Monitoring', path: '/merge-queue/monitoring', icon: <MdMonitorHeart /> },
+      { title: 'Troubleshooting', path: '/merge-queue/troubleshooting', icon: <FaBug /> },
     ],
   },
   {

--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -18,7 +18,7 @@ import {GoGitMerge, GoGitCommit, GoCodeReview} from 'react-icons/go';
 import {BsPatchQuestion, BsRocket, BsPlugin, BsStack, BsDoorOpen, BsLightningCharge, BsListTask, BsRobot, BsChatText, BsType, BsCommand} from 'react-icons/bs';
 import {BiSolidCoinStack, BiRuler} from 'react-icons/bi';
 import {TbCrystalBall, TbPackages, TbGitBranch} from 'react-icons/tb';
-import {FaUserShield, FaStairs, FaCirclePlay, FaRegLightbulb, FaGear, FaTrafficLight, FaSnowflake, FaMoneyBill1, FaRegCirclePause} from 'react-icons/fa6';
+import {FaUserShield, FaStairs, FaCirclePlay, FaRegLightbulb, FaGear, FaTrafficLight, FaSnowflake, FaMoneyBill1, FaRegCirclePause, FaBug} from 'react-icons/fa6';
 import {FaShieldAlt, FaRegListAlt} from 'react-icons/fa';
 import {AiOutlinePartition, AiOutlineDeploymentUnit, AiOutlineFile, AiOutlineApi} from 'react-icons/ai';
 import {LiaShareAltSolid} from 'react-icons/lia';
@@ -231,6 +231,12 @@ and adapt it to your own needs.
     description="Monitor key metrics of your merge queue to optimize throughput and reduce latency, ensuring a streamlined development cycle."
     path="/merge-queue/monitoring"
     icon={<MdMonitorHeart/>}
+  />
+  <Docset
+    title="Troubleshooting"
+    description="Solutions for troubleshooting common issues with Mergify's merge queue to ensure smooth and efficient pull request processing."
+    path="/merge-queue/troubleshooting"
+    icon={<FaBug/>}
   />
 </DocsetGrid>
 

--- a/src/content/merge-queue/batches.mdx
+++ b/src/content/merge-queue/batches.mdx
@@ -283,22 +283,22 @@ While using batch merging and speculative checks together can significantly
 speed up your merge queue processing, it's crucial to consider the following
 points for an optimal setup:
 
-- **CI Resource Utilization**: Increasing the batch size and speculative checks
-  could lead to higher usage of your Continuous Integration (CI) resources.
-  Ensure that your CI provider can handle the increased load without affecting
-  other tasks or exceeding any limitations.
+### Branch Protection Settings
 
-- **Base Branch Updates**: Batch merging tests pull requests against the latest
-  version of the base branch within another temporary pull request. Therefore,
-  if a new commit is pushed to the base branch, Mergify resets the process and
-  starts over with the updated base branch.
+Since pull requests are tested within temporary ones, the branch protection
+setting `Require branches to be up to date before merging` needs to be
+disabled. If your team requires a linear history, you can set the queue option
+`merge_method: rebase`.
 
-- **Branch Protection Settings**: Since pull requests are tested within
-  temporary ones, the branch protection setting `Require branches to be up to
-  date before merging` needs to be disabled. If your team requires a linear
-  history, you can set the queue option `merge_method: rebase`.
+This does not mean that Mergify will test outdated PRs, but it will merge the
+original pull requests once its speculative checks are finished. The original
+PR won't be up-to-date according to GitHub, which means using this setting
+would block the merge.
 
-- **Queue Management**: With batch merging, if a pull request within a batch
-  fails, it is removed from the queue, and the remaining ones are processed as
-  usual. It's essential to monitor your queue to handle any such failures
-  promptly.
+### Queued PR Changes
+
+Remember that changes to PRs or the queue can disrupt the batch process. If a
+PR is updated or changed in a way that it no longer meets the `queue_rules`, it
+will be removed from the queue, and the order of checks will be updated. In
+such cases, the process resets, and the remaining PRs are rechecked in their
+new order.

--- a/src/content/merge-queue/lifecycle.mdx
+++ b/src/content/merge-queue/lifecycle.mdx
@@ -218,6 +218,12 @@ On the other hand, if you manually dequeued a pull request using the
 command, you will need to use the `@mergifyio queue` command to put back the PR
 in a queue matching its `queue_conditions`.
 
+## Base Branch Updates
+
+The merge queue tests pull requests against the latest version of the base
+branch. Therefore, if a new commit is pushed to the base branch, Mergify resets
+the process and starts over with the updated base branch.
+
 ## Monitoring the Status of PRs in the Merge Queue
 
 To keep track of the status and progress of your pull requests in the merge

--- a/src/content/merge-queue/speculative-checks.mdx
+++ b/src/content/merge-queue/speculative-checks.mdx
@@ -3,7 +3,6 @@ title: Speculative Checks
 description: Accelerates the merging process by testing the compatibility of multiple queued pull requests in parallel.
 ---
 
-import { PrimaryLink } from '../../components/RelativeLink';
 import { Info } from "../../components/Alerts/Info"
 import { Warning } from "../../components/Alerts/Warning"
 import { Screenshot } from "../../components/Images"
@@ -239,35 +238,6 @@ In all these scenarios, the speculative checks process is dynamic and adjusts
 itself to the changes, ensuring that the merged code meets the criteria defined
 in the `queue_rules`.
 
-## Advanced Tips and Best Practices
-
-### 1. Use a High `speculative_checks` Value for Active Repositories
-
-If your repository is very active with numerous pull requests being created and
-merged regularly, consider setting a high `speculative_checks` value. This
-allows more PRs to be tested in parallel, thereby speeding up the overall
-merging process.
-
-### 2. Optimize Your CI Pipeline
-
-Speculative checks aim to reduce the overall merge time by parallelizing the
-testing of multiple PRs. This, however, requires a robust CI/CD pipeline that
-can handle multiple runs simultaneously. Optimizing your pipeline by reducing
-test run time or increasing concurrent job limit can significantly improve the
-effectiveness of speculative checks.
-
-### 3. Pair with Priority Rules
-
-When combined with [priority rules](priority), speculative checks become even
-more powerful. You can define priority for PRs so that urgent ones are merged
-faster, while the rest are tested speculatively in the background.
-
-### 4. Review Your `queue_rules` Regularly
-
-Regularly reviewing and updating your `queue_rules` can ensure your speculative
-checks configuration is always aligned with your project's current needs and
-workflow.
-
 ## Important Considerations
 
 While speculative checks can greatly speed up the merging process, there are a
@@ -277,7 +247,7 @@ few important considerations to keep in mind when using this feature:
 
 Speculative checks operate by creating temporary pull requests, which merge
 multiple PRs with the base branch. This process requires the branch protection
-setting "Require branches to be up to date before merging" to be disabled.
+setting `Require branches to be up to date before merging` to be disabled.
 
 This does not mean that Mergify will test outdated PRs, but it will merge the
 original pull requests once its speculative checks is finished. The original PR
@@ -293,41 +263,7 @@ depending on your requirements and available CI resources.
 ### Queued PR Changes
 
 Remember that changes to PRs or the queue can disrupt the speculative checks
-process. If a PR is updated in a way that it no longer meets the `queue_rules`,
-it will be removed from the queue, and the order of checks will be updated. In
-such cases, the process resets, and the remaining PRs are rechecked in their
-new order.
-
-## Troubleshooting Speculative Checks
-
-### Problem: Continuous Integration Pipeline Isn't Triggered 
-
-If your continuous integration pipeline isn't triggered when temporary pull
-requests are created, check your CI system configuration. Make sure it is set
-up to run on all pull requests, not just those targeting specific branches.
-
-Branches created by Mergify are prefixed with `mergify/merge-queue/` by default
-and can be change with the [`queue_branch_prefix`
-settings](/configuration/file-format#queue-rules).
-
-### Problem: Mergify Creates Temporary Pull Requests, But They Aren't Merged
-
-Check the `queue_rules` merge conditions in your Mergify configuration. If
-these conditions aren't met, Mergify won't be able to merge the temporary pull
-requests.
-
-### Problem: Merge Process is Slow Despite Speculative Checks
-
-This could be due to various reasons. Your `speculative_checks` number might be
-too low, causing fewer PRs to be tested together. Alternatively, your
-continuous integration might be the bottleneck. Check the capacity of your CI
-system; you might need to scale it up to handle the load from speculative
-checks.
-
-Remember, the primary goal of speculative checks is to reduce the overall time
-to merge all PRs. It does not necessarily decrease the time to merge a single
-PR.
-
-For further issues, don't hesitate to contact the <PrimaryLink
-href="mailto:support@mergify.com">Mergify support team</PrimaryLink> will be
-glad to assist you.
+process. If a PR is updated or changed in a way that it no longer meets the
+`queue_rules`, it will be removed from the queue, and the order of checks will
+be updated. In such cases, the process resets, and the remaining PRs are
+rechecked in their new order.

--- a/src/content/merge-queue/troubleshooting.mdx
+++ b/src/content/merge-queue/troubleshooting.mdx
@@ -1,0 +1,48 @@
+---
+title: Troubleshooting your Merge Queue
+description: Solutions for troubleshooting common issues with Mergify's merge queue to ensure smooth and efficient pull request processing.
+---
+
+import { PrimaryLink } from '../../components/RelativeLink';
+
+Navigating the complexities of Mergify's merge queue can sometimes lead to
+challenges. This guide offers concise, effective solutions for the most common
+issues, helping you maintain a smooth and efficient pull request process.
+
+Whether it's a delay, an unexpected behavior, or a processing hiccup, we've got
+you covered with practical tips to keep your workflow running seamlessly.
+
+### Problem: Continuous Integration Pipeline Isn't Triggered 
+
+If your continuous integration pipeline isn't triggered when temporary pull
+requests are created, check your CI system configuration. Make sure it is set
+up to run on all pull requests, not just those targeting specific branches.
+
+Branches created by Mergify are prefixed with `mergify/merge-queue/` by default
+and can be change with the [`queue_branch_prefix`
+settings](/configuration/file-format#queue-rules).
+
+### Problem: Mergify Creates Temporary Pull Requests, But They Aren't Merged
+
+Check the `merge_conditions` in the `queue_rules` from your Mergify
+configuration. If these conditions aren't met, Mergify won't be able to merge
+the temporary pull requests.
+
+### Problem: Merge Process is Slow Despite Speculative Checks
+
+This could be due to various reasons. Your `speculative_checks` number might be
+too low, causing fewer PRs to be tested together. Alternatively, your
+continuous integration might be the bottleneck. Check the capacity of your CI
+system; you might need to scale it up to handle the load from speculative
+checks.
+
+Remember, the primary goal of speculative checks is to reduce the overall time
+to merge all PRs. It does not necessarily decrease the time to merge a single
+PR.
+
+You can check the [performance](performance) page for more insight on merge
+queue performances.
+
+For further issues, don't hesitate to contact the <PrimaryLink
+href="mailto:support@mergify.com">Mergify support team</PrimaryLink> will be
+glad to assist you.


### PR DESCRIPTION
This factorize some part of the content and create a new page
troubleshooting. This makes sure the docs are not too verbose and do not
repeat different information in different places.

Change-Id: Ice4085e88260c256ee9007e09921de3179f862ef