### PR TITLE
docs: update regex on merge protection to properly match with groups

### DIFF
--- a/src/content/docs/merge-protections/index.mdx
+++ b/src/content/docs/merge-protections/index.mdx
@@ -120,7 +120,7 @@ description: Make sure that we follow https://www.conventionalcommits.org/en/v1.
 if:
   - base = main
 success_conditions:
-  - "title ~= ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:(.+))?:"
+  - "title ~= ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\))?:"
 ```
 
 ## Scheduling Freezes

--- a/src/content/docs/merge-protections/index.mdx
+++ b/src/content/docs/merge-protections/index.mdx
@@ -120,7 +120,7 @@ description: Make sure that we follow https://www.conventionalcommits.org/en/v1.
 if:
   - base = main
 success_conditions:
-  - "title ~= ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\))?:"
+  - "title ~= ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\(.+\))?:"
 ```
 
 ## Scheduling Freezes


### PR DESCRIPTION
## Overview
This pull request updates the regex pattern used for merge protection to properly match commit messages with groups.

## Changes
- File changed: `src/content/docs/merge-protections/index.mdx`
- Modified the regex pattern in the success conditions for merge protection:
  - Old: `"title ~= ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:(.+))?:"`
  - New: `"title ~= ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\))?:"`

## Impact of the changes
- Improves the accuracy of commit message validation in merge protection rules
- Ensures that commit messages with scopes (e.g., `feat(api):`) are correctly matched
- Maintains compliance with the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/)