### PR TITLE
fix(circleci): add missing quote

### DIFF
--- a/src/content/docs/integrations/circleci.mdx
+++ b/src/content/docs/integrations/circleci.mdx
@@ -38,7 +38,7 @@ your Mergify rules. Here's a simple example:
 pull_request_rules:
   - name: Automatically merge when CircleCI build succeeds
     conditions:
-      - check-success=ci/circleci: test  # Change this to match your CircleCI check name
+      - "check-success=ci/circleci: test"  # Change this to match your CircleCI check name
       - "#approved-reviews-by>=1"
     actions:
       merge:


### PR DESCRIPTION
When a CI name has a ":," we must quote the whole line.
Otherwise, the YAML parser thinks it's a mapping instead of a string.

Fixes https://github.com/Mergifyio/mergify/issues/5116