### PR TITLE
docs(stacks): add comparison page for gh-stack vs Mergify Stacks

### DIFF
--- a/src/components/GitGraph.astro
+++ b/src/components/GitGraph.astro
@@ -84,13 +84,13 @@ function renderLinear(p: {
 
   const R = 18;
   const SPACING = 80;
-  const PAD_LEFT = 70;
   const COMMIT_Y = 32;
   const PR_Y = 100;
   const PR_H = 26;
   const PR_R = 6;
   const FONT = 11;
   const CHAR_W = 7;
+  const PAD_LEFT = Math.max(70, branch.length * CHAR_W + 40);
   const PR_PAD_X = 16;
   const ANNO_GAP = 16;
 

--- a/src/content/docs/stacks.mdx
+++ b/src/content/docs/stacks.mdx
@@ -91,4 +91,7 @@ GitHub. See the [setup guide](/stacks/setup) for details.
   <Docset title="Team Adoption" path="/stacks/team" icon="fa6-solid:people-group">
     Why and how to roll out stacked PRs across your engineering team.
   </Docset>
+  <Docset title="Compare Tools" path="/stacks/compare" icon="fa6-solid:scale-balanced">
+    Honest comparison with gh-stack and guidance on evaluating stacking tools.
+  </Docset>
 </DocsetGrid>

--- a/src/content/docs/stacks/compare.mdx
+++ b/src/content/docs/stacks/compare.mdx
@@ -1,0 +1,18 @@
+---
+title: Compare Stacking Tools
+description: Honest comparisons between Mergify Stacks and other stacked PR tools.
+---
+
+import DocsetGrid from '~/components/DocsetGrid/DocsetGrid.astro';
+import Docset from '~/components/DocsetGrid/Docset.astro';
+
+Choosing a stacking tool matters. Each one makes different trade-offs around
+workflow complexity, Git model, platform integration, and collaboration support.
+These pages give you an honest look at how Mergify Stacks compares so you can
+pick what fits your team.
+
+<DocsetGrid>
+  <Docset title="gh-stack (GitHub)" path="/stacks/compare/gh-stack" icon="simple-icons:github">
+    GitHub's native stacking CLI. Multi-branch model with GitHub UI integration.
+  </Docset>
+</DocsetGrid>

--- a/src/content/docs/stacks/compare/gh-stack.mdx
+++ b/src/content/docs/stacks/compare/gh-stack.mdx
@@ -1,0 +1,210 @@
+---
+title: Mergify Stacks vs gh-stack
+description: An honest comparison of Mergify Stacks and GitHub's gh-stack CLI for stacked pull requests.
+---
+
+import GitGraph from '~/components/GitGraph.astro';
+import StackMapping from '~/components/StackMapping.astro';
+
+GitHub released [gh-stack](https://github.github.com/gh-stack/), a stacking
+extension for the `gh` CLI. Both tools solve the same problem (big PRs are hard
+to review, so split them into a chain of small ones), but they take different
+approaches to get there.
+
+## Two Models for Stacking
+
+The biggest difference is how each tool thinks about branches.
+
+| | Mergify Stacks | gh-stack |
+|---|---|---|
+| **Local model** | One branch, many commits | One branch per PR |
+| **Identity** | Change-Id trailer in commit message | Branch name |
+| **Who manages branches** | Mergify auto-creates remote branches | Developer creates and names them |
+| **Mental model** | "Chain of commits" | "Chain of dependent branches" |
+
+Both produce the same result on GitHub: chained PRs where each targets the
+previous one's branch. The difference is what you deal with locally.
+
+### Mergify Stacks: one branch, many commits
+
+You work on a single branch. Each commit maps to a PR automatically:
+
+<GitGraph
+  commits={["A", "B", "C"]}
+  commitColor="green"
+  branch="feat/auth"
+  prs={[
+    { label: "PR #1", commits: 0, annotation: "base: main" },
+    { label: "PR #2", commits: 1, annotation: "base: PR #1" },
+    { label: "PR #3", commits: 2, annotation: "base: PR #2" },
+  ]}
+/>
+
+Under the hood, `mergify stack push` creates a remote branch per commit and
+chains the PRs:
+
+<StackMapping entries={[
+  { commit: "A: add model", branch: "stack/.../Ia1b2c3", pr: "PR #1" },
+  { commit: "B: add endpoint", branch: "stack/.../Id4e5f6", pr: "PR #2" },
+  { commit: "C: add tests", branch: "stack/.../Ig7h8i9", pr: "PR #3" },
+]} />
+
+You never see or manage these remote branches. They're an implementation detail.
+
+### gh-stack: one branch per PR
+
+You create and name a separate branch for each change. Each branch becomes a PR
+that targets the branch below it:
+
+<GitGraph
+  nodes={[
+    { id: "m1", label: "M", color: "gray" },
+    { id: "m2", label: "", color: "gray" },
+    { id: "a1", label: "A", color: "green" },
+    { id: "a2", label: "A'", color: "green" },
+    { id: "a3", label: "", color: "green" },
+    { id: "b1", label: "B", color: "blue" },
+    { id: "b2", label: "", color: "blue" },
+    { id: "c1", label: "C", color: "amber" },
+    { id: "c2", label: "C'", color: "amber" },
+  ]}
+  edges={[
+    { from: "m1", to: "m2", label: "main" },
+    { from: "m2", to: "a1" },
+    { from: "a1", to: "a2" },
+    { from: "a2", to: "a3", label: "feat/model" },
+    { from: "a3", to: "b1" },
+    { from: "b1", to: "b2", label: "feat/endpoint" },
+    { from: "b2", to: "c1" },
+    { from: "c1", to: "c2", label: "feat/tests" },
+  ]}
+/>
+
+Three branches, three PRs: `feat/model` targets `main`, `feat/endpoint`
+targets `feat/model`, `feat/tests` targets `feat/endpoint`. You navigate
+between them with `gh stack up` and `gh stack down`.
+
+## Feature Comparison
+
+| Feature | Mergify Stacks | gh-stack |
+|---|---|---|
+| Create a stack | `mergify stack new` + commits | `gh stack init` + `gh stack add` per branch |
+| Push changes | `mergify stack push` | `gh stack push` |
+| Create PRs | Included in `mergify stack push` | Separate `gh stack submit` command |
+| View the stack | `mergify stack list` | `gh stack view` |
+| Edit mid-stack | `mergify stack edit` (interactive rebase) | Checkout the branch, edit, rebase |
+| Reorder changes | `mergify stack reorder` or `mergify stack move` | Manual rebase + `gh stack rebase` |
+| Squash changes | `mergify stack edit` (squash/fixup) | Manual |
+| Cascading rebase | Automatic on push | `gh stack rebase --upstack` / `--downstack` |
+| Sync after merge | `mergify stack sync` | `gh stack sync` |
+| Open PR in browser | `mergify stack open` (interactive picker) | Links from `gh stack view` |
+| Collaboration | `mergify stack checkout` | Difficult (force-push based) |
+| Draft PRs | `mergify stack push --draft` | `gh stack submit --draft` |
+| Merge Queue | [Native Mergify integration](/merge-queue) | GitHub's built-in merge queue |
+| Merge a stack | Bottom-up via Merge Queue | `gh stack merge` (not yet implemented) |
+| Stack visualization | Stack comment on each PR | Native GitHub UI stack map |
+| Branch naming | Auto-generated ([configurable](/stacks/concepts#branch-mapping)) | Developer-chosen or auto-numbered |
+| Navigate between PRs | N/A (single branch) | `gh stack up` / `down` / `top` / `bottom` |
+| Unstack | Not needed (standard Git branches) | `gh stack unstack` |
+| Atomic push | `--force-with-lease --atomic` (all-or-nothing) | `--force-with-lease --atomic` (all-or-nothing) |
+| Conflict memory | Git's native rerere | Built-in automatic rerere |
+| Pre-operation safety | Git reflog | Automatic branch snapshots before rebases |
+| Exit codes | Standard | Structured (8 specific codes) |
+
+## Where Mergify Is Stronger
+
+**Simpler workflow.** One branch, standard Git. You don't create branches or
+navigate between them. You commit and rebase like you already do. The branching
+complexity lives on the remote side where you don't have to think about it.
+
+**One command does more.** `mergify stack push` rebases on the target branch,
+pushes all changes, and creates or updates PRs in a single command. With
+gh-stack, pushing and creating PRs are separate steps (`push` then `submit`).
+
+**Merge Queue depth.** Mergify's Merge Queue has [batching](/merge-queue/batches),
+[priority lanes](/merge-queue/priority),
+[speculative checks](/merge-queue/parallel-checks), and
+[queue freeze](/merge-queue/pause). gh-stack relies on GitHub's built-in merge
+queue, which is more limited.
+
+**Collaboration support.** `mergify stack checkout` lets a teammate pick up
+your stack locally and push changes. `mergify stack sync` pulls remote changes
+back down, so commits made by bots or review suggestions are incorporated
+automatically. With gh-stack's force-push model, coordinating on the same stack
+is harder.
+
+**Merge works today.** Stacked PRs land through the Merge Queue as each
+dependency merges. gh-stack's `merge` command is listed in the docs but not
+yet implemented.
+
+## Where gh-stack Is Stronger
+
+**Native GitHub UI.** gh-stack gets a stack map rendered directly in the PR
+interface. Mergify posts a stack comment on each PR, which works well but is
+a comment rather than a native UI element.
+
+## Other Considerations
+
+**Platform lock-in.** gh-stack is GitHub-only by design. Mergify's stacking
+workflow also targets GitHub today, but the architecture isn't tied to a single
+platform.
+
+**Distribution.** gh-stack ships as a `gh` CLI extension and will likely get
+deeper GitHub integration over time. Mergify CLI is a standalone install
+(`uv tool install mergify-cli`).
+
+**Pricing.** Both are free. Mergify Stacks is a standalone CLI that doesn't
+require a Mergify subscription.
+
+## Switching from gh-stack
+
+If you've been using gh-stack and want to try Mergify Stacks, the migration is
+straightforward. The main shift is moving from "one branch per PR" to "one
+commit per PR on a single branch."
+
+### Install and setup
+
+```bash
+uv tool install mergify-cli
+mergify stack setup
+```
+
+This installs the CLI and adds a `commit-msg` hook that generates
+[Change-Ids](/stacks/concepts#change-id) for your commits. See the
+[setup guide](/stacks/setup) for details.
+
+### Concept mapping
+
+| gh-stack | Mergify Stacks |
+|---|---|
+| `gh stack init` | `mergify stack new` |
+| `gh stack add` (create a branch) | `git commit` (create a commit) |
+| `gh stack push` + `gh stack submit` | `mergify stack push` |
+| `gh stack up` / `down` | Not needed (single branch) |
+| `gh stack rebase` | Automatic on `mergify stack push` |
+| `gh stack sync` | `mergify stack sync` |
+| `gh stack view` | `mergify stack list` |
+
+### Workflow before and after
+
+**With gh-stack:**
+
+```bash
+gh stack init
+# work on first change
+gh stack add
+# work on second change
+gh stack push
+gh stack submit
+```
+
+**With Mergify Stacks:**
+
+```bash
+mergify stack new
+git commit -m "first change"
+git commit -m "second change"
+mergify stack push
+```
+
+The result on GitHub is the same: two chained PRs, each showing one change.

--- a/src/content/docs/stacks/team.mdx
+++ b/src/content/docs/stacks/team.mdx
@@ -81,17 +81,7 @@ queue, and so on, without manual coordination.
 
 ## Comparing with Alternatives
 
-Several tools offer stacked PRs. Here's how Mergify Stacks compares:
-
-| | Mergify Stacks | Graphite | ghstack | spr |
-|---|---|---|---|---|
-| **Workflow** | Standard Git | Custom CLI | Standard Git | Standard Git |
-| **Branch model** | One local branch | Managed branches | Managed branches | Managed branches |
-| **GitHub integration** | PR chaining + deps | PR chaining + dashboard | PR chaining | PR chaining |
-| **Merge queue** | [Built-in](/merge-queue) | Separate | None | None |
-| **Pricing** | Included with Mergify | Separate subscription | Open source | Open source |
-| **Setup** | CLI + one command | CLI + account setup | CLI install | CLI install |
-
-Mergify Stacks uses standard Git. You don't learn new commands for committing
-or managing branches. You use `git commit`, `git rebase`, and
-`git commit --amend` like you always have. Stacks handles the GitHub side.
+Several tools offer stacked PRs, each with different trade-offs around workflow
+complexity, branch management, platform integration, and collaboration support.
+See the [detailed comparisons](/stacks/compare) for an honest look at how
+Mergify Stacks measures up against alternatives, starting with gh-stack.

--- a/src/content/navItems.tsx
+++ b/src/content/navItems.tsx
@@ -220,6 +220,15 @@ const navItems: NavItem[] = [
       { title: 'Updating Stacks', path: '/stacks/updating', icon: 'fa6-solid:pen-to-square' },
       { title: 'Reviewing Stacks', path: '/stacks/reviewing', icon: 'fa6-solid:magnifying-glass' },
       { title: 'Team Adoption', path: '/stacks/team', icon: 'fa6-solid:people-group' },
+      {
+        title: 'Compare Tools',
+        path: '/stacks/compare',
+        icon: 'fa6-solid:scale-balanced',
+        children: [
+          { title: 'Overview', path: '/stacks/compare', icon: 'fa6-regular:lightbulb' },
+          { title: 'vs gh-stack', path: '/stacks/compare/gh-stack', icon: 'simple-icons:github' },
+        ],
+      },
     ],
   },
   {


### PR DESCRIPTION
Add an extensible comparison section under /stacks/compare with an honest
feature-by-feature comparison against GitHub's gh-stack CLI. Includes
visual diagrams contrasting the two branching models, a switching guide,
and concept mapping table.

- New hub page at stacks/compare.mdx with DocsetGrid for future tools
- New stacks/compare/gh-stack.mdx with full comparison and migration guide
- Replace inline comparison table in stacks/team.mdx with link to hub
- Add Compare Tools entry to stacks landing page and sidebar navigation
- Fix GitGraph PAD_LEFT to accommodate longer branch names

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>