### PR TITLE
chore: fix `report_path` option for `gha-mergify-ci` action

### DIFF
--- a/src/content/docs/ci-insights/cypress.mdx
+++ b/src/content/docs/ci-insights/cypress.mdx
@@ -50,7 +50,7 @@ test:cypress` (or similar), include a step like:
   uses: mergifyio/gha-mergify-ci@v6
   with:
     token: ${{ secrets.MERGIFY_TOKEN }}
-    report_paths: cypress/results/junit*.xml
+    report_path: cypress/results/junit*.xml
 ```
 
 Key Points:
@@ -58,7 +58,7 @@ Key Points:
 - `if: success() || failure()`: Runs the upload step even if tests
   fail, ensuring **CI Insights** has the full report.
 
-- `report_paths: src/junit.xml`: Points to where your JUnit file is located.
+- `report_path: src/junit.xml`: Points to where your JUnit file is located.
   Make sure it matches the `outputFile` path you set in Cypress (e.g.,
   `./cypress/results/junit-*.xml`).
 
@@ -75,7 +75,7 @@ directly in the CI Insights dashboard.
 ## Troubleshooting Tips
 
 - File Paths: Double-check that `mochaFile` in Cypress matches the path used in
-  `report_paths`.
+  `report_path`.
 
 - Permissions: Make sure the `MERGIFY_TOKEN` is valid and setup in your GitHub
   Actions secrets [as explained in the

--- a/src/content/docs/ci-insights/golang.mdx
+++ b/src/content/docs/ci-insights/golang.mdx
@@ -46,7 +46,7 @@ For example, in your workflow file:
   uses: mergifyio/gha-mergify-ci@v6
   with:
     token: ${{ secrets.MERGIFY_TOKEN }}
-    report_paths: junit.xml
+    report_path: junit.xml
 ```
 
 ## 3. Verify and Review in CI Insights
@@ -63,7 +63,7 @@ dashboard](https://dashboard.mergify.com/ci-insights/jobs).
 ## Troubleshooting Tips
 
 - File Paths: Double-check that the JUnit output file matches the path used in
-  `report_paths`.
+  `report_path`.
 
 - Permissions: Make sure the `MERGIFY_TOKEN` is valid and setup in your GitHub
   Actions secrets [as explained in the

--- a/src/content/docs/ci-insights/vitest.mdx
+++ b/src/content/docs/ci-insights/vitest.mdx
@@ -58,7 +58,7 @@ similar), include a step like:
   uses: mergifyio/gha-mergify-ci@v6
   with:
     token: ${{ secrets.MERGIFY_TOKEN }}
-    report_paths: src/junit.xml
+    report_path: src/junit.xml
 ```
 
 Key Points:
@@ -66,7 +66,7 @@ Key Points:
 - `if: success() || failure()`: Runs the upload step even if tests
   fail, ensuring **CI Insights** has the full report.
 
-- `report_paths: src/junit.xml`: Points to where your JUnit file is located.
+- `report_path: src/junit.xml`: Points to where your JUnit file is located.
   Make sure it matches the `outputFile` path you set in Vitest (e.g.,
   `./junit.xml`).
 
@@ -83,7 +83,7 @@ directly in the CI Insights dashboard.
 ## Troubleshooting Tips
 
 - File Paths: Double-check that `outputFile` in Vitest matches the path used in
-  `report_paths`.
+  `report_path`.
 
 - Permissions: Make sure the `MERGIFY_TOKEN` is valid and setup in your GitHub
   Actions secrets [as explained in the docs]((/ci-insights#enabling-ci-insights-for-github)).


### PR DESCRIPTION
It has been renamed to `report_path`, from `report_paths`