### PR TITLE
fix(algolia): wrong key when adding custom table options

### DIFF
--- a/plugins/remark-algolia.ts
+++ b/plugins/remark-algolia.ts
@@ -1,4 +1,5 @@
 import { visit } from 'unist-util-visit';
+import futureConfigSchema from '../public/mergify-configuration-schema-future-version.json';
 import configSchema from '../public/mergify-configuration-schema.json';
 import { toString } from 'mdast-util-to-string';
 import algoliasearch from 'algoliasearch';
@@ -55,11 +56,12 @@ export function remarkAlgolia(): unified.Plugin<[], mdast.Root> {
 		visit(tree, 'mdxJsxFlowElement', (element) => {
 			switch (element.name) {
 				case 'OptionsTable':
-					const name = element.attributes.find(
-						(attr) => attr.type === 'mdxJsxAttribute' && attr.name === 'name'
+					const def = element.attributes.find(
+						(attr) => attr.type === 'mdxJsxAttribute' && attr.name === 'def'
 					).value;
-					const optionsTableData = configSchema?.$defs?.[name]?.properties;
-
+					
+					const optionsTableData = futureConfigSchema?.$defs?.[def as string]?.properties;
+					
 					tables.push({
 						node: JSON.stringify(element),
 						data: JSON.stringify(optionsTableData),
@@ -78,10 +80,10 @@ export function remarkAlgolia(): unified.Plugin<[], mdast.Root> {
 					break;
 
 				case 'ActionOptionsTable':
-					const action = element.attributes.find(
-						(attr) => attr.type === 'mdxJsxAttribute' && attr.name === 'action'
+					const actionDef = element.attributes.find(
+						(attr) => attr.type === 'mdxJsxAttribute' && attr.name === 'def'
 					).value;
-					const actionOptions = configSchema?.$defs?.[action]?.properties;
+					const actionOptions = configSchema?.$defs?.[actionDef as string]?.properties;
 
 					tables.push({
 						node: JSON.stringify(element),


### PR DESCRIPTION
When indexing mdx pages to algolia, we retrieve our custom `OptionsTable` and `ActionOptionsTable`, we extract the config schema definitions they render to pass it to algolia in order to provide searching through those tables.

Those tables have changed and takes a `def` props instead of a `name` prop to point to the definition they render, that was breaking things.