### PR TITLE
fix: Fix all broken links on docs

### DIFF
--- a/src/content/docs/configuration/conditions.mdx
+++ b/src/content/docs/configuration/conditions.mdx
@@ -139,7 +139,7 @@ Here is a list of the available operators:
       </td>
 
       <td>This operator checks for [regular
-      expressions](./data-types#regular-expressions)
+      expressions](/configuration/data-types#regular-expressions)
       matching. If the target attribute type is a list, each
       element of the list is matched against the value and the condition is
       true if any value matches.</td>

--- a/src/content/docs/configuration/data-types.mdx
+++ b/src/content/docs/configuration/data-types.mdx
@@ -45,7 +45,7 @@ pull_request_rules:
 
 {/* fix links to "Operators" */}
 
-You can use regular expressions with matching operators in your [conditions](conditions).
+You can use regular expressions with matching operators in your [conditions](/configuration/conditions).
 
 Mergify leverages [Python regular expressions](https://docs.python.org/3/library/re.html)
 to match rules.
@@ -286,7 +286,7 @@ Mergify also provides custom Jinja2 filters:
 ```
 
 :::caution
-You need to replace the `-` character by `_` from the [pull request attribute](conditions#attributes-list)
+You need to replace the `-` character by `_` from the [pull request attribute](/configuration/conditions#attributes-list)
 names when using templates. The `-` is not a valid character for variable 
 names in Jinja2 template.
 :::

--- a/src/content/docs/configuration/file-format.mdx
+++ b/src/content/docs/configuration/file-format.mdx
@@ -54,11 +54,11 @@ different aspect of Mergify:
   actions;
 
 - [`shared`](#shared) allows to [define any YAML payload that can be used using
-  YAML anchors](sharing#sharing-configuration-sections);
+  YAML anchors](/configuration/sharing#sharing-configuration-sections);
 
 - [`extends`](#extends) allows to [extend the
-  configuration](sharing#extending-configuration-files) file by importing
-  another configuration file.
+  configuration](/configuration/sharing#extending-configuration-files) 
+  file by importing another configuration file.
 
 ### Pull Request Rules
 
@@ -142,7 +142,7 @@ different rules.
 
 You can store anything in the `shared` key. Its main purpose is to provide a
 place to put redundant YAML anchors. See
-[Sharing](sharing#sharing-configuration-sections).
+[Sharing](/configuration/sharing#sharing-configuration-sections).
 
 ### Extends
 
@@ -150,7 +150,7 @@ Mergify offers a feature to extend your configuration file by incorporating
 settings from another repository, aiding in consistency and reducing
 duplication. This is achieved by using the `extends` keyword at the top of your
 configuration file and specifying the source repository. See [Extending
-Configuration Files](sharing#extending-configuration-files).
+Configuration Files](/configuration/sharing#extending-configuration-files).
 
 {/* <OptionsTable name="Extend" /> */}
 

--- a/src/content/docs/configuration/sharing.mdx
+++ b/src/content/docs/configuration/sharing.mdx
@@ -11,9 +11,9 @@ consistency, and increase code reusability.
 
 [YAML anchors (`&`) and aliases
 (`*`)](https://yaml.org/spec/1.2.2/#anchors-and-aliases) are supported in the
-[configuration file](file-format). These allow you to reuse configuration
-sections. For example, you can create a list of continuous integration checks
-and use it in multiple sections:
+[configuration file](/configuration/file-format). These allow you to reuse
+configuration sections. For example, you can create a list of continuous
+integration checks and use it in multiple sections:
 
 ```yaml
 queue_rules:

--- a/src/content/docs/merge-queue/batches.mdx
+++ b/src/content/docs/merge-queue/batches.mdx
@@ -133,7 +133,7 @@ synergy to improve the efficiency of your merge queue.
 
 Batch merging allows Mergify to test multiple pull requests together as a
 single unit, reducing the amount of time waiting for individual pull request
-tests to complete. On the other hand, [speculative checks](speculative-checks)
+tests to complete. On the other hand, [speculative checks](/merge-queue/speculative-checks)
 allow for multiple batches to be tested in parallel, further speeding up the
 merge process.
 
@@ -209,7 +209,7 @@ With this configuration, even if your CI time is 10 minutes, you can merge the
 first 6 pull requests in only 10 minutes, as opposed to the 1 hour it would
 typically take to test each pull request individually.
 
-Check out our [performance page](performance) for more information.
+Check out our [performance page](/merge-queue/performance) for more information.
 
 ## Merging the Draft PRs
 

--- a/src/content/docs/merge-queue/freeze.mdx
+++ b/src/content/docs/merge-queue/freeze.mdx
@@ -171,7 +171,7 @@ commands in Mergify:
    queues, and how that will impact lower priority ones due to the cascade
    effect. In some situations, it might make sense to freeze a lower priority
    queue instead to avoid unnecessary disruptions. See [multiple
-   queues](multi).
+   queues](/merge-queue/multi).
 
 6. Use descriptive names for queues: This helps in easily identifying and
    managing the queues, especially in situations when you have to freeze or

--- a/src/content/docs/merge-queue/index.mdx
+++ b/src/content/docs/merge-queue/index.mdx
@@ -583,7 +583,7 @@ quality code and less on administrative tasks.
 
 - **Optimizes Resource Usage**: merge queues minimize the use of CI resources
 by avoiding unnecessary checks on PRs that are not up-to-date with the main
-branch. Usage of advanced options such as [batches](batches).
+branch. Usage of advanced options such as [batches](/merge-queue/batches).
 
 - **Enhances Collaboration**: merge queues promote a more collaborative
 environment where developers don't need to compete to get their PRs merged.

--- a/src/content/docs/merge-queue/lifecycle.mdx
+++ b/src/content/docs/merge-queue/lifecycle.mdx
@@ -42,13 +42,13 @@ the process:
 
 4. **Entering the queue:** Once a pull request meets the specified queue
    conditions, it is added to the end of the merge queue. However, [priority
-   rules](priority) can be used to alter its position in the queue.
+   rules](/merge-queue/priority) can be used to alter its position in the queue.
 
 Please note that, by default, only one pull request is processed at a time to
 ensure that each pull request is tested against the most recent state of the
 base branch. You can test multiple pull requests at once by using
-[batches](batches) or in advance by using [speculative
-checks](speculative-checks).
+[batches](/merge-queue/batches) or in advance by using [speculative
+checks](/merge-queue/speculative-checks).
 
 ```dot class="graph"
 strict digraph {
@@ -80,7 +80,7 @@ the queue.
 1. **Position in the queue:** The pull request assumes its position in the
    queue based on the order in which it entered. As mentioned in the previous
    section, the order may be influenced by any defined [priority
-   rules](priority).
+   rules](/merge-queue/priority).
 
 2. **Waiting for its turn:** The pull request will wait in the queue until it
    is its turn to be processed. The processing of pull requests in the queue is

--- a/src/content/docs/merge-queue/multi.mdx
+++ b/src/content/docs/merge-queue/multi.mdx
@@ -37,15 +37,18 @@ then moves down to lower priority queues.
 
 Inside each queue, pull requests are processed in the order they arrive,
 following a First-In-First-Out (FIFO) model. However, if you define [priority
-rules](priority), you can influence this order. Each pull request can have its
+rules](/merge-queue/priority), you can influence this order. Each pull request
+can have its
 own priority within the queue based on these rules. This adds another layer of
 control, allowing you to specify the order of pull requests within each queue.
 
 In short, queues control the order in which groups of pull requests are
-processed, while [priority rules](priority) (if defined) can adjust the order
+processed, while [priority rules](/merge-queue/priority)
+(if defined) can adjust the order
 of pull requests within each queue. Furthermore, each queue can have its own
-configuration (e.g., [speculative checks](speculative-checks),
-[batches](batches)), giving you even more control over its behavior.
+configuration (e.g., [speculative checks](/merge-queue/speculative-checks),
+[batches](/merge-queue/batches)),
+giving you even more control over its behavior.
 
 This dual-layer system gives you fine-grained control over your pull request
 processing pipeline.
@@ -61,7 +64,7 @@ can use.
 1. **Define Your Queues**: Start by identifying the different queues you need.
    This could be based on your project's requirements, the type of pull
    requests, or the teams working on them. Write your
-   [`queue_conditions`](lifecycle#adding-a-pull-request-to-the-merge-queue)
+   [`queue_conditions`](/merge-queue/lifecycle#adding-a-pull-request-to-the-merge-queue)
    accordingly.
 
 ```yaml

--- a/src/content/docs/merge-queue/pause.mdx
+++ b/src/content/docs/merge-queue/pause.mdx
@@ -56,7 +56,7 @@ the merge queues.
 ### Non-CI Incidents
 
 If an incident is unrelated to the CI, like a production issue, but you wish to
-halt merging while allowing checks to run, then the [freeze feature](freeze) is
+halt merging while allowing checks to run, then the [freeze feature](/merge-queue/freeze) is
 a more suitable choice. "Freezing" simply halts merges, letting checks and
 other actions proceed.
 

--- a/src/content/docs/merge-queue/performance.mdx
+++ b/src/content/docs/merge-queue/performance.mdx
@@ -44,16 +44,16 @@ Based on this trade-off, there are 3 scenarios that you can choose from:
 
 - **Reliable and Fast:** If you aim to reduce latency and maximize throughput
   without considering CI costs, enable **[speculative
-  checks](speculative-checks)**. This feature lets Mergify test pull requests
-  in parallel, predicting potential merges and executing CI runs
+  checks](/merge-queue/speculative-checks)**. This feature lets Mergify test
+  pull requests in parallel, predicting potential merges and executing CI runs
   simultaneously. Speculative checks can slightly increase CI cost: there might
-  be certain scenarios that are tested and whose results won't be used if a
-  pull request ahead in the queue fails.
+  be certain scenarios that are tested and whose results won't be used if a pull
+  request ahead in the queue fails.
 
-- **Cheap and Fast:** By using [batch mode](batches), you can merge groups of
-  pull requests simultaneously. This reduces CI runs but merges pull request
-  that are not tested individually. There is therefore a theoretical risk than
-  a hidden failure is merged, while the whole batch passes the CI.
+- **Cheap and Fast:** By using [batch mode](/merge-queue/batches), you can merge
+  groups of pull requests simultaneously. This reduces CI runs but merges pull
+  request that are not tested individually. There is therefore a theoretical
+  risk than a hidden failure is merged, while the whole batch passes the CI.
   
 You can also combine speculative checks and batching to achieve a balanced
 approach between reliability, cheapness, and velocity. This configuration
@@ -164,7 +164,7 @@ necessary tests are executed. Remember, every minute saved in CI time can have
 a cascading positive effect on your overall merge efficiency.
 
 A strategic approach to further optimize CI runtime is the [**Two-Step
-CI**](two-step) method. This approach differentiates between:
+CI**](/merge-queue/two-step) method. This approach differentiates between:
 
 1. **Preliminary Tests**: These are the tests run immediately when a PR is
 created or updated. They're designed to be quick yet effective, ensuring only

--- a/src/content/docs/merge-queue/priority.mdx
+++ b/src/content/docs/merge-queue/priority.mdx
@@ -167,8 +167,8 @@ In this configuration:
 
 The `allow_checks_interruption` option plays a critical role in managing the
 sequence of pull requests within the merge queue. When set to `true`, which is
-the default setting, this option allows the interruption of ongoing
-[speculative checks](speculative-checks) if a pull request with higher priority
+the default setting, this option allows the interruption of ongoing [speculative
+checks](/merge-queue/speculative-checks) if a pull request with higher priority
 enters the queue.
 
 In practice, this means that if a high priority pull request is added to the

--- a/src/content/docs/merge-queue/setup.mdx
+++ b/src/content/docs/merge-queue/setup.mdx
@@ -125,7 +125,7 @@ queue and will be merged when they reach the top of the queue.
 Remember, the PRs in the queue are ordered based on their addition time. The PR
 added first will be merged first after all its conditions are met. You can
 modify the order of the pull request inside a queue using
-[priorities](priority).
+[priorities](/merge-queue/priority).
 
 ## Conclusion
 
@@ -141,13 +141,15 @@ queues to your specific needs.
 For further exploration and inspiration, here are some additional resources and
 use cases that you might find useful:
 
-- Using [priorities to order your pull requests](priority);
-- Using [multiple queues](multi);
-- Speeding up your merge queue with [speculative checks](speculative-checks);
-- Saving CI time with [batches](batches);
+- Using [priorities to order your pull requests](/merge-queue/priority);
+- Using [multiple queues](/merge-queue/multi);
+- Speeding up your merge queue with [speculative checks](/merge-queue/speculative-checks);
+- Saving CI time with [batches](/merge-queue/batches);
 {/* FIXME: add link */}
 - Delaying checks at merge time;
-- Splitting repositories into [partitions](partitions) (monorepo support).
+
+- Splitting repositories into [partitions](/merge-queue/partitions)
+  (monorepo support).
 
 Remember, the possibilities with merge queues are limited only by your
 imagination. Happy merging!

--- a/src/content/docs/merge-queue/troubleshooting.mdx
+++ b/src/content/docs/merge-queue/troubleshooting.mdx
@@ -38,8 +38,8 @@ Remember, the primary goal of speculative checks is to reduce the overall time
 to merge all PRs. It does not necessarily decrease the time to merge a single
 PR.
 
-You can check the [performance](performance) page for more insight on merge
-queue performances.
+You can check the [performance](/merge-queue/performance) page for more insight
+on merge queue performances.
 
 For further issues, don't hesitate to contact the <a
 href="mailto:support@mergify.com">Mergify support team</a> will be

--- a/src/content/docs/merge-queue/two-step.mdx
+++ b/src/content/docs/merge-queue/two-step.mdx
@@ -62,10 +62,10 @@ aspects while ensuring a thorough check before the merge. This also aids in
 conserving CI resources, as not all tests are run at every PR iteration.
 
 With Mergify's merge queue, you can further optimize this process. If you're
-[batching](batches) multiple PRs for a merge, instead of running the pre-merge
-tests for each PR individually, you can run them once for the entire batch.
-This can result in significant savings, especially when the pre-merge tests are
-extensive.
+[batching](/merge-queue/batches) multiple PRs for a merge, instead of running
+the pre-merge tests for each PR individually, you can run them once for the
+entire batch. This can result in significant savings, especially when the
+pre-merge tests are extensive.
 
 ```dot class="graph"
 strict digraph {

--- a/src/content/docs/workflow/actions/copy.mdx
+++ b/src/content/docs/workflow/actions/copy.mdx
@@ -10,9 +10,10 @@ When the conditions you specify are met, Mergify will create a new pull request
 to merge the changes into the specified base branch.
 
 :::note
-  The `copy` action is equivalent to the [`backport`](backport) action. The
-  only difference is that the `backport` action will only copy the original
-  pull request once it is merged.
+  The `copy` action is equivalent to the
+  [`backport`](/workflow/actions/backport) action. The only difference is that
+  the `backport` action will only copy the original pull request once it is
+  merged.
 :::
 
 Note that in case of a conflict during the copy, Mergify will create a pull

--- a/src/content/docs/workflow/actions/merge.mdx
+++ b/src/content/docs/workflow/actions/merge.mdx
@@ -14,11 +14,11 @@ reducing the need for manual intervention.
 Whatever your conditions are, Mergify might inject extra conditions for the
 merge action to take place:
 
-- Mergify always respects the [branch protection settings](merge#branch-protection-conditions)
+- Mergify always respects the [branch protection settings](#branch-protection-conditions)
 
-- Mergify always respect [pull request dependencies](merge#pull-request-dependencies)
+- Mergify always respect [pull request dependencies](#pull-request-dependencies)
 
-- Mergify always respect the [merge date](merge#merge-date)
+- Mergify always respect the [merge date](#merge-date)
 
 - Mergify allows merging pull request modifying its configuration file by
   default. But Mergify will always check whether these changes are
@@ -94,7 +94,7 @@ before merging your pull request.
 
 To use this feature, add the `Merge-After:` header to the body of your pull
 request, followed by the date in the [timestamp
-format](../../configuration/data-types#timestamp).
+format](/configuration/data-types#timestamp).
 
 For example, if a pull request body contains:
 
@@ -132,7 +132,7 @@ pull_request_rules:
 When a pull request is merged using the squash or merge method, you can
 override the default commit message. To that end, you need to set
 `commit_message_template`. This setting is a
-[template](../../configuration/data-types#template), which means you can use
+[template](/configuration/data-types#template), which means you can use
 attributes of the pull request to build the content of the commit message.
 
 ```yaml

--- a/src/content/docs/workflow/automerge.mdx
+++ b/src/content/docs/workflow/automerge.mdx
@@ -172,7 +172,7 @@ project's specific needs. For a full list of available conditions, refer to the
 [conditions documentation](/configuration/conditions).
 
 You can also check [custom branch protection rules
-examples](custom-branch-protections).
+examples](/workflow/custom-branch-protections).
 
 ## Automatic Merge and Queues
 

--- a/src/content/docs/workflow/custom-branch-protections.mdx
+++ b/src/content/docs/workflow/custom-branch-protections.mdx
@@ -30,7 +30,7 @@ There are two common ways of writing custom branch protection settings using
 Mergify:
 
 - Integrate your custom branch protection rules directly into your [automatic
-  merge](automerge) rules;
+  merge](/workflow/automerge) rules;
 
 - Write custom checks that are posted by Mergify on pull requests like a CI
   would do. These custom checks can also be used as conditions in the automatic


### PR DESCRIPTION
Fixing all broken links, those was broken because of the trailing slash added the prod environment which breaks relative links. Solution is to make those not relative anymore.