### PR TITLE
docs(merge-queue): add Buildkite examples to scope detection pages

### DIFF
--- a/src/components/BuildkiteCIUploadStep.astro
+++ b/src/components/BuildkiteCIUploadStep.astro
@@ -15,20 +15,20 @@ const { reportPath } = Astro.props;
       - mergifyio/mergify-ci#v1:
           action: junit-process
           report_path: ${reportPath}
-          token: "\${MERGIFY_CI_TOKEN}"`}
+          token: "\${MERGIFY_TOKEN}"`}
 	lang="yaml"
 	theme="slack-ochin"
 />
 <p>Key Points:</p>
 <ul>
 	<li>
-		The plugin runs in the <code>post-command</code> hook, so it uploads results <strong>after</strong> your tests finish — even if they fail.
+		The plugin runs in the <code>post-command</code> hook, so it uploads results <strong>after</strong> your tests finish, even if they fail.
 	</li>
 	<li>
 		<Code code={`report_path: ${reportPath}`} inline lang="yaml" theme="slack-ochin" />: Points to
 		where your JUnit file is located. Make sure it matches the path you set in your test configuration.
 	</li>
 	<li>
-		Silent failure detection is automatic — the plugin reads the step's exit code to detect cases where the test runner crashed but the JUnit report appears clean.
+		Silent failure detection is automatic: the plugin reads the step's exit code to detect cases where the test runner crashed but the JUnit report appears clean.
 	</li>
 </ul>

--- a/src/components/BuildkiteCIUploadStepMatrix.astro
+++ b/src/components/BuildkiteCIUploadStepMatrix.astro
@@ -26,7 +26,7 @@ const { reportPath } = Astro.props;
           action: junit-process
           job_name: "Tests ({{matrix}})"
           report_path: ${reportPath}
-          token: "\${MERGIFY_CI_TOKEN}"`}
+          token: "\${MERGIFY_TOKEN}"`}
 	lang="yaml"
 	theme="slack-ochin"
 />

--- a/src/content/docs/ci-insights/test-frameworks/pytest.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/pytest.mdx
@@ -97,7 +97,7 @@ steps:
   - label: "Run Tests 🧪"
     command: pytest
     env:
-      MERGIFY_TOKEN: "${MERGIFY_CI_TOKEN}"
+      MERGIFY_TOKEN: "${MERGIFY_TOKEN}"
 ```
 
 The plugin collects your test results and sends them to CI Insights.
@@ -127,7 +127,7 @@ steps:
   - label: "Run Tox Tests"
     command: tox
     env:
-      MERGIFY_TOKEN: "${MERGIFY_CI_TOKEN}"
+      MERGIFY_TOKEN: "${MERGIFY_TOKEN}"
 ```
 
 In your `tox.ini`, make sure the plugin is included in your testenv dependencies:
@@ -170,7 +170,7 @@ steps:
       - "3.11"
       - "3.12"
     env:
-      MERGIFY_TOKEN: "${MERGIFY_CI_TOKEN}"
+      MERGIFY_TOKEN: "${MERGIFY_TOKEN}"
       MERGIFY_TEST_JOB_NAME: "tox-{{matrix}}"
 ```
 

--- a/src/content/docs/ci-insights/test-frameworks/rspec.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/rspec.mdx
@@ -77,7 +77,7 @@ steps:
   - label: "Run RSpec Tests 🧪"
     command: bundle exec rspec
     env:
-      MERGIFY_TOKEN: "${MERGIFY_CI_TOKEN}"
+      MERGIFY_TOKEN: "${MERGIFY_TOKEN}"
 ```
 
 The gem automatically collects your test results and sends them to CI Insights.

--- a/src/content/docs/ci-insights/test-frameworks/testng.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/testng.mdx
@@ -107,7 +107,7 @@ For Gradle projects:
   run: ./gradlew test
 ```
 
-<MergifyCIUploadStep  reportPath="build/test-results/test/*.xml" />
+<MergifyCIUploadStep reportPath="build/test-results/test/*.xml" />
 <MergifyCIUploadStepMatrix reportPath="build/test-results/test/*.xml" />
 
 <GhaMergifyCiQuarantineSetup />

--- a/src/content/docs/ci-insights/test-frameworks/vitest.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/vitest.mdx
@@ -89,7 +89,7 @@ steps:
   - label: "Run Tests 🧪"
     command: npm test
     env:
-      MERGIFY_TOKEN: "${MERGIFY_CI_TOKEN}"
+      MERGIFY_TOKEN: "${MERGIFY_TOKEN}"
 ```
 
 The reporter automatically collects your test results and sends them to CI

--- a/src/content/docs/merge-queue/scopes/bazel.mdx
+++ b/src/content/docs/merge-queue/scopes/bazel.mdx
@@ -24,8 +24,9 @@ queue_rules:
 
 ## Detecting Scopes with Bazel
 
-In your GitHub Actions workflow, use `bazel query` to determine affected projects and
-upload them to Mergify:
+Use `bazel query` to determine affected projects and upload them to Mergify.
+
+### GitHub Actions
 
 ```yaml
 name: Detect Scopes
@@ -63,6 +64,39 @@ jobs:
           action: scopes-upload
           token: ${{ secrets.MERGIFY_TOKEN }}
           scopes: ${{ steps.scopes.outputs.scopes }}
+```
+
+### Buildkite
+
+Using the
+[`mergifyio/mergify-ci`](https://github.com/Mergifyio/mergify-ci-buildkite-plugin)
+Buildkite plugin, a first step resolves the merge-queue-aware base and head
+SHAs and exposes them as meta-data, while a second step computes the affected
+projects with `bazel query` and uploads them to Mergify:
+
+```yaml
+steps:
+  - label: ":mag: Get git refs"
+    key: git-refs
+    plugins:
+      - mergifyio/mergify-ci#v1:
+          action: scopes-git-refs
+
+  - label: ":mag: Detect and upload scopes"
+    depends_on: git-refs
+    command: |
+      BASE=$(buildkite-agent meta-data get "mergify-ci.base")
+      HEAD=$(buildkite-agent meta-data get "mergify-ci.head")
+      SCOPES=$( \
+        bazel query --keep_going --noshow_progress --output=package \
+          "buildfiles(set($(git diff --name-only --diff-filter=ACMR \"$BASE\" \"$HEAD\" | tr '\n' ' ')))" \
+        2>/dev/null | sort -u | paste -sd, - \
+      )
+      buildkite-agent meta-data set "mergify-ci.scopes" "$SCOPES"
+    plugins:
+      - mergifyio/mergify-ci#v1:
+          action: scopes-upload
+          token: "${MERGIFY_TOKEN}"
 ```
 
 :::note

--- a/src/content/docs/merge-queue/scopes/file-patterns.mdx
+++ b/src/content/docs/merge-queue/scopes/file-patterns.mdx
@@ -59,7 +59,7 @@ To wire scopes into GitHub Actions, follow the
 - Waiting on the right set of jobs so required checks always report, even when work is skipped.
 
 That guide already includes complete workflow samples, so you do not need to duplicate the config
-here—just reuse the same scopes you declared above.
+here. Just reuse the same scopes you declared above.
 
 ## The Merge Queue Scope
 

--- a/src/content/docs/merge-queue/scopes/nx.mdx
+++ b/src/content/docs/merge-queue/scopes/nx.mdx
@@ -24,8 +24,10 @@ queue_rules:
 
 ## Detecting Scopes with Nx
 
-In your GitHub Actions workflow, use the `nx show projects` command to determine affected projects and
-upload them to Mergify:
+Use the `nx show projects` command to determine affected projects and upload
+them to Mergify.
+
+### GitHub Actions
 
 ```yaml
 name: Detect Scopes
@@ -59,6 +61,35 @@ jobs:
           action: scopes-upload
           token: ${{ secrets.MERGIFY_TOKEN }}
           scopes: ${{ steps.scopes.outputs.scopes }}
+```
+
+### Buildkite
+
+Using the
+[`mergifyio/mergify-ci`](https://github.com/Mergifyio/mergify-ci-buildkite-plugin)
+Buildkite plugin, a first step resolves the merge-queue-aware base and head
+SHAs and exposes them as meta-data, while a second step computes the affected
+projects with Nx and uploads them to Mergify:
+
+```yaml
+steps:
+  - label: ":mag: Get git refs"
+    key: git-refs
+    plugins:
+      - mergifyio/mergify-ci#v1:
+          action: scopes-git-refs
+
+  - label: ":mag: Detect and upload scopes"
+    depends_on: git-refs
+    command: |
+      BASE=$(buildkite-agent meta-data get "mergify-ci.base")
+      HEAD=$(buildkite-agent meta-data get "mergify-ci.head")
+      SCOPES=$(npx nx show projects --affected --base="$BASE" --head="$HEAD" | paste -sd, -)
+      buildkite-agent meta-data set "mergify-ci.scopes" "$SCOPES"
+    plugins:
+      - mergifyio/mergify-ci#v1:
+          action: scopes-upload
+          token: "${MERGIFY_TOKEN}"
 ```
 
 :::note

--- a/src/content/docs/merge-queue/scopes/others.mdx
+++ b/src/content/docs/merge-queue/scopes/others.mdx
@@ -24,8 +24,10 @@ queue_rules:
 
 ## Detecting Scopes with Your Build Tool
 
-In your GitHub Actions workflow, use your monorepo tool to determine affected projects and
-upload them to Mergify:
+Use your monorepo tool to determine affected projects and upload them to
+Mergify.
+
+### GitHub Actions
 
 ```yaml
 name: Detect Scopes
@@ -59,6 +61,35 @@ jobs:
           action: scopes-upload
           token: ${{ secrets.MERGIFY_TOKEN }}
           scopes: ${{ steps.scopes.outputs.scopes }}
+```
+
+### Buildkite
+
+Using the
+[`mergifyio/mergify-ci`](https://github.com/Mergifyio/mergify-ci-buildkite-plugin)
+Buildkite plugin, a first step resolves the merge-queue-aware base and head
+SHAs and exposes them as meta-data, while a second step computes the affected
+projects with your monorepo tool and uploads them to Mergify:
+
+```yaml
+steps:
+  - label: ":mag: Get git refs"
+    key: git-refs
+    plugins:
+      - mergifyio/mergify-ci#v1:
+          action: scopes-git-refs
+
+  - label: ":mag: Detect and upload scopes"
+    depends_on: git-refs
+    command: |
+      BASE=$(buildkite-agent meta-data get "mergify-ci.base")
+      HEAD=$(buildkite-agent meta-data get "mergify-ci.head")
+      SCOPES=$(my_monorepo_command_to_get_impacted_projects "$BASE" "$HEAD" | paste -sd, -)
+      buildkite-agent meta-data set "mergify-ci.scopes" "$SCOPES"
+    plugins:
+      - mergifyio/mergify-ci#v1:
+          action: scopes-upload
+          token: "${MERGIFY_TOKEN}"
 ```
 
 :::note

--- a/src/content/docs/merge-queue/scopes/turborepo.mdx
+++ b/src/content/docs/merge-queue/scopes/turborepo.mdx
@@ -24,8 +24,10 @@ queue_rules:
 
 ## Detecting Scopes with Turborepo
 
-In your GitHub Actions workflow, use the `turbo run build --dry` command to determine affected projects and
-upload them to Mergify:
+Use the `turbo run build --dry=json` command to determine affected projects and
+upload them to Mergify.
+
+### GitHub Actions
 
 ```yaml
 name: Detect Scopes
@@ -59,6 +61,35 @@ jobs:
           action: scopes-upload
           token: ${{ secrets.MERGIFY_TOKEN }}
           scopes: ${{ steps.scopes.outputs.scopes }}
+```
+
+### Buildkite
+
+Using the
+[`mergifyio/mergify-ci`](https://github.com/Mergifyio/mergify-ci-buildkite-plugin)
+Buildkite plugin, a first step resolves the merge-queue-aware base and head
+SHAs and exposes them as meta-data, while a second step computes the affected
+projects with `turbo run build --dry=json` and uploads them to Mergify:
+
+```yaml
+steps:
+  - label: ":mag: Get git refs"
+    key: git-refs
+    plugins:
+      - mergifyio/mergify-ci#v1:
+          action: scopes-git-refs
+
+  - label: ":mag: Detect and upload scopes"
+    depends_on: git-refs
+    command: |
+      BASE=$(buildkite-agent meta-data get "mergify-ci.base")
+      HEAD=$(buildkite-agent meta-data get "mergify-ci.head")
+      SCOPES=$(npx turbo run build --dry=json --filter="[$BASE...$HEAD]" | jq -r '.packages | join(",")')
+      buildkite-agent meta-data set "mergify-ci.scopes" "$SCOPES"
+    plugins:
+      - mergifyio/mergify-ci#v1:
+          action: scopes-upload
+          token: "${MERGIFY_TOKEN}"
 ```
 
 :::note

--- a/src/content/docs/monorepo-ci/buildkite.mdx
+++ b/src/content/docs/monorepo-ci/buildkite.mdx
@@ -81,7 +81,7 @@ steps:
     plugins:
       - mergifyio/mergify-ci#v1:
           action: scopes
-          token: "${MERGIFY_CI_TOKEN}"
+          token: "${MERGIFY_TOKEN}"
 
   - label: ":pipeline: Upload conditional steps"
     depends_on: detect-scopes
@@ -107,7 +107,7 @@ if echo "$SCOPES" | jq -e '.frontend == "true"' > /dev/null 2>&1; then
       - mergifyio/mergify-ci#v1:
           action: junit-process
           report_path: "junit.xml"
-          token: "${MERGIFY_CI_TOKEN}"
+          token: "${MERGIFY_TOKEN}"
 YAML
 fi
 
@@ -119,7 +119,7 @@ if echo "$SCOPES" | jq -e '.api == "true"' > /dev/null 2>&1; then
       - mergifyio/mergify-ci#v1:
           action: junit-process
           report_path: "reports/*.xml"
-          token: "${MERGIFY_CI_TOKEN}"
+          token: "${MERGIFY_TOKEN}"
 YAML
 fi
 


### PR DESCRIPTION
The scope detection guides for Nx, Bazel, Turborepo, and custom build
tools only showed GitHub Actions workflows. Add a sibling Buildkite
example under each page using the `mergifyio/mergify-ci` plugin with
`scopes-git-refs` and `scopes-upload`, so Buildkite users have a
drop-in pattern.

Also standardize Buildkite plugin token references on `MERGIFY_TOKEN`
(matching the CI Insights setup doc), fix a few pre-existing em dashes
in the Buildkite components and file-patterns guide, align the
Turborepo Buildkite intro on `--dry=json`, and drop a stray double
space in testng.mdx.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>