### PR TITLE
refactor: remove section about deprecated `priority_rules`

### DIFF
--- a/src/content/docs/merge-queue/priority.mdx
+++ b/src/content/docs/merge-queue/priority.mdx
@@ -264,8 +264,3 @@ If a pull request ends up in an unexpected position in the queue:
 
 - Make sure there isn't another priority rule that is placing the pull request
   at a different position.
-
-- Confirm that your priority rules are correctly set up at the top level of your
-  configuration file. Also make sure that there aren't priority rules defined
-  both at the top level and under the `queue_rule` section (which is now deprecated),
-  as both cannot be defined at the same time.


### PR DESCRIPTION
The `priority_rules` inside the `queue_rules` section has already been
fully removed.