### PR TITLE
ci: only set SITE_URL for preview branches

### DIFF
--- a/cf-build.sh
+++ b/cf-build.sh
@@ -44,7 +44,10 @@ exit() { slack_message "*Deployment (${CF_PAGES_BRANCH}/${CF_PAGES_COMMIT_SHA}/$
 conclusion="failure" emoji="💥"
 trap exit EXIT
 
-export SITE_URL="$CF_PAGES_URL"
+
+if [[ ${CF_PAGES_BRANCH} == preview/* ]]; then
+    export SITE_URL="$CF_PAGES_URL"
+fi
 
 astro build 2>&1 | tee -a build.log
 


### PR DESCRIPTION
Cloudflare CF_PAGES_URL is the random assigned domain, not it's alias.
In production, it's not `docs.mergify.com`.
Since docs.mergify.com is the default, this change only set SITE_URL when the deployed branch is a preview one.