### PR TITLE
docs(refactor): update and fix little incoherences

### DIFF
--- a/src/content/docs/merge-queue/index.mdx
+++ b/src/content/docs/merge-queue/index.mdx
@@ -206,7 +206,7 @@ strict digraph g {
 }
 ```
 
-What's not seen here, is that the new commit on the main branchhave caused a
+What's not seen here, is that the new commit on the main branch have caused a
 change in the behavior of the code that makes the changes in our developer's PR
 incompatible.
 

--- a/src/content/docs/workflow/actions/merge.mdx
+++ b/src/content/docs/workflow/actions/merge.mdx
@@ -32,7 +32,7 @@ settings that allow to enforce certain restrictions when pushing commits to
 your repository.
 
 Mergify automatically injects those conditions in your rules, though,
-they can be bypassed.
+they could be bypassed.
 (see
 [branch_protection_injection_mode](/configuration/file-format/#queue-rules).
 For example, if you request your pull request to be approved by at least

--- a/src/content/docs/workflow/actions/merge.mdx
+++ b/src/content/docs/workflow/actions/merge.mdx
@@ -31,9 +31,12 @@ protection](https://docs.github.com/en/repositories/configuring-branches-and-mer
 settings that allow to enforce certain restrictions when pushing commits to
 your repository.
 
-Mergify automatically injects those conditions in your rules as they can't be
-bypassed. For example, if you request your pull request to be approved by at
-least one person, Mergify will inject the `#approved-reviews-by>=1` condition.
+Mergify automatically injects those conditions in your rules, though,
+they can be bypassed.
+(see
+[branch_protection_injection_mode](/configuration/file-format/#queue-rules).
+For example, if you request your pull request to be approved by at least
+one person, Mergify will inject the `#approved-reviews-by>=1` condition.
 
 <Image src={branchProtectionConditionsScreenshot} alt="Mergify Branch Protection Condition Injection" />
 


### PR DESCRIPTION
branch protections can now by bypassed,
so we added a link to the keyword doing allowing
to do so.