### PR TITLE
docs(stacks): reposition Stacks as AI-agent-first

### DIFF
--- a/src/content/docs/stacks.mdx
+++ b/src/content/docs/stacks.mdx
@@ -12,9 +12,14 @@ AI can write 1,000 lines of code in minutes, but nobody wants to review a
 1,000-line pull request. Reviewers skim instead of reading, bugs slip through,
 and merges stall for days.
 
-<Button variant="primary" href="/stacks/setup" target="_self">
-  Get Started →
-</Button>
+<div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+  <Button variant="primary" href="/stacks/setup" target="_self">
+    Get Started →
+  </Button>
+  <Button variant="secondary" href="/stacks/agents" target="_self">
+    Give your agent this link →
+  </Button>
+</div>
 
 ## The Problem: One Branch = One PR
 
@@ -57,9 +62,20 @@ reviewers see the logical progression of your work.
 - Automatic PR chaining with dependency tracking
 - Smart updates that only touch PRs that changed
 - Standard Git, no new commands to learn
+- Ships with skills for Claude Code, Cursor, and any agent supporting [skills.sh](https://skills.sh)
 - Complements [Merge Queue](/merge-queue) for safe, fast landing
 
 ## Get Started in 30 Seconds
+
+**For your AI coding agent:** share this URL:
+
+```text
+https://docs.mergify.com/stacks/agents
+```
+
+Your agent installs the CLI and the Stacks skill itself, then you prompt it as usual.
+
+**For yourself:**
 
 ```bash
 uv tool install mergify-cli
@@ -67,12 +83,15 @@ mergify stack setup
 mergify stack push
 ```
 
-Three commands to go from a branch with commits to a stack of reviewable PRs on
-GitHub. See the [setup guide](/stacks/setup) for details.
+See the [setup guide](/stacks/setup) for the full walkthrough.
 
 ## Learn More
 
 <DocsetGrid>
+  <Docset title="For AI Agents" path="/stacks/agents" icon="fa6-solid:robot">
+    A single URL to hand your AI coding agent so it installs the CLI and the
+    Stacks skill itself.
+  </Docset>
   <Docset title="Concepts" path="/stacks/concepts" icon="fa6-solid:diagram-project">
     How stacks work under the hood: Change-Ids, branch mapping, and PR chaining.
   </Docset>

--- a/src/content/docs/stacks/agents.mdx
+++ b/src/content/docs/stacks/agents.mdx
@@ -1,0 +1,64 @@
+---
+title: Stacks for AI Agents
+description: One-page bootstrap for AI coding agents — install the Mergify CLI and the Stacks skill.
+---
+
+You are an AI coding agent. Follow these three steps to enable stacked pull
+request support. After step 2, your skill system will contain the full Stacks
+workflow. Consult it for any stack-related task.
+
+## 1. Install the Mergify CLI
+
+Install `mergify-cli` with `uv` (preferred) or `pipx`:
+
+```bash
+uv tool install mergify-cli
+```
+
+```bash
+pipx install mergify-cli
+```
+
+Verify:
+
+```bash
+mergify --version
+```
+
+## 2. Install the Stacks skill
+
+Pick the command that matches your runtime.
+
+**Claude Code:**
+
+```text
+/plugin marketplace add Mergifyio/mergify-cli
+/plugin install mergify-stack@mergify
+/reload-plugins
+```
+
+**Any agent supporting [skills.sh](https://skills.sh) (Cursor, Cline, and others):**
+
+```bash
+npx skills add Mergifyio/mergify-cli
+```
+
+The skill contains the full Stacks workflow (commands, rules, and common
+scenarios). Load it before performing any stack work.
+
+## 3. Initialize the repository
+
+Run in the repository root:
+
+```bash
+mergify stack setup
+```
+
+This installs a `commit-msg` Git hook that generates a `Change-Id` for every
+new commit, and a `pre-push` hook that warns if `git push` is used instead of
+`mergify stack push`.
+
+## You are ready
+
+The skill installed in step 2 contains the workflow. Follow it for any
+stack-related task.

--- a/src/content/docs/stacks/setup.mdx
+++ b/src/content/docs/stacks/setup.mdx
@@ -6,23 +6,72 @@ description: Install Mergify CLI and configure your repository for stacked PRs.
 import { Image } from 'astro:assets';
 import deleteHeadBranches from '../../images/github-delete-head-branches.png';
 
-## Prerequisites
+## 1. Install the Mergify CLI
 
-1. **Install the Mergify CLI**, see the [CLI installation guide](/cli) for
-   instructions.
+See the [CLI installation guide](/cli) for full instructions.
 
-2. **GitHub authentication**: Stacks needs access to create PRs. Either:
-   - Set the `GITHUB_TOKEN` environment variable, or
-   - Install the [GitHub CLI](https://cli.github.com/) and run `gh auth login`
+Quick install:
 
-3. **Enable "[Automatically delete head branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches)"**
-   in your GitHub repository settings (Settings > General > Pull Requests).
-   When a stacked PR merges, this cleans up its remote branch automatically
-   so the next PR in the chain can rebase onto `main` cleanly.
+```bash
+uv tool install mergify-cli
+```
+
+## 2. Install skills for your AI coding agent
+
+Mergify ships skills that teach AI coding agents how to work with Stacks, so
+they run `mergify stack push` instead of `git push`, amend commits instead of
+creating fixups, and follow stack conventions automatically.
+
+**Claude Code:**
+
+```text
+/plugin marketplace add Mergifyio/mergify-cli
+/plugin install mergify-stack@mergify
+/reload-plugins
+```
+
+Or run `/plugin` on its own and use the **Marketplaces** tab to add
+`Mergifyio/mergify-cli`, then pick `mergify-stack` from **Discover**.
+
+**Any agent supporting [skills.sh](https://skills.sh)** (Cursor, Cline, and
+others):
+
+```bash
+npx skills add Mergifyio/mergify-cli
+```
+
+:::tip
+  Prefer to hand a single URL to your agent? Point it at
+  [docs.mergify.com/stacks/agents](/stacks/agents). That page walks the agent
+  through installing the CLI and the Stacks skill itself.
+:::
+
+:::tip
+  The same marketplace ships plugins for other Mergify features: merge queue,
+  CI insights, config validation, and scheduled freezes. Open `/plugin` and
+  browse **Discover** to pick the ones you want.
+:::
+
+:::tip
+  Third-party marketplaces don't auto-update by default. Open `/plugin`, go to
+  **Marketplaces**, select **mergify**, and choose **Enable auto-update** to
+  receive new skills and fixes as we ship them.
+:::
+
+## 3. Configure GitHub
+
+Stacks needs access to create PRs. Set the `GITHUB_TOKEN` environment
+variable, or install the [GitHub CLI](https://cli.github.com/) and run
+`gh auth login`.
+
+Enable "[Automatically delete head branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches)"
+in your GitHub repository settings (Settings > General > Pull Requests). When
+a stacked PR merges, this cleans up its remote branch automatically so the
+next PR in the chain can rebase onto `main` cleanly.
 
 <Image src={deleteHeadBranches} alt="GitHub setting: Automatically delete head branches" style={{ maxWidth: '66%' }} />
 
-## Initialize Your Repository
+## 4. Initialize your repository
 
 Run the setup command in your Git repository:
 
@@ -39,47 +88,6 @@ This installs:
 
 - A `pre-push` hook that warns you if you accidentally use `git push` instead
   of `mergify stack push`.
-
-## AI Agent Skills
-
-Mergify CLI provides AI skills that teach coding agents how to work with
-Stacks — so they automatically use `mergify stack push` instead of `git push`,
-amend commits instead of creating fixup commits, and follow stack conventions.
-
-### Install via npx (all agents)
-
-This works with [Claude Code](https://claude.ai/code),
-[Cursor](https://cursor.sh), and
-[many other AI agents](https://skills.sh):
-
-```bash
-npx skills add Mergifyio/mergify-cli
-```
-
-### Install as a Claude Code plugin
-
-Add the marketplace, then install the Stacks plugin:
-
-```text
-/plugin marketplace add Mergifyio/mergify-cli
-/plugin install mergify-stack@mergify
-/reload-plugins
-```
-
-Or run `/plugin` on its own and use the **Marketplaces** tab to add
-`Mergifyio/mergify-cli`, then pick `mergify-stack` from **Discover**.
-
-:::tip
-  The same marketplace ships plugins for other Mergify features —
-  merge queue, CI insights, config validation, and scheduled freezes.
-  Open `/plugin` and browse **Discover** to pick the ones you want.
-:::
-
-:::tip
-  Third-party marketplaces don't auto-update by default. Open `/plugin`,
-  go to **Marketplaces**, select **mergify**, and choose **Enable
-  auto-update** to receive new skills and fixes as we ship them.
-:::
 
 ## Verify It Works
 


### PR DESCRIPTION
- Add /stacks/agents bootstrap page — a single URL a human can hand to
  their AI coding agent; the agent installs mergify-cli and the Stacks
  skill itself, then follows the skill's workflow.
- Lead setup with skill installation (Claude Code plugin or npx skills)
  before repo init, so the primary reader path is "install the skill
  that teaches your agent" rather than "configure Git hooks by hand".
- Add secondary CTA, feature bullet, and DocsetGrid tile on the landing
  page so the AI-agent positioning is visible at first glance.