### PR TITLE
docs(stacks): apply proofread fixes for AI agent positioning

### DIFF
--- a/src/content/docs/stacks.mdx
+++ b/src/content/docs/stacks.mdx
@@ -67,13 +67,13 @@ reviewers see the logical progression of your work.
 
 ## Get Started in 30 Seconds
 
-**For your AI agent** — share this URL:
+**For your AI coding agent:** share this URL:
 
 ```text
 https://docs.mergify.com/stacks/agents
 ```
 
-Your agent installs the CLI and skill itself, then you prompt it as usual.
+Your agent installs the CLI and the Stacks skill itself, then you prompt it as usual.
 
 **For yourself:**
 

--- a/src/content/docs/stacks/agents.mdx
+++ b/src/content/docs/stacks/agents.mdx
@@ -5,7 +5,7 @@ description: One-page bootstrap for AI coding agents — install the Mergify CLI
 
 You are an AI coding agent. Follow these three steps to enable stacked pull
 request support. After step 2, your skill system will contain the full Stacks
-workflow — consult it for any stack-related task.
+workflow. Consult it for any stack-related task.
 
 ## 1. Install the Mergify CLI
 
@@ -43,8 +43,8 @@ Pick the command that matches your runtime.
 npx skills add Mergifyio/mergify-cli
 ```
 
-The skill contains the full Stacks workflow — commands, rules, and common
-scenarios. Load it before performing any stack work.
+The skill contains the full Stacks workflow (commands, rules, and common
+scenarios). Load it before performing any stack work.
 
 ## 3. Initialize the repository
 

--- a/src/content/docs/stacks/setup.mdx
+++ b/src/content/docs/stacks/setup.mdx
@@ -16,9 +16,9 @@ Quick install:
 uv tool install mergify-cli
 ```
 
-## 2. Install skills for your AI agent
+## 2. Install skills for your AI coding agent
 
-Mergify ships skills that teach AI coding agents how to work with Stacks — so
+Mergify ships skills that teach AI coding agents how to work with Stacks, so
 they run `mergify stack push` instead of `git push`, amend commits instead of
 creating fixups, and follow stack conventions automatically.
 
@@ -33,8 +33,8 @@ creating fixups, and follow stack conventions automatically.
 Or run `/plugin` on its own and use the **Marketplaces** tab to add
 `Mergifyio/mergify-cli`, then pick `mergify-stack` from **Discover**.
 
-**Any agent supporting [skills.sh](https://skills.sh)** — Cursor, Cline, and
-others:
+**Any agent supporting [skills.sh](https://skills.sh)** (Cursor, Cline, and
+others):
 
 ```bash
 npx skills add Mergifyio/mergify-cli
@@ -42,12 +42,12 @@ npx skills add Mergifyio/mergify-cli
 
 :::tip
   Prefer to hand a single URL to your agent? Point it at
-  [docs.mergify.com/stacks/agents](/stacks/agents) — the page walks the agent
-  through installing the CLI and skill itself.
+  [docs.mergify.com/stacks/agents](/stacks/agents). That page walks the agent
+  through installing the CLI and the Stacks skill itself.
 :::
 
 :::tip
-  The same marketplace ships plugins for other Mergify features — merge queue,
+  The same marketplace ships plugins for other Mergify features: merge queue,
   CI insights, config validation, and scheduled freezes. Open `/plugin` and
   browse **Discover** to pick the ones you want.
 :::


### PR DESCRIPTION
Em dashes swapped for commas/periods/colons/parentheses per site style;
canonical term "AI coding agent" restored in setup heading and landing
copy; "the Stacks skill" consistent in prose referring to the installed
skill.

Depends-On: #11144