### PR TITLE
docs(merge-queue): add dedicated GitHub Rulesets compatibility page

### DIFF
--- a/src/content/docs/merge-queue/batches.mdx
+++ b/src/content/docs/merge-queue/batches.mdx
@@ -281,15 +281,13 @@ for an optimal setup:
 
 ### Branch Protection Settings
 
-Since pull requests are tested within temporary ones, the branch protection
-setting `Require branches to be up to date before merging` needs to be
-disabled. If your team requires a linear history, you can set the queue option
-`merge_method: rebase`.
+Batches require the branch protection setting *Require branches to be up to
+date before merging* to be disabled. If your team requires a linear history,
+you can set the queue option `merge_method: rebase`.
 
-This does not mean that Mergify will test outdated PRs, but it will merge the
-original pull requests once its parallel checks are finished. The original PR
-won't be up-to-date according to GitHub, which means using this setting would
-block the merge.
+For details on why and how to resolve this, see [GitHub Rulesets
+Compatibility: Require Branches to Be Up to
+Date](/merge-queue/github-rulesets#require-branches-to-be-up-to-date).
 
 ### Queued PR Changes
 

--- a/src/content/docs/merge-queue/deploy.mdx
+++ b/src/content/docs/merge-queue/deploy.mdx
@@ -72,6 +72,7 @@ GitHub rulesets and provides the most consistent, automated workflow.
 
 3. Click the verification button to confirm your setup is correct.
 
-**Be careful**: Mergify injects ruleset rules as conditions in the Merge Queue.
-If you want Mergify to bypass the injection of the ruleset rules, please
-see the [merge action](/workflow/actions/merge/) documentation.
+**Be careful**: Mergify injects ruleset rules as conditions in the merge queue.
+If you want Mergify to bypass the injection of the ruleset rules, see
+[GitHub Rulesets Compatibility](/merge-queue/github-rulesets) for details on
+bypass modes and known incompatibilities.

--- a/src/content/docs/merge-queue/github-rulesets.mdx
+++ b/src/content/docs/merge-queue/github-rulesets.mdx
@@ -1,0 +1,163 @@
+---
+title: GitHub Rulesets Compatibility
+description: How Mergify interacts with GitHub branch protections and rulesets, including known incompatibilities and how to resolve them.
+---
+
+Mergify automatically detects [GitHub branch
+protections](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+and
+[rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
+configured on your repository and injects them as conditions. This page
+explains how that injection works, which ruleset rule types are supported,
+which ones are incompatible with the merge queue, and how to resolve
+conflicts.
+
+## How Condition Injection Works
+
+When Mergify processes a pull request, it reads the branch protection and
+ruleset rules that apply to the target branch and converts them into
+[merge conditions](/configuration/conditions). For example, if you require at
+least one approved review, Mergify injects the condition
+`#approved-reviews-by >= 1`.
+
+This injection happens automatically for both the
+[`merge`](/workflow/actions/merge) action and the merge queue. For the
+merge queue, you can control how injection behaves using the setting below.
+
+### Controlling Injection
+
+You can control merge queue injection with the
+[`branch_protection_injection_mode`](/configuration/file-format/#queue-rules)
+option on your queue rules:
+
+- **`queue`** (default) -- rules are injected as required conditions for
+  both queuing and merging pull requests.
+
+- **`merge`** -- rules are injected as merge conditions, checked after the
+  queue has tested the pull request.
+
+- **`none`** -- no injection at all. This mode requires a
+  [`merge_bot_account`](/configuration/file-format/#queue-rules) with admin
+  rights. Use this only if you manage all conditions explicitly in your
+  Mergify configuration.
+
+### Bypass Actors and Injection
+
+If you are using GitHub rulesets (not classic branch protections), you can
+add Mergify as a **bypass actor** on the ruleset. The bypass mode determines
+whether injection still happens:
+
+- **`always` bypass mode** -- Mergify can bypass the rules, but it still
+  injects them as conditions in your queue.
+
+- **`exempt` bypass mode** -- Mergify skips injection entirely for that
+  ruleset. Use this when you want Mergify to ignore specific ruleset rules.
+
+## Ruleset Rule Compatibility
+
+Mergify handles each GitHub ruleset rule type as follows.
+
+| Ruleset rule type | Mergify behavior | Notes |
+|---|---|---|
+| `required_status_checks` | Injected as conditions | See [below](#require-branches-to-be-up-to-date) |
+| `pull_request` | Injected as conditions | Limited code owner support |
+| `required_deployments` | Used by [Merge Protections](/merge-protections) | -- |
+| `merge_queue` (GitHub native) | **Incompatible** | See [below](#github-native-merge-queue-rule) |
+| `creation` | Checked for branch/tag creation | -- |
+| `update` | Checked for branch updates | -- |
+
+:::caution
+  Branch protection support has some limitations. For example, GitHub does
+  not provide an API to support [code
+  owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners),
+  which makes it unreliable in certain circumstances.
+:::
+
+## Known Incompatibilities
+
+### GitHub Native Merge Queue Rule
+
+If the `merge_queue` ruleset rule (GitHub's built-in merge queue) is enabled
+on the target branch and Mergify is **not** a bypass actor, GitHub blocks
+Mergify from merging pull requests -- all merges must go through GitHub's own
+queue.
+
+**Resolution:**
+
+- **Preferred:** disable the `merge_queue` ruleset rule on branches where you
+  use Mergify's merge queue.
+
+- **Alternative:** add Mergify as a bypass actor on that ruleset with the
+  `always` bypass mode. This lets Mergify merge directly while GitHub's queue
+  is still active for other actors.
+
+### Require Branches to Be Up to Date
+
+The `strict_required_status_checks_policy` setting (labeled *Require branches
+to be up to date before merging* in the GitHub UI) is incompatible with
+[parallel checks](/merge-queue/parallel-checks) and
+[batches](/merge-queue/batches).
+
+Mergify creates temporary batch pull requests to test combined changes. The
+original pull requests are merged after those checks pass, but GitHub
+considers them "not up to date" because they were not the branches that were
+tested. This setting blocks the merge.
+
+:::note
+  Disabling this setting does **not** mean Mergify tests outdated code.
+  Mergify always updates pull requests against the latest base branch before
+  testing.
+:::
+
+**Resolution:**
+
+- **Preferred:** disable the *Require branches to be up to date before
+  merging* setting.
+
+- **Alternative:** add Mergify as a bypass actor on the ruleset with `always`
+  bypass mode.
+
+### Review Requirements and Fast-Forward
+
+The `required_approving_review_count` and `require_code_owner_review` ruleset
+rules are incompatible with the [`fast-forward` merge
+method](/merge-queue/merge-strategies#fast-forward) when using batch-PR mode.
+
+In batch-PR mode, Mergify creates a temporary batch pull request that
+combines multiple PRs. This batch PR does not carry the review approvals
+from the original PRs, so GitHub blocks the fast-forward push if review
+requirements are enforced.
+
+**Resolution:**
+
+- Add Mergify as a bypass actor on the ruleset that enforces review
+  requirements, with `always` bypass mode.
+
+## Configuring Mergify as a Bypass Actor
+
+To add Mergify as a bypass actor on a GitHub ruleset:
+
+1. Go to your repository **Settings > Rules > Rulesets**.
+
+2. Select the ruleset you want to modify (or create a new one).
+
+3. Under **Bypass list**, click **Add bypass**.
+
+4. Search for the **Mergify** app and select it.
+
+5. Choose the bypass mode:
+
+   - **Always** -- Mergify can bypass the rules but still injects them as
+     merge conditions (recommended for most cases).
+
+   - **Exempt** -- Mergify bypasses the rules **and** skips injecting them
+     as conditions. Use this when you want Mergify to fully ignore specific
+     rules.
+
+6. Save the ruleset.
+
+:::tip
+  If you only want to exempt Mergify from specific rules (e.g.,
+  `merge_queue`) but still enforce others (e.g., `required_status_checks`),
+  create separate rulesets for each group and set different bypass modes.
+:::

--- a/src/content/docs/merge-queue/merge-strategies.mdx
+++ b/src/content/docs/merge-queue/merge-strategies.mdx
@@ -215,6 +215,8 @@ commits** from folding each PR into the batch branch.
   Fast-forward requires Mergify to push directly to the base branch without
   going through a pull request merge. If GitHub branch protections are enabled,
   you must allow Mergify to **bypass the required pull requests** setting.
+  See [GitHub Rulesets Compatibility](/merge-queue/github-rulesets) for
+  setup instructions.
 
   <Image src={requiredPRbypassScreenshot} alt="Mergify bypass required pull requests" />
 :::

--- a/src/content/docs/merge-queue/parallel-checks.mdx
+++ b/src/content/docs/merge-queue/parallel-checks.mdx
@@ -234,14 +234,10 @@ queue_rules:
 
 ### Branch Protection Settings
 
-Parallel checks operate by creating temporary pull requests, which merge
-multiple PRs with the base branch. This process requires the branch protection
-setting `Require branches to be up to date before merging` to be disabled.
-
-This does not mean that Mergify will test outdated PRs, but it will merge the
-original pull requests once its parallel checks is finished. The original PR
-won't be up-to-date according to GitHub, which means using this setting would
-block the merge.
+Parallel checks require the branch protection setting *Require branches to be
+up to date before merging* to be disabled. For details on why and how to
+resolve this, see [GitHub Rulesets Compatibility: Require Branches to Be Up to
+Date](/merge-queue/github-rulesets#require-branches-to-be-up-to-date).
 
 ### Tuning parallel checks
 

--- a/src/content/docs/merge-queue/setup.mdx
+++ b/src/content/docs/merge-queue/setup.mdx
@@ -54,7 +54,7 @@ With zero configuration, your queue already:
 - **Updates PRs** against the latest main before merging
 - **Runs your CI** on the updated code (not stale branches)
 - **Merges automatically** when checks pass
-- **Respects your GitHub branch protections** and rulesets
+- **Respects your [GitHub branch protections and rulesets](/merge-queue/github-rulesets)**
 
 This alone prevents the classic problem: PRs that pass CI individually but
 break main when merged together.

--- a/src/content/docs/workflow/actions/merge.mdx
+++ b/src/content/docs/workflow/actions/merge.mdx
@@ -26,38 +26,15 @@ merge action to take place:
 
 ## Branch Protection Conditions
 
-GitHub provides [branch
-protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
-and [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
-settings that allow to enforce certain restrictions when pushing commits to
-your repository.
-
-Mergify automatically injects those conditions in your rules, though,
-they could be bypassed.
-(see
-[branch_protection_injection_mode](/configuration/file-format/#queue-rules).
-For example, if you request your pull request to be approved by at least
-one person, Mergify will inject the `#approved-reviews-by >= 1` condition.
+Mergify automatically reads your GitHub branch protections and rulesets and
+injects them as merge conditions. For example, if you require at least one
+approved review, Mergify injects the `#approved-reviews-by >= 1` condition.
 
 <Image src={branchProtectionConditionsScreenshot} alt="Mergify Branch Protection Condition Injection" />
 
-If you're using rulesets instead of the classic branch protections, you can also bypass
-the injection of those conditions by setting Mergify as a bypass actor with the bypass mode set to `exempt`.
-With all other bypass modes, Mergify will inject the conditions in your rules.
-
-Note that branch protection supports has some limitations. For example, GitHub
-does not provide an API to support [code
-owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
-which makes it unreliable in certain circumstances.
-
-The following protection settings are only partially supported by Mergify:
-
-- Require status checks to pass before merging;
-- Require branches to be up to date before merging;
-- Require review from Code Owners;
-- Require linear history;
-- Require conversation resolution before merging;
-- Require approvals.
+For details on how injection works, which ruleset rules are compatible,
+known incompatibilities, and how to configure bypass actors, see
+[GitHub Rulesets Compatibility](/merge-queue/github-rulesets).
 
 ## Pull Request Dependencies
 

--- a/src/content/docs/workflow/actions/queue.mdx
+++ b/src/content/docs/workflow/actions/queue.mdx
@@ -33,3 +33,10 @@ pull_request_rules:
 In this example, any pull request that has the label `queue-me` will be
 automatically queued. The pull request still needs to match the
 `queue_conditions` defined in the queue to enter the queue.
+
+:::note
+  By default, Mergify injects your GitHub branch protections and ruleset
+  rules as queue conditions. If some ruleset rules are incompatible with
+  your queue setup, see [GitHub Rulesets
+  Compatibility](/merge-queue/github-rulesets) for resolution steps.
+:::

--- a/src/content/navItems.tsx
+++ b/src/content/navItems.tsx
@@ -166,6 +166,11 @@ const navItems: NavItem[] = [
       { title: 'Two-Step CI', path: '/merge-queue/two-step', icon: 'fa6-solid:stairs' },
       { title: 'Deployment', path: '/merge-queue/deploy', icon: 'mdi:rocket-launch-outline' },
       {
+        title: 'GitHub Rulesets Compatibility',
+        path: '/merge-queue/github-rulesets',
+        icon: 'simple-icons:github',
+      },
+      {
         title: 'Browser Extensions',
         path: '/merge-queue/browser-extensions',
         icon: 'fa6-solid:puzzle-piece',


### PR DESCRIPTION
Consolidate scattered ruleset/branch-protection guidance into a single
reference page and update existing pages to link to it instead of
duplicating content.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>