### PR TITLE
docs: add documentation for new `max_parallel_checks` key

### DIFF
--- a/public/mergify-configuration-schema.json
+++ b/public/mergify-configuration-schema.json
@@ -72,6 +72,13 @@
     "extends": {
       "type": "string"
     },
+    "max_parallel_checks": {
+      "type": "integer",
+      "description": "The maximum number of checks to run in parallel for the merge queue. Must be between 1 and 128.",
+      "default": 1,
+      "minimum": 1,
+      "maximum": 128
+    },
     "queue_rules": {
       "type": "array",
       "items": {
@@ -911,7 +918,7 @@
           "$ref": "#/$defs/Template"
         },
         "merge_method": {
-          "description": "Merge method to use. `fast-forward` is not supported on queues with `speculative_checks > 1`, `batch_size > 1`, or with `allow_inplace_checks` set to false.",
+          "description": "Merge method to use. `fast-forward` is not supported on queues with `speculative_checks > 1`, `batch_size > 1`, or with `allow_inplace_checks` set to false. Using this would also implicitely limit the number of `max_parallel_checks` to 1.",
           "$ref": "#/$defs/MergeMethod"
         },
         "priority_rules": {
@@ -937,7 +944,8 @@
           "default": "mergify/merge-queue/"
         },
         "speculative_checks": {
-          "description": "The maximum number of checks to run in parallel in the queue. Must be between 1 and 20.",
+          "description": "This attribute is deprecated in favor of `max_parallel_checks` at the top level of the Mergify configuration file.\nThe maximum number of checks to run in parallel in the queue. Must be between 1 and 20.",
+          "deprecated": true,
           "type": "number",
           "default": 1,
           "minimum": 1,

--- a/src/content/docs/merge-queue/speculative-checks.mdx
+++ b/src/content/docs/merge-queue/speculative-checks.mdx
@@ -30,12 +30,12 @@ set them up.
 
 The speculative checks functionality operates by grouping multiple pull
 requests together based on their order in the queue and the
-`speculative_checks` value set in your `queue_rules`. These PRs are then tested
+`max_parallel_checks` value set in your Mergify configuration file. These PRs are then tested
 together in a speculative manner, meaning they are combined and tested as if
 they were going to be merged.
 
 Consider a situation where you have 5 pull requests (PR #1 to PR #5) and
-`speculative_checks` is set to 3. In this case, Mergify would create three
+`max_parallel_checks` is set to 3. In this case, Mergify would create three
 temporary PRs:
 
 - Temporary PR #1: Combines PR #1
@@ -125,17 +125,18 @@ failures.
 
 ## Configuring Speculative Checks
 
-Configuring speculative checks requires the use of the `speculative_checks`
-setting in your `queue_rules`. The value for `speculative_checks` determines
+Configuring speculative checks requires the use of the `max_parallel_checks`
+setting in your Mergify configuration file. The value for `max_parallel_checks` determines
 the maximum number of PRs that can be embarked together for speculative
 checking.
 
 Here's a sample configuration:
 
 ```yaml
+max_parallel_checks: 3
+
 queue_rules:
   - name: default
-    speculative_checks: 3
     merge_conditions:
       - "#approved-reviews-by >= 2"
       - check-success = test
@@ -147,7 +148,7 @@ simply dictates the maximum number of PRs that can be scheduled together for
 simultaneous testing.
 
 Remember, speculative checks are optional and the use of this feature depends
-on your specific project needs. You may need to adjust the `speculative_checks`
+on your specific project needs. You may need to adjust the `max_parallel_checks`
 value depending on the CI resources available and the typical size and
 complexity of PRs in your project.
 
@@ -202,8 +203,8 @@ block the merge.
 ### Parallel Checks Limit
 
 You can set the number of parallel speculative checks by adjusting the
-`speculative_checks` value in `queue_rules`. The number can range from 1 to 20,
-depending on your requirements and available CI resources.
+`max_parallel_checks` value at the root of your Mergify configuration file.
+The value can range from 1 to 128, depending on your requirements and available CI resources.
 
 ### Queued PR Changes
 


### PR DESCRIPTION
This also includes documentation for the deprecation of
`speculative_checks` in the `queue_rules` section

Fixes MRGFY-4082
Depends-On: https://github.com/Mergifyio/engine/pull/13958