### PR TITLE
fix(ci-insights): Remove the duplicated Runners nav item

### DIFF
--- a/src/content/docs/ci-insights.mdx
+++ b/src/content/docs/ci-insights.mdx
@@ -21,18 +21,18 @@ GitHub and covers basic configuration steps.
 
 <DocsetGrid>
   <Docset
-    title="Jobs"
-    path="/ci-insights/jobs"
-    icon="fa6-solid:list-check"
-  >
-    Monitor job health, duration, cost, and flaky behavior.
-  </Docset>
-  <Docset
     title="Runners"
     path="/ci-insights/runners"
     icon="fa6-solid:server"
   >
     Track runner fleet performance, queue times, and reliability.
+  </Docset>
+  <Docset
+    title="Jobs"
+    path="/ci-insights/jobs"
+    icon="fa6-solid:list-check"
+  >
+    Monitor job health, duration, cost, and flaky behavior.
   </Docset>
   <Docset
     title="Auto-Retry"

--- a/src/content/navItems.tsx
+++ b/src/content/navItems.tsx
@@ -26,7 +26,6 @@ const navItems: NavItem[] = [
         icon: 'fa6-solid:bug',
       },
       { title: 'Quarantine', path: '/ci-insights/quarantine', icon: 'fa-solid:radiation' },
-      { title: 'Runners', path: '/ci-insights/runners', icon: 'fa6-solid:server' },
       {
         title: 'CI Setup',
         icon: 'fa6-solid:gear',


### PR DESCRIPTION
The goal of this PR is to remove a duplicated entry introduced in a previous commit in the CI Insights nav bar items.