### PR TITLE
chore: improve documentation of the MERGIFY_TOKEN

### DIFF
--- a/src/content/docs/ci-insights/cypress.mdx
+++ b/src/content/docs/ci-insights/cypress.mdx
@@ -38,6 +38,11 @@ both have JUnit generated while keeping the standard output.
 
 ## 2. Update Your GitHub Actions Workflow
 
+:::note
+  Ensure your CI Insights token (`MERGIFY_TOKEN`) is set up as explained in the [installation
+  docs](/ci-insights#enabling-ci-insights-for-github).
+:::
+
 Once you have the JUnit file produced by Cypress, add a step to upload these
 results to **CI Insights** via the `mergifyio/gha-mergify-ci` action.
 

--- a/src/content/docs/ci-insights/golang.mdx
+++ b/src/content/docs/ci-insights/golang.mdx
@@ -32,6 +32,11 @@ gotestsum --junitfile junit.xml
 
 ## 2. Update Your GitHub Actions Workflow
 
+:::note
+  Ensure your CI Insights token (`MERGIFY_TOKEN`) is set up as explained in the [installation
+  docs](/ci-insights#enabling-ci-insights-for-github).
+:::
+
 After generating the JUnit report, add a step to upload the results to CI
 Insights using the mergifyio/gha-mergify-ci action.
 

--- a/src/content/docs/ci-insights/pytest.mdx
+++ b/src/content/docs/ci-insights/pytest.mdx
@@ -20,11 +20,6 @@ automatically upload your
 test results to **CI Insights**. This can be done in different way depending on
 your way of managing your Python dependencies. Below are a few examples:
 
-:::note
-  Ensure your CI Insights token is set up as explained in the [installation
-  docs](/ci-insights#enabling-ci-insights-for-github).
-:::
-
 ### Pip / Requirements File
 
 `pip install pytest-mergify`
@@ -66,6 +61,11 @@ poetry add --group dev pytest-mergify
 ```
 
 ## 2. Modify Your Workflow
+
+:::note
+  Ensure your CI Insights token (`MERGIFY_TOKEN`) is set up as explained in the [installation
+  docs](/ci-insights#enabling-ci-insights-for-github).
+:::
 
 Your workflow should run your test as usual while exporting the secret
 `MERGIFY_TOKEN` as an environment variable. You'll need to add the following

--- a/src/content/docs/ci-insights/vitest.mdx
+++ b/src/content/docs/ci-insights/vitest.mdx
@@ -46,6 +46,11 @@ alongside the standard console output.
 
 ## 2. Update Your GitHub Actions Workflow
 
+:::note
+  Ensure your CI Insights token (`MERGIFY_TOKEN`) is set up as explained in the [installation
+  docs](/ci-insights#enabling-ci-insights-for-github).
+:::
+
 Once you have the JUnit file produced by Vitest, add a step to upload these
 results to **CI Insights** via the `mergifyio/gha-mergify-ci` action.
 


### PR DESCRIPTION
This makes clear MERGIFY_TOKEN is CI Insights token.
This move the note block just before we need the MERGIFY_TOKEN.
This adds the note block in all others pages.