### PR TITLE
docs(api): surface pull_requests tag and link scopes endpoint

### DIFF
--- a/src/components/ApiReference/openapi.ts
+++ b/src/components/ApiReference/openapi.ts
@@ -166,6 +166,7 @@ export const TAG_LABELS: Record<string, string> = {
   statistics: 'Statistics',
   scheduled_freeze: 'Scheduled Freeze',
   merge_queue: 'Merge Queue',
+  pull_requests: 'Pull Requests',
 };
 
 // Tag descriptions for sub-page intros
@@ -178,6 +179,7 @@ export const TAG_DESCRIPTIONS: Record<string, string> = {
   statistics: 'Access merge queue and CI performance statistics.',
   scheduled_freeze: 'Schedule merge queue freezes for maintenance or release windows.',
   merge_queue: 'Control merge queue state — pause, unpause, and inspect status.',
+  pull_requests: 'Push scopes and other per-pull-request data to Mergify.',
 };
 
 export function humanizeTag(tag: string): string {

--- a/src/content/docs/merge-queue/scopes.mdx
+++ b/src/content/docs/merge-queue/scopes.mdx
@@ -90,9 +90,9 @@ Scopes can be attached to pull requests automatically or manually:
   step-by-step setup.
 
 - **Manual upload:** Use the [`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci)
-  GitHub Action, the REST API, or the `mergify scopes-send` CLI to push scopes computed by your own
-  tooling (Nx, Bazel, Turborepo, etc.). Examples are available in the build tool guides under
-  [Scopes integrations](/merge-queue/scopes).
+  GitHub Action, the [REST API](/api/pull-requests), or the `mergify scopes-send` CLI to push scopes
+  computed by your own tooling (Nx, Bazel, Turborepo, etc.). Examples are available in the build
+  tool guides under [Scopes integrations](/merge-queue/scopes).
 
 ## Configuration schema
 


### PR DESCRIPTION
Register the `pull_requests` OpenAPI tag in the API reference so the
scopes endpoint (`POST /repos/{owner}/{repository}/pulls/{number}/scopes`)
appears as a labeled card on /api with a description, and link to it
from the merge-queue scopes guide where the REST API is mentioned.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>