### PR TITLE
chore(flaky-tests): remove matrix

### DIFF
--- a/src/content/docs/ci-insights/setup/github-actions.mdx
+++ b/src/content/docs/ci-insights/setup/github-actions.mdx
@@ -70,11 +70,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        run: [1, 2, 3, 4, 5]  # Run the same tests 5 times in parallel
-      fail-fast: false  # Don't cancel other runs if one fails
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -149,11 +144,6 @@ jobs:
 
 - **Frequency**: Running twice daily (every 12 hours) provides a good balance
   between detection accuracy and resource usage
-
-- **Parallel Execution**: Use matrix strategy to run multiple test executions
-  simultaneously
-
-- **`fail-fast: false`**: Ensure all test runs complete even if some fail
 
 - **Default Branch Only**: Focus on the default branch where flaky tests have
   the most impact


### PR DESCRIPTION
We don't use matrix anymore for that because the job_name is not the
same with matrix. Using RUN_COUNT is enough.