### PR TITLE
fix(sidebar): Missing padding on nav items in production

### DIFF
--- a/src/components/LeftSidebar/NavGroup.astro
+++ b/src/components/LeftSidebar/NavGroup.astro
@@ -112,7 +112,7 @@ const { navGroup, currentPageMatch } = Astro.props as Props;
 	}
 
 	details > ul {
-		padding-left: 1rem;
+		padding-left: 1rem !important;
 	}
 
 	details > summary {


### PR DESCRIPTION
There's some missing padding on nav items on sidebar which makes every items on same column.