### PR TITLE
ci: publish the dist directory

### DIFF
--- a/cf-build.sh
+++ b/cf-build.sh
@@ -56,7 +56,4 @@ fi
 
 astro build 2>&1 | tee -a build.log
 
-rm -rf public
-mv dist public
-
 conclusion="success" emoji="🦾"


### PR DESCRIPTION
We no longer need this hack since astro is in production.