### PR TITLE
docs: add CLI pause/unpause commands to pause page

### DIFF
--- a/src/content/docs/cli.mdx
+++ b/src/content/docs/cli.mdx
@@ -64,6 +64,6 @@ mergify --token your_token_here <command>
 |---|---|---|
 | `mergify stack` | Create and manage stacked pull requests | [Stacks](/stacks) |
 | `mergify freeze` | Schedule and manage merge freezes | [Scheduling Freezes](/merge-protections/freeze) |
-| `mergify queue` | Monitor merge queue status | [Monitoring](/merge-queue/monitoring) |
+| `mergify queue` | Monitor and control merge queue | [Monitoring](/merge-queue/monitoring) |
 | `mergify config` | Validate and simulate config | [Config](/configuration/file-format#validating-with-the-cli) |
 | `mergify ci` | Upload and analyze CI results | [CI Insights](/ci-insights) |

--- a/src/content/docs/merge-queue/pause.mdx
+++ b/src/content/docs/merge-queue/pause.mdx
@@ -46,6 +46,20 @@ the queue.
 
 <Image alt="Pause button is in the top right corner in Mergify's dashboard" src={screenshotButtonPause} />
 
+### Using the CLI
+
+Pause the queue from the terminal with an optional reason:
+
+```bash
+mergify queue pause --reason "deploying hotfix"
+```
+
+Resume when ready:
+
+```bash
+mergify queue unpause
+```
+
 ### Using the API
 
 You can also pause the merge queue programmatically using the [Mergify


### PR DESCRIPTION
Add mergify queue pause and unpause CLI commands to the existing
pause page alongside the dashboard and API methods.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>