### PR TITLE
docs(integrations): replace queue action with autoqueue in dependency bot guides

### DIFF
--- a/src/content/docs/integrations/dependabot.mdx
+++ b/src/content/docs/integrations/dependabot.mdx
@@ -19,19 +19,17 @@ intervention.
 There are two primary ways to automate the merging of Dependabot PRs with
 Mergify:
 
-### 1. Direct Merge or Merge Queue
+### 1. Using the Merge Queue
 
-You can set up a pull request rule to automatically merge Dependabot PRs or
-place them in the merge queue.
+You can set up a queue rule to automatically enqueue Dependabot PRs into the
+merge queue using [`autoqueue`](/merge-queue/rules#autoqueueing-pull-requests).
 
 ```yaml
-pull_request_rules:
-  - name: Automatically merge Dependabot PRs
-    conditions:
+queue_rules:
+  - name: default
+    autoqueue: true
+    queue_conditions:
       - author = dependabot[bot]
-    actions:
-      merge:
-      # Or use queue: to use the merge queue
 ```
 
 ### 2. PR Approval
@@ -53,19 +51,18 @@ pull_request_rules:
 
 Dependabot provides specific labels for the type of dependency update, such as
 `dependabot-dependency-name`, `dependabot-dependency-type`, and
-`dependabot-update-type`. You can use these labels in your Mergify rules to
+`dependabot-update-type`. You can use these in your queue rule conditions to
 filter which Dependabot PRs to auto-merge. For instance, you might only want to
 auto-merge minor version bumps:
 
 ```yaml
-pull_request_rules:
-  - name: Auto merge minor version bumps
-    conditions:
+queue_rules:
+  - name: default
+    autoqueue: true
+    merge_method: merge
+    queue_conditions:
       - author = dependabot[bot]
       - dependabot-update-type = version-update:semver-minor
-    actions:
-      queue:
-        method: merge
 ```
 
 ## Batching Dependency Updates
@@ -81,18 +78,12 @@ For example, you could set up a merge queue to batch those PRs 10 by 10:
 queue_rules:
   # If you have other queue rules defined, add this at the end so it is processed last
   - name: dep-update
+    autoqueue: true
     batch_size: 10
     # Wait for up to 30 minutes for the batch to fill up
     batch_max_wait_time: 30 min
     queue_conditions:
       - author = dependabot[bot]
-
-pull_request_rules:
-  - name: Automatically queue Dependabot PRs
-    conditions:
-      - author = dependabot[bot]
-    actions:
-      queue:
 ```
 
 ## Disable Dependabot's Automatic Rebase

--- a/src/content/docs/integrations/renovate.mdx
+++ b/src/content/docs/integrations/renovate.mdx
@@ -17,19 +17,17 @@ submits automated pull requests.
 There are two primary ways to automate the merging of Renovate PRs with
 Mergify:
 
-### 1. Direct Merge or Merge Queue
+### 1. Using the Merge Queue
 
-You can set up a pull request rule to automatically merge Renovate PRs or
-place them in the merge queue.
+You can set up a queue rule to automatically enqueue Renovate PRs into the
+merge queue using [`autoqueue`](/merge-queue/rules#autoqueueing-pull-requests).
 
 ```yaml
-pull_request_rules:
-  - name: Automatically merge Renovate PRs
-    conditions:
+queue_rules:
+  - name: default
+    autoqueue: true
+    queue_conditions:
       - author = renovate[bot]
-    actions:
-      merge:
-      # Or use queue: to use the merge queue
 ```
 
 ### 2. PR Approval
@@ -60,18 +58,12 @@ For example, you could set up a merge queue to batch those PRs 10 by 10:
 queue_rules:
   # If you have other queues defined, add this at the end so it is processed last
   - name: dep-update
+    autoqueue: true
     batch_size: 10
     # Wait for up to 30 minutes for the batch to fill up
     batch_max_wait_time: 30 min
     queue_conditions:
       - author = renovate[bot]
-
-pull_request_rules:
-  - name: Automatically queue Renovate PRs
-    conditions:
-      - author = renovate[bot]
-    actions:
-      queue:
 ```
 
 With Mergify and Renovate working together, you can ensure your project's

--- a/src/content/docs/integrations/snyk.mdx
+++ b/src/content/docs/integrations/snyk.mdx
@@ -59,18 +59,18 @@ allowing for a thorough review.
    file](/configuration/file-format) file in the repository root.
 
      ```yaml
-     pull_request_rules:
-       - name: Automatic merge Snyk PRs on Status Checks passing
-         conditions:
+     queue_rules:
+       - name: default
+         autoqueue: true
+         merge_method: merge
+         queue_conditions:
            - author = snyk-bot
            - base = main
-         actions:
-           merge:
-             method: merge
      ```
 
-     This configuration ensures that Snyk PRs are automatically merged when
-     they meet the defined conditions.
+     This configuration uses [`autoqueue`](/merge-queue/rules#autoqueueing-pull-requests)
+     to automatically enqueue and merge Snyk PRs when they meet the defined
+     conditions.
 
 ## Batching Dependency Updates
 
@@ -86,18 +86,12 @@ For example, you could set up a merge queue to batch those PRs 10 by 10:
 queue_rules:
   # If you have other queue rules defined, add this at the end so it is processed last
   - name: dep-update
+    autoqueue: true
     batch_size: 10
     # Wait for up to 30 minutes for the batch to fill up
     batch_max_wait_time: 30 min
     queue_conditions:
       - author = snyk-bot
-
-pull_request_rules:
-  - name: Automatically queue Snyk PRs
-    conditions:
-      - author = snyk-bot
-    actions:
-      queue:
 ```
 
 ## Tips for Efficient Dependency Upgrades


### PR DESCRIPTION
Dependabot, Renovate, and Snyk integration pages were showing
pull_request_rules with queue action as the primary pattern, leading
customers to copy this instead of using autoqueue on queue_rules.
Replace all examples with autoqueue: true on queue_rules.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>