### PR TITLE
docs(stacks): fix Claude Code plugin install command

### DIFF
--- a/src/content/docs/stacks/setup.mdx
+++ b/src/content/docs/stacks/setup.mdx
@@ -58,18 +58,28 @@ npx skills add Mergifyio/mergify-cli
 
 ### Install as a Claude Code plugin
 
-From the official marketplace:
-
-```text
-/plugin install mergify@claude-plugins-official
-```
-
-Or from the repository:
+Add the marketplace, then install the Stacks plugin:
 
 ```text
 /plugin marketplace add Mergifyio/mergify-cli
-/plugin install mergify
+/plugin install mergify-stack@mergify
+/reload-plugins
 ```
+
+Or run `/plugin` on its own and use the **Marketplaces** tab to add
+`Mergifyio/mergify-cli`, then pick `mergify-stack` from **Discover**.
+
+:::tip
+  The same marketplace ships plugins for other Mergify features —
+  merge queue, CI insights, config validation, and scheduled freezes.
+  Open `/plugin` and browse **Discover** to pick the ones you want.
+:::
+
+:::tip
+  Third-party marketplaces don't auto-update by default. Open `/plugin`,
+  go to **Marketplaces**, select **mergify**, and choose **Enable
+  auto-update** to receive new skills and fixes as we ship them.
+:::
 
 ## Verify It Works
 


### PR DESCRIPTION
## Summary

Fix the Claude Code plugin install instructions on the Stacks setup page.

## The bug

The docs told users to run `/plugin install mergify` (either from the
`claude-plugins-official` marketplace or after adding
`Mergifyio/mergify-cli`). Both commands fail with:

```
Plugin "mergify" not found in any marketplace
```

- `Mergifyio/mergify-cli/.claude-plugin/marketplace.json` declares one
  plugin per skill — `mergify-stack`, `mergify-merge-queue`,
  `mergify-ci`, `mergify-config`, `mergify-freeze` — not a combined
  `mergify` plugin.
- The official `claude-plugins-official` marketplace does not list a
  Mergify plugin at all.

## The fix

Replace the broken commands with the correct install for this page
(`mergify-stack@mergify`) plus `/reload-plugins`, point users at the
interactive `/plugin` flow as an alternative, mention the other Mergify
plugins are available from the same marketplace, and invite users to
enable auto-update.

## Upstream context

Upstream PR Mergifyio/mergify-cli#1164 renamed `plugin.json`'s name
to `mergify` and added the three missing skills to `marketplace.json`.
The docs were written against the intended single-plugin naming, but
`marketplace.json` still lists five separate plugins, so the single
`/plugin install mergify` command never worked in the shipped state.

A follow-up on `mergify-cli` may later consolidate the five plugins
into a single `mergify` plugin — if that happens, the install commands
here will need to be updated again.

## Test plan

- [x] `npm run check` passes
- [x] Manual: `/plugin marketplace add Mergifyio/mergify-cli` then
      `/plugin install mergify-stack@mergify` then `/reload-plugins`
      in Claude Code
- [ ] Manual: interactive `/plugin` flow works for adding the
      marketplace and picking `mergify-stack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)