### PR TITLE
chore: change the command to install mergify-cli

### DIFF
--- a/src/content/docs/stacks.mdx
+++ b/src/content/docs/stacks.mdx
@@ -75,8 +75,17 @@ and precise changes to commits.
 Begin by installing the Mergify CLI using
 [pip](https://packaging.python.org/en/latest/tutorials/installing-packages/):
 
+Linux:
+
 ```bash
-pip install mergify_cli
+python3 -m pip install --user mergify-cli
+```
+
+MacOS:
+
+```bash
+brew install pipx
+pipx install mergify-cli
 ```
 
 ### Configuration


### PR DESCRIPTION
This is the documented upstream command as pip binary may not installed
by default.