### PR TITLE
docs: fix link color in navbar and outline offset

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -78,7 +78,7 @@ a:focus {
 
 a:focus-visible {
   outline: 2px solid var(--theme-accent);
-  outline-offset: 2px;
+  outline-offset: 0px;
   border-radius: 2px;
 }
 
@@ -463,6 +463,11 @@ body {
   --section-merge-protections-accent-bg: rgba(82, 173, 230, 0.15);
   --section-workflow-accent: #e62474;
   --section-workflow-accent-bg: rgba(230, 36, 116, 0.15);
+}
+
+.nav-link a:hover,
+.nav-link a:focus-visible {
+  color: inherit;
 }
 
 /* Merge Queue section: override ToC highlight color */


### PR DESCRIPTION
- offset too big -> outline not visible on right
- links are blue by default, override to inherit from base color