### PR TITLE
docs: remove incorrect --branch flag from stack checkout command

### DIFF
--- a/src/content/docs/stacks/team.mdx
+++ b/src/content/docs/stacks/team.mdx
@@ -47,7 +47,7 @@ If a teammate has pushed a stack and you want to pick it up locally (to help,
 pair, or continue the work), use `checkout` with their branch name:
 
 ```bash
-mergify stack checkout --branch feat/their-feature
+mergify stack checkout feat/their-feature
 ```
 
 This reconstructs the stack locally by fetching the remote branches and


### PR DESCRIPTION
The `mergify stack checkout` command takes the branch name as a
positional argument, not via a --branch flag.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>