### PR TITLE
fix: Anchor link is hard to click on

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -187,7 +187,7 @@ h5 {
 
 .heading-wrapper {
 	--icon-size-x: 2rem;
-	--icon-size-y: 1.5rem;
+	--icon-size-y: 1.875rem;
 	margin-inline-end: var(--icon-size-x);
 }
 
@@ -210,6 +210,7 @@ h5 {
 	text-decoration: none;
 	justify-content: center;
 	vertical-align: baseline;
+	z-index: 10;
 }
 
 /* Float anchor links to the left of headings on larger screens. */


### PR DESCRIPTION
Left sidebar was on top of the anchor link, without visually hiding it. But the hover was stoped by the sidebar midway on the icon making it disapear and hard to click on.
Also increasing the anchor size to match the title font size, making it a little bit easier to click on.