### PR TITLE
fix: expand JSX table components in markdown/LLM output

### DIFF
--- a/src/pages/[...slug].md.ts
+++ b/src/pages/[...slug].md.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { APIRoute } from 'astro';
 import { allPages } from '~/content';
+import { mdxToMarkdown } from '~/util/mdxToMarkdown';
 
 type MarkdownSourceProps = {
   id: string;
@@ -36,6 +37,7 @@ export const GET: APIRoute = async ({ props }) => {
   const fsPath = path.join(process.cwd(), 'src', 'content', collection, id + '.mdx');
   try {
     let source = await readFile(fsPath, 'utf-8');
+    source = mdxToMarkdown(source);
     if (!source.endsWith('\n')) source += '\n';
     return new Response(source, { headers: { 'Content-Type': 'text/markdown; charset=utf-8' } });
   } catch {

--- a/src/util/mdxToMarkdown.test.ts
+++ b/src/util/mdxToMarkdown.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'vitest';
+import { mdxToMarkdown } from './mdxToMarkdown';
+
+describe('mdxToMarkdown', () => {
+  test('should strip import statements', () => {
+    const input = `---
+title: Test
+---
+
+import MyComponent from '~/components/MyComponent';
+import { something } from 'some-lib';
+
+# Hello
+
+Some content.
+`;
+    const result = mdxToMarkdown(input);
+    expect(result).not.toContain('import MyComponent');
+    expect(result).not.toContain('import { something }');
+    expect(result).toContain('# Hello');
+    expect(result).toContain('Some content.');
+  });
+
+  test('should expand OptionsTable with a known def', () => {
+    const input = `# Config
+
+<OptionsTable def="CloseActionModel" />
+`;
+    const result = mdxToMarkdown(input);
+    expect(result).not.toContain('<OptionsTable');
+    expect(result).toContain('Key name');
+    expect(result).toContain('Value type');
+    expect(result).toContain('Description');
+    expect(result).toContain('`message`');
+  });
+
+  test('should expand ActionOptionsTable with a known def', () => {
+    const input = `<ActionOptionsTable def="CloseActionModel" />`;
+    const result = mdxToMarkdown(input);
+    expect(result).not.toContain('<ActionOptionsTable');
+    expect(result).toContain('Key name');
+    expect(result).toContain('`message`');
+  });
+
+  test('should expand PullRequestAttributesTable', () => {
+    const input = `# Conditions
+
+<PullRequestAttributesTable />
+`;
+    const result = mdxToMarkdown(input);
+    expect(result).not.toContain('<PullRequestAttributesTable');
+    expect(result).toContain('Attribute name');
+    expect(result).toContain('Value type');
+    expect(result).toContain('Description');
+  });
+
+  test('should handle single-quoted def attribute', () => {
+    const input = `<ActionOptionsTable def='CloseActionModel'/>`;
+    const result = mdxToMarkdown(input);
+    expect(result).not.toContain('<ActionOptionsTable');
+    expect(result).toContain('`message`');
+  });
+
+  test('should strip remaining self-closing JSX components', () => {
+    const input = `# Page
+
+<DocsetGrid category="merge-queue" />
+
+Some text.
+`;
+    const result = mdxToMarkdown(input);
+    expect(result).not.toContain('<DocsetGrid');
+    expect(result).toContain('Some text.');
+  });
+
+  test('should strip wrapping JSX components but keep inner content', () => {
+    const input = `<Aside type="note">
+  Important info here.
+</Aside>`;
+    const result = mdxToMarkdown(input);
+    expect(result).not.toContain('<Aside');
+    expect(result).not.toContain('</Aside>');
+    expect(result).toContain('Important info here.');
+  });
+
+  test('should strip nested JSX components', () => {
+    const input = `<DocsetGrid>
+  <Docset title="Backport" path="backport">
+    Copy a pull request to another branch.
+  </Docset>
+  <Docset title="Queue" path="queue">
+    Add a pull request to a merge queue.
+  </Docset>
+</DocsetGrid>`;
+    const result = mdxToMarkdown(input);
+    expect(result).not.toContain('<DocsetGrid');
+    expect(result).not.toContain('<Docset');
+    expect(result).not.toContain('</Docset>');
+    expect(result).toContain('Copy a pull request to another branch.');
+    expect(result).toContain('Add a pull request to a merge queue.');
+  });
+
+  test('should preserve frontmatter', () => {
+    const input = `---
+title: My Page
+description: A test page
+---
+
+# Content
+`;
+    const result = mdxToMarkdown(input);
+    expect(result).toContain('title: My Page');
+    expect(result).toContain('description: A test page');
+  });
+
+  test('should collapse excessive blank lines', () => {
+    const input = `# Title
+
+
+
+\n\n\n
+
+Content here.
+`;
+    const result = mdxToMarkdown(input);
+    // Should not have more than 2 consecutive newlines
+    expect(result).not.toMatch(/\n{3,}/);
+  });
+
+  test('should handle unknown def gracefully', () => {
+    const input = `<OptionsTable def="NonExistentDef" />`;
+    const result = mdxToMarkdown(input);
+    expect(result).toContain('<!-- Unknown definition: NonExistentDef -->');
+  });
+
+  test('should produce a default column when defaults exist', () => {
+    // BackportActionModel has defaults like ignore_conflicts: true
+    const input = `<OptionsTable def="BackportActionModel" />`;
+    const result = mdxToMarkdown(input);
+    expect(result).toContain('Default');
+  });
+});

--- a/src/util/mdxToMarkdown.ts
+++ b/src/util/mdxToMarkdown.ts
@@ -1,0 +1,241 @@
+import * as yaml from 'js-yaml';
+import jsonpointer from 'jsonpointer';
+import configSchema from './sanitizedConfigSchema';
+
+// ── Schema helpers ──────────────────────────────────────────────────────────
+
+const valueTypeLinks: Record<string, string> = {
+  Commit: '/configuration/data-types#commit',
+  CommitAuthor: '/configuration/data-types#commit-author',
+  ListOfRuleConditions: '/configuration/conditions',
+  CommandRestrictionsConditionsModel: '/configuration/conditions',
+  PullRequestRuleConditionsModel: '/configuration/conditions',
+  QueueRuleMergeConditionsModel: '/configuration/conditions',
+  PriorityRuleConditionsModel: '/configuration/conditions',
+  GhaActionModelWorkflow: '/workflow/actions/github_actions#workflow-action',
+  GhaActionModelDispatch: '/workflow/actions/github_actions#workflow-action-dispatch',
+  CommandRestrictionsModel: '/commands/restrictions#command-restriction-format',
+  GitHubRepositoryPermission: '/configuration/data-types#github-repository-permissions',
+};
+
+const valueTypeFormatLinks: Record<string, string> = {
+  template: '/configuration/data-types#template',
+  'date-time': '/configuration/data-types#timestamp',
+  duration: '/configuration/data-types#duration',
+};
+
+function getItemFromSchema(schema: any, path: string): any {
+  const refPath = path.replace('#', '');
+  return jsonpointer.get(schema, refPath);
+}
+
+function getTitle(schema: any, ref: string): string {
+  const item = getItemFromSchema(schema, ref);
+  return item?.title || item?.name || '';
+}
+
+function getTypeLink(ref: string): string | undefined {
+  const refId = ref.split('/').at(-1);
+  return refId ? valueTypeLinks[refId] : undefined;
+}
+
+/**
+ * Plain-text version of the React `getValueType` — returns a markdown string
+ * instead of JSX elements.
+ */
+function getValueTypeText(schema: any, definition: any): string {
+  if (definition.type === 'array') {
+    let typeDesc: string;
+    if (definition.items?.$ref) {
+      const link = getTypeLink(definition.items.$ref);
+      const title = getTitle(schema, definition.items.$ref);
+      typeDesc = link ? `[${title}](${link})` : title;
+    } else {
+      typeDesc = getValueTypeText(schema, definition.items);
+    }
+    return `list of ${typeDesc}`;
+  }
+
+  if (definition.$ref !== undefined) {
+    const link = getTypeLink(definition.$ref);
+    const title = getTitle(schema, definition.$ref);
+    return link ? `[${title}](${link})` : title;
+  }
+
+  if (definition.anyOf || definition.oneOf || definition.allOf) {
+    const defs: any[] = definition.anyOf || definition.oneOf || definition.allOf;
+    return defs
+      .map((item, index) => {
+        const text = getValueTypeText(schema, item);
+        if (index === defs.length - 2) return `${text} or `;
+        if (index < defs.length - 1) return `${text}, `;
+        return text;
+      })
+      .join('');
+  }
+
+  if (definition.enum) {
+    return definition.enum
+      .map((item: any, index: number) => {
+        const val = `\`${item}\``;
+        if (index === definition.enum.length - 2) return `${val} or `;
+        if (index < definition.enum.length - 1) return `${val}, `;
+        return val;
+      })
+      .join('');
+  }
+
+  if (definition.const !== undefined) {
+    return `\`${definition.const}\``;
+  }
+
+  if (definition.format) {
+    const link = valueTypeFormatLinks[definition.format];
+    if (link) return `[${definition.format}](${link})`;
+  }
+
+  if (definition.type) {
+    return `\`${definition.type}\``;
+  }
+
+  return '';
+}
+
+// ── Markdown table builders ─────────────────────────────────────────────────
+
+/** Escape pipe characters inside markdown table cells. */
+function escapeCell(text: string): string {
+  return text.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function formatDefault(value: any): string {
+  if (value === null || value === undefined) return '';
+  const dumped = yaml
+    .dump(value, {
+      noCompatMode: true,
+      lineWidth: -1,
+      quotingType: '"',
+      noRefs: true,
+    })
+    .trim();
+  return `\`${dumped}\``;
+}
+
+function cleanDescription(desc: string | undefined): string {
+  if (!desc) return '';
+  // The descriptions are plain markdown already — just collapse newlines for table cells
+  return desc.replace(/\n/g, ' ').trim();
+}
+
+function buildOptionsTableMarkdown(defName: string): string {
+  const def = (configSchema as any).$defs[defName];
+  if (!def?.properties) return `<!-- Unknown definition: ${defName} -->\n`;
+
+  const options = def.properties;
+  const entries = Object.entries(options).sort(([a], [b]) => a.localeCompare(b));
+
+  const hasDefault = entries.some(([, d]: [string, any]) => d.default !== undefined);
+  const hasDeprecated = entries.some(([, d]: [string, any]) => d.deprecated);
+
+  // Build header
+  const headers = ['Key name', 'Value type', 'Description'];
+  if (hasDefault) headers.push('Default');
+  if (hasDeprecated) headers.push('');
+  const separators = headers.map(() => '---');
+
+  const rows: string[] = [];
+  rows.push(`| ${headers.join(' | ')} |`);
+  rows.push(`| ${separators.join(' | ')} |`);
+
+  for (const [key, definition] of entries) {
+    const d = definition as any;
+    const valueType = escapeCell(getValueTypeText(configSchema, d));
+    const desc = escapeCell(cleanDescription(d.description));
+    const cells = [`\`${key}\``, valueType, desc];
+    if (hasDefault) cells.push(d.default !== undefined ? escapeCell(formatDefault(d.default)) : '');
+    if (hasDeprecated) cells.push(d.deprecated ? '**deprecated**' : '');
+    rows.push(`| ${cells.join(' | ')} |`);
+  }
+
+  return rows.join('\n') + '\n';
+}
+
+function buildPullRequestAttributesTableMarkdown(): string {
+  const attributes = (configSchema as any).$defs.PullRequestAttributes?.properties;
+  if (!attributes) return '<!-- PullRequestAttributes definition not found -->\n';
+
+  const entries = Object.entries(attributes).sort(([a], [b]) => a.localeCompare(b));
+
+  const rows: string[] = [];
+  rows.push('| Attribute name | Value type | Description |');
+  rows.push('| --- | --- | --- |');
+
+  for (const [key, value] of entries) {
+    const v = value as any;
+    const valueType = escapeCell(getValueTypeText(configSchema, v));
+    const desc = escapeCell(cleanDescription(v.description));
+    rows.push(`| \`${key}\` | ${valueType} | ${desc} |`);
+  }
+
+  return rows.join('\n') + '\n';
+}
+
+// ── MDX → Markdown pipeline ────────────────────────────────────────────────
+
+/** Remove MDX import statements. */
+function stripImports(source: string): string {
+  return source.replace(/^import\s+.*$/gm, '');
+}
+
+/** Expand `<OptionsTable def="..." />` and `<ActionOptionsTable def="..." />` tags. */
+function expandOptionsTableTags(source: string): string {
+  return source.replace(
+    /<(?:Options|ActionOptions)Table\s+def=["']([^"']+)["']\s*\/?>/g,
+    (_match, defName) => buildOptionsTableMarkdown(defName)
+  );
+}
+
+/** Expand `<PullRequestAttributesTable />` tag. */
+function expandPullRequestAttributesTable(source: string): string {
+  return source.replace(/<PullRequestAttributesTable\s*\/?>/g, () =>
+    buildPullRequestAttributesTableMarkdown()
+  );
+}
+
+/** Strip remaining JSX/HTML component tags that can't render as markdown. */
+function stripRemainingJsx(source: string): string {
+  // Strip self-closing custom components: <Component ... />
+  let result = source.replace(/<[A-Z]\w*\s[^>]*\/>/g, '');
+  // Strip opening/closing pairs of custom components but keep inner content.
+  // Loop until stable to handle nested components (e.g. <DocsetGrid><Docset>...</Docset></DocsetGrid>).
+  let prev;
+  do {
+    prev = result;
+    result = result.replace(/<([A-Z]\w*)[^>]*>([\s\S]*?)<\/\1>/g, '$2');
+  } while (result !== prev);
+  // Strip self-closing custom components without attributes: <Component />
+  result = result.replace(/<[A-Z]\w*\s*\/>/g, '');
+  return result;
+}
+
+/** Collapse runs of 3+ blank lines into 2. */
+function collapseBlankLines(source: string): string {
+  return source.replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * Convert raw MDX source into clean, LLM-friendly markdown.
+ *
+ * - Strips import statements
+ * - Expands schema-driven table components into markdown tables
+ * - Removes remaining JSX tags
+ */
+export function mdxToMarkdown(source: string): string {
+  let result = source;
+  result = stripImports(result);
+  result = expandOptionsTableTags(result);
+  result = expandPullRequestAttributesTable(result);
+  result = stripRemainingJsx(result);
+  result = collapseBlankLines(result);
+  return result;
+}


### PR DESCRIPTION
The "Copy for LLM" and "View as Markdown" routes were serving raw MDX
source, including unresolved JSX component tags like <OptionsTable>,
<ActionOptionsTable>, and <PullRequestAttributesTable>. LLM consumers
saw raw tags instead of the actual configuration reference data.

Add a post-processing step that strips imports, expands schema-driven
table components into markdown tables from mergify-configuration-schema.json,
removes remaining JSX tags, and collapses blank lines.

Closes MRGFY-6921

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>