### PR TITLE
docs: fix links by using absolute

### DIFF
--- a/src/content/docs/configuration/conditions.mdx
+++ b/src/content/docs/configuration/conditions.mdx
@@ -139,7 +139,7 @@ Here is a list of the available operators:
       </td>
 
       <td>This operator checks for [regular
-      expressions](./data-types#regular-expressions)
+      expressions](/configuration/data-types#regular-expressions)
       matching. If the target attribute type is a list, each
       element of the list is matched against the value and the condition is
       true if any value matches.</td>


### PR DESCRIPTION
Relative does not work as the page ends with a / and therefore this is
just used as a link to a subpage of this one.

Change-Id: I871786e9f5d4452bbd7a789272d5b341340999a3