### PR TITLE
fix: upgrade astro

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@fontsource/poppins": "^5.1.0",
         "@fontsource/source-sans-pro": "^5.1.0",
         "@nanostores/preact": "^0.5.2",
-        "@rollup/rollup-darwin-x64": "^4.22.0",
         "@scalar/api-reference": "^1.25.9",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
@@ -6532,9 +6531,10 @@
       }
     },
     "node_modules/astro": {
-      "version": "4.15.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-4.15.6.tgz",
-      "integrity": "sha512-SWcUNwm8CiVRaIbh4w5byh62BNihpsovlCd4ElvC7cL/53D24HcI7AaGFsPrromCamQklwQmIan/QS7x/3lLuQ==",
+      "version": "4.15.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-4.15.8.tgz",
+      "integrity": "sha512-pdXjtRF6O1xChiPAUF32R7oVRTW7AK1/Oy/JqPNhLfbelO0l6C7cLdSEuSLektwOEnMhOVXqccetjBs7HPaoxA==",
+      "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.10.3",
         "@astrojs/internal-helpers": "0.4.1",
@@ -6582,7 +6582,6 @@
         "ora": "^8.1.0",
         "p-limit": "^6.1.0",
         "p-queue": "^8.0.1",
-        "path-to-regexp": "6.2.2",
         "preferred-pm": "^4.0.0",
         "prompts": "^2.4.2",
         "rehype": "^13.0.1",
@@ -13608,11 +13607,6 @@
       "engines": {
         "node": "14 || >=16.14"
       }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",


### PR DESCRIPTION
This drops path-to-regex that have critical CVEs.

Fixes https://github.com/Mergifyio/docs/security/dependabot/73