### PR TITLE
chore: remove useless caption

### DIFF
--- a/src/components/Tables/PullRequestAttributes.tsx
+++ b/src/components/Tables/PullRequestAttributes.tsx
@@ -12,7 +12,6 @@ export default function PullRequestAttributes({ staticAttributes }: Props) {
 
 	return (
 		<table>
-			<caption>Pull Request Attributes</caption>
 			<thead>
 				<tr>
 					<th>Attribute name</th>


### PR DESCRIPTION
That the only table with a caption, the text above is enough to get what
the table is.

eg:

```
Attributes List

Attributes are properties of pull requests or events used to filter and
evaluate the conditions within rules. They can be used to create more
specific and targeted rules for your repository.
```

Depends-On: #6249