### PR TITLE
feat(algolia): Replace index

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,6 +10,7 @@ import dotenv, { DotenvPopulateInput } from 'dotenv';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeSlug from 'rehype-slug';
 import remarkSmartypants from 'remark-smartypants';
+import { AlgoliaUpdateIndex } from './integrations/algolia-update-index';
 import { asideAutoImport, astroAsides } from './integrations/astro-asides';
 import { astroYoutubeEmbeds, youtubeAutoImport } from './integrations/astro-youtube-embed';
 import { ScalarApiReference } from './integrations/scalar-api-reference';
@@ -54,6 +55,7 @@ export default defineConfig({
       priority: 0.7,
     }),
     ScalarApiReference(),
+    AlgoliaUpdateIndex(),
   ],
   scopedStyleStrategy: 'where',
   compressHTML: false,

--- a/integrations/algolia-update-index.ts
+++ b/integrations/algolia-update-index.ts
@@ -1,0 +1,31 @@
+import { algoliasearch } from 'algoliasearch';
+import type { AstroIntegration } from 'astro';
+import { getCollectedAlgoliaPages, type PageData } from '../plugins/remark-algolia';
+
+export function AlgoliaUpdateIndex(): AstroIntegration {
+  return {
+    name: 'algolia-update-index',
+    hooks: {
+      'astro:build:done': async () => {
+        const appId = process.env.PUBLIC_ALGOLIA_APP_ID;
+        const writeKey = process.env.ALGOLIA_WRITE_KEY;
+        const indexName = process.env.PUBLIC_ALGOLIA_INDEX_NAME;
+
+        if (!appId || !writeKey || !indexName) {
+          console.info('[Algolia] missing env, skip replaceAll');
+          return;
+        }
+
+        const pages: PageData[] = getCollectedAlgoliaPages();
+        console.info(`[Algolia] collected pages: ${pages.length}`);
+        if (pages.length === 0) {
+          return;
+        }
+
+        const client = algoliasearch(appId, writeKey) as any;
+        await client.replaceAllObjects({ indexName, objects: pages, safe: true });
+        console.info('[Algolia] Index updated.');
+      },
+    },
+  };
+}


### PR DESCRIPTION
This is changing the way we are recording our algolia index.
Instead of updating each page at load, we are collecting them all and replacing the entire index with them at the end.

Relates to MRGFY-5897
