### PR TITLE
chore: switch from autoqueue to auto_merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,6 @@
 extends: .github
 shared:
   DefaultQueueOptions: &DefaultQueueOptions
-    autoqueue: true
     commit_message_template: |
       {{ title }} (#{{ number }})
 
@@ -122,3 +121,4 @@ merge_queue:
 
 merge_protections_settings:
   reporting_method: deployments
+  auto_merge: true


### PR DESCRIPTION
Remove `autoqueue: true` from the shared queue options and enable
`auto_merge: true` in `merge_protections_settings`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>