### PR TITLE
docs: wrap code in `pre` on OptionsTable.mdx

### DIFF
--- a/src/components/Tables/OptionsTable.tsx
+++ b/src/components/Tables/OptionsTable.tsx
@@ -71,16 +71,18 @@ export function OptionsTableBase(options: OptionDefinition) {
 								{!shouldHideDefaultColumn && (
 									<td>
 										{hasDefaultValue(definition) && (
-											<code
-												dangerouslySetInnerHTML={{
-													__html: yaml.dump(definition.default, {
-														noCompatMode: true,
-														lineWidth: -1,
-														quotingType: '"',
-														noRefs: true,
-													}),
-												}}
-											/>
+											<pre>
+												<code
+													dangerouslySetInnerHTML={{
+														__html: yaml.dump(definition.default, {
+															noCompatMode: true,
+															lineWidth: -1,
+															quotingType: '"',
+															noRefs: true,
+														}),
+													}}
+												/>
+											</pre>
 										)}
 									</td>
 								)}


### PR DESCRIPTION
Before:
<img width="516" alt="Screenshot 2024-04-30 at 8 27 50 PM" src="https://github.com/Mergifyio/docs/assets/3956745/738303c2-e769-493a-b414-403410949446">

After:
<img width="310" alt="Screenshot 2024-04-30 at 8 28 18 PM" src="https://github.com/Mergifyio/docs/assets/3956745/2a246245-07cf-46fa-bfad-16f25194845a">
