### PR TITLE
docs(stacks): add checkout command and --base option

### DIFF
--- a/src/content/docs/stacks/creating.mdx
+++ b/src/content/docs/stacks/creating.mdx
@@ -23,6 +23,12 @@ This is equivalent to `git checkout -b feat/my-feature --track origin/main`. You
 can also create branches however you normally do. Stacks doesn't require its own
 branch creation command.
 
+To branch from something other than `main` (a release branch, for example):
+
+```bash
+mergify stack new feat/my-feature --base origin/release-v2
+```
+
 ## Make Commits
 
 Work normally. Each commit should represent one logical unit of work, something

--- a/src/content/docs/stacks/team.mdx
+++ b/src/content/docs/stacks/team.mdx
@@ -41,6 +41,19 @@ to install anything.
 
 As more developers see the benefits in review, adoption spreads naturally.
 
+## Working on Someone Else's Stack
+
+If a teammate has pushed a stack and you want to pick it up locally (to help,
+pair, or continue the work), use `checkout` with their branch name:
+
+```bash
+mergify stack checkout --branch feat/their-feature
+```
+
+This reconstructs the stack locally by fetching the remote branches and
+rebuilding the commit chain. You can then make changes and push updates with
+`mergify stack push` as usual.
+
 ## When to Use Stacks
 
 Not every change needs a stack. Use stacks when the alternative is a large,


### PR DESCRIPTION
Document `mergify stack checkout` for team collaboration (picking up
a teammate's stack locally) and `--base` option for branching from
non-default branches.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Claude-Session-Id: a911b6ad-5466-48a4-b4d3-85198ebc7c28