### PR TITLE
docs: add documentation for `report_mode` on copy and backport action

### DIFF
--- a/public/mergify-configuration-openapi.json
+++ b/public/mergify-configuration-openapi.json
@@ -537,6 +537,15 @@
         "$ref": "#/definitions/BranchName"
       }
     },
+    "ReportModeArray": {
+      "$id": "/definitions/ReportModeArray",
+      "description": "list of report modes",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["check", "comment"]
+      }
+    },
     "PriorityRule": {
       "$id": "/definitions/PriorityRule",
       "description": "priority rule",
@@ -994,6 +1003,11 @@
               "description": "The pull request title.",
               "default": "{{ title }} (backport #{{ number }})",
               "$ref": "#/definitions/Template"
+            },
+            "report_mode": {
+              "description": "List of reporting modes for the action's result",
+              "default": ["check"],
+                "$ref": "#/definitions/ReportModeArray"
             }
           }
         },
@@ -1049,6 +1063,11 @@
               "description": "The pull request title.",
               "default": "{{ title }} (copy #{{ number }})",
               "$ref": "#/definitions/Template"
+            },
+            "report_mode": {
+              "description": "List of reporting modes for the action's result",
+              "default": ["check"],
+                "$ref": "#/definitions/ReportModeArray"
             }
           }
         },

--- a/public/mergify-configuration-openapi.json
+++ b/public/mergify-configuration-openapi.json
@@ -1065,7 +1065,7 @@
               "$ref": "#/definitions/Template"
             },
             "report_mode": {
-              "description": "List of reporting modes for the action's result",
+              "description": "List of reporting modes for the action's result.",
               "default": ["check"],
                 "$ref": "#/definitions/ReportModeArray"
             }

--- a/public/mergify-configuration-openapi.json
+++ b/public/mergify-configuration-openapi.json
@@ -1005,7 +1005,7 @@
               "$ref": "#/definitions/Template"
             },
             "report_mode": {
-              "description": "List of reporting modes for the action's result",
+              "description": "List of reporting modes for the action's result.",
               "default": ["check"],
                 "$ref": "#/definitions/ReportModeArray"
             }

--- a/src/components/Tables/ConfigOptions.tsx
+++ b/src/components/Tables/ConfigOptions.tsx
@@ -22,6 +22,7 @@ const valueTypeLinks: { [key: string]: string } = {
 		'/workflow/actions/github_actions#workflow-action-dispatch',
 	'/definitions/CommandRestriction': '/commands/restrictions#command-restriction-format',
 	'/definitions/QueueDequeueReason': '/configuration/data-types#queue-dequeue-reason',
+	'/definitions/ReportModeArray': '/configuration/data-types#report-modes',
 };
 
 export interface OptionDefinition {

--- a/src/content/docs/configuration/data-types.mdx
+++ b/src/content/docs/configuration/data-types.mdx
@@ -378,3 +378,32 @@ This describes the reason why a pull request has been removed from the queue.
     </tr>
   </tbody>
 </table>
+
+## Report Modes
+
+Report modes allow you to choose the type of report you want for your actions.
+Report mode values can be expressed in the configuration as a list of strings.
+The default value is `["check"]` and the list can't be empty.
+To fill the list, the following report modes are available:
+
+<table>
+  <thead>
+    <th>Mode</th>
+    <th>Description</th>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><code>check</code></td>
+      <td>Report the action's result as a GitHub check on the Pull Request. This is the default report mode.</td>
+    </tr>
+
+    <tr>
+      <td><code>comment</code></td>
+      <td>Report the action's result as a comment on the Pull Request</td>
+    </tr>
+
+  </tbody>
+</table>
+
+Report mode option is currently supported for only the following actions: [`backport`](/workflow/actions/backport), [`copy`](/workflow/actions/copy).


### PR DESCRIPTION
Following the implementation of the new report mode config option for backport and copy actions, we needed to add the corresponding documentation.

Fixes MRGFY-3331