### PR TITLE
ci: run astro build in the ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,24 @@ jobs:
           npm ci
           npm run test
 
+  build:
+    timeout-minutes: 20
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4.2.0
+
+      - name: Setup Node 🔧
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: 20
+
+      - name: Build
+        run: |
+          npm ci
+          npm run build
+
   test-broken-links:
     timeout-minutes: 20
     runs-on: ubuntu-22.04

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -65,7 +65,7 @@ export default defineConfig({
 		smartypants: false,
 		remarkPlugins: [
 			remarkGraphvizPlugin(),
-			...(process.env.ALGOLIA_WRITE_KEY ? [remarkAlgolia()] : []),
+			remarkAlgolia(),
 			[
 				remarkSmartypants,
 				{

--- a/plugins/remark-algolia.ts
+++ b/plugins/remark-algolia.ts
@@ -17,11 +17,16 @@ interface PageData {
 
 async function savePageToAlgolia(pageData: PageData) {
 	if (process.env.NODE_ENV !== 'production') return;
+	if (!process.env.ALGOLIA_WRITE_KEY) {
+		console.info('No Algolia write key found, skipping indexing');
+		return;
+	}
+		
 	console.info('Starting indexing on algolia...');
 
 	const client = algoliasearch(process.env.PUBLIC_ALGOLIA_APP_ID, process.env.ALGOLIA_WRITE_KEY);
 	const index = client.initIndex(process.env.PUBLIC_ALGOLIA_INDEX_NAME);
-
+	
 	console.info(`Indexing page: ${pageData.objectID}`);
 	await index.saveObject(pageData);
 }

--- a/plugins/remark-algolia.ts
+++ b/plugins/remark-algolia.ts
@@ -26,7 +26,6 @@ async function savePageToAlgolia(pageData: PageData) {
 
 	const client = algoliasearch(process.env.PUBLIC_ALGOLIA_APP_ID, process.env.ALGOLIA_WRITE_KEY);
 	const index = client.initIndex(process.env.PUBLIC_ALGOLIA_INDEX_NAME);
-	
 	console.info(`Indexing page: ${pageData.objectID}`);
 	await index.saveObject(pageData);
 }


### PR DESCRIPTION
We should run the astro build in the CI to catch errors early on the PR. This change make it so the Algolia plugin compiles the MDX but without indexing it, so we will be able to catch further errors before it goes in production.