### PR TITLE
docs: add Mergify CLI examples for scopes and JUnit upload

### DIFF
--- a/src/components/MergifyCliUploadStep.astro
+++ b/src/components/MergifyCliUploadStep.astro
@@ -1,0 +1,45 @@
+---
+import { Code } from 'astro:components';
+
+export interface Props {
+  reportPath: string;
+  testCommand?: string;
+}
+
+const { reportPath, testCommand = '<your test command>' } = Astro.props;
+---
+
+<p>
+	Install the <a href="/cli">Mergify CLI</a> in your pipeline and export
+	<Code code={`MERGIFY_TOKEN`} inline lang="bash" theme="slack-ochin" />. Run
+	<Code code={`mergify ci junit-process`} inline lang="bash" theme="slack-ochin" /> after your tests:
+</p>
+
+<Code
+	code={`set -o pipefail
+${testCommand}
+exit_code=$?
+mergify ci junit-process \\
+  --test-exit-code "$exit_code" \\
+  ${reportPath}
+exit $exit_code`}
+	lang="bash"
+	theme="slack-ochin"
+/>
+
+<p>Key Points:</p>
+<ul>
+	<li>
+		<Code code={`MERGIFY_TOKEN`} inline lang="bash" theme="slack-ochin" />: Export this
+		environment variable with your Mergify application key so <code>junit-process</code> can authenticate to the API.
+	</li>
+	<li>
+		<Code code={`--test-exit-code "$exit_code"`} inline lang="bash" theme="slack-ochin" />: Passes the test runner's exit
+		code so Mergify can detect silent failures where the runner crashed but the JUnit report appears clean.
+	</li>
+	<li>
+		On CI systems other than GitHub Actions, also pass
+		<Code code={`--tests-target-branch <branch>`} inline lang="bash" theme="slack-ochin" /> so the command knows which
+		branch to compare against for quarantine decisions.
+	</li>
+</ul>

--- a/src/content/docs/ci-insights/test-frameworks/cypress.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/cypress.mdx
@@ -13,6 +13,7 @@ import GhaMergifyCiQuarantineSetup from "./_gha_mergify_ci_quarantine_setup.mdx"
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 <IntegrationLogo src={cypressLogo} alt="Cypress logo" />
 
@@ -67,6 +68,10 @@ test:cypress` (or similar), include a step like:
 <BuildkiteCIUploadStepMatrix reportPath="cypress/results/junit*.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+<MergifyCliUploadStep reportPath="cypress/results/junit*.xml" testCommand="npm run test:cypress" />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/golang.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/golang.mdx
@@ -13,6 +13,7 @@ import MergifyCIUploadStepMatrix from "../../../../components/MergifyCIUploadSte
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 <IntegrationLogo src={golangLogo} alt="Golang logo" />
 
@@ -66,6 +67,10 @@ For example, in your workflow file:
 <BuildkiteCIUploadStepMatrix reportPath="junit.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+<MergifyCliUploadStep reportPath="junit.xml" testCommand="go test -v ./... 2>&1 | go-junit-report > junit.xml" />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/jest.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/jest.mdx
@@ -13,6 +13,7 @@ import MergifyCIUploadStepMatrix from "../../../../components/MergifyCIUploadSte
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 <IntegrationLogo src={jestLogo} alt="Jest logo" />
 
@@ -91,6 +92,10 @@ For example, in your workflow file:
 <BuildkiteCIUploadStepMatrix reportPath="junit.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+<MergifyCliUploadStep reportPath="junit.xml" testCommand="npx jest --reporters=default --reporters=jest-junit" />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/junit.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/junit.mdx
@@ -11,6 +11,7 @@ import CIInsightsSetupNote from "../../../../components/CIInsightsSetupNote.astr
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 This guide shows how to generate JUnit reports from your JUnit tests and upload
 them to **CI Insights** using your CI workflow.
@@ -112,6 +113,16 @@ For Gradle projects:
 <BuildkiteCIUploadStepMatrix reportPath="build/test-results/test/*.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+For Maven projects:
+
+<MergifyCliUploadStep reportPath="target/surefire-reports/*.xml" testCommand="mvn test" />
+
+For Gradle projects:
+
+<MergifyCliUploadStep reportPath="build/test-results/test/*.xml" testCommand="./gradlew test" />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/minitest.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/minitest.mdx
@@ -11,6 +11,7 @@ import CIInsightsSetupNote from "../../../../components/CIInsightsSetupNote.astr
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 This guide shows how to generate JUnit reports from your Minitest tests and upload
 them to **CI Insights** using your CI workflow.
@@ -153,6 +154,10 @@ Using `minitest-reporters` approach:
 <BuildkiteCIUploadStepMatrix reportPath="junit.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+<MergifyCliUploadStep reportPath="junit.xml" testCommand="bundle exec rake test" />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/mstest.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/mstest.mdx
@@ -11,6 +11,7 @@ import CIInsightsSetupNote from "../../../../components/CIInsightsSetupNote.astr
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 This guide shows how to generate JUnit reports from your MSTest tests and upload
 them to **CI Insights** using your CI workflow.
@@ -100,6 +101,10 @@ For example, in your workflow file:
 <BuildkiteCIUploadStepMatrix reportPath="junit.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+<MergifyCliUploadStep reportPath="junit.xml" testCommand={`dotnet test --logger "junit;LogFilePath=junit.xml"`} />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/nunit.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/nunit.mdx
@@ -11,6 +11,7 @@ import CIInsightsSetupNote from "../../../../components/CIInsightsSetupNote.astr
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 This guide shows how to generate JUnit reports from your NUnit tests and upload
 them to **CI Insights** using your CI workflow.
@@ -119,6 +120,10 @@ For example, in your workflow file:
 <BuildkiteCIUploadStepMatrix reportPath="junit.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+<MergifyCliUploadStep reportPath="junit.xml" testCommand={`dotnet test --logger "junit;LogFilePath=junit.xml"`} />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/pest.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/pest.mdx
@@ -11,6 +11,7 @@ import CIInsightsSetupNote from "../../../../components/CIInsightsSetupNote.astr
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 This guide shows how to generate JUnit reports from your Pest tests and upload
 them to **CI Insights** using your CI workflow.
@@ -111,6 +112,10 @@ For example, in your workflow file:
 <BuildkiteCIUploadStepMatrix reportPath="junit.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+<MergifyCliUploadStep reportPath="junit.xml" testCommand="./vendor/bin/pest --log-junit junit.xml" />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/phpunit.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/phpunit.mdx
@@ -11,6 +11,7 @@ import CIInsightsSetupNote from "../../../../components/CIInsightsSetupNote.astr
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 This guide shows how to generate JUnit reports from your PHPUnit tests and upload
 them to **CI Insights** using your CI workflow.
@@ -98,6 +99,10 @@ For example, in your workflow file:
 <BuildkiteCIUploadStepMatrix reportPath="junit.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+<MergifyCliUploadStep reportPath="junit.xml" testCommand="./vendor/bin/phpunit --log-junit junit.xml" />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/playwright.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/playwright.mdx
@@ -13,6 +13,7 @@ import MergifyCIUploadStepMatrix from "../../../../components/MergifyCIUploadSte
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 <IntegrationLogo src={playwrightLogo} alt="Playwright logo" />
 
@@ -84,6 +85,13 @@ For example, in your workflow file:
 <BuildkiteCIUploadStepMatrix reportPath="junit.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+<MergifyCliUploadStep
+  reportPath="junit.xml"
+  testCommand="npx playwright test --reporter=list --reporter=junit:junit.xml"
+/>
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/rust.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/rust.mdx
@@ -13,6 +13,7 @@ import GhaMergifyCiQuarantineSetup from "./_gha_mergify_ci_quarantine_setup.mdx"
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 <IntegrationLogo src={rustLogo} alt="Rust logo" />
 
@@ -116,6 +117,10 @@ Alternative approach using cargo2junit:
 <BuildkiteCIUploadStepMatrix reportPath="junit.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+<MergifyCliUploadStep reportPath="junit.xml" testCommand="cargo test -- --nocapture 2>&1 | cargo2junit > junit.xml" />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/ci-insights/test-frameworks/testng.mdx
+++ b/src/content/docs/ci-insights/test-frameworks/testng.mdx
@@ -11,6 +11,7 @@ import CIInsightsSetupNote from "../../../../components/CIInsightsSetupNote.astr
 import BuildkiteCIUploadStep from "../../../../components/BuildkiteCIUploadStep.astro"
 import BuildkiteCIUploadStepMatrix from "../../../../components/BuildkiteCIUploadStepMatrix.astro"
 import BuildkiteCIQuarantineSetup from "./_buildkite_mergify_ci_quarantine_setup.mdx"
+import MergifyCliUploadStep from "../../../../components/MergifyCliUploadStep.astro"
 
 This guide shows how to generate JUnit reports from your TestNG tests and upload
 them to **CI Insights** using your CI workflow.
@@ -125,6 +126,16 @@ For Gradle projects:
 <BuildkiteCIUploadStepMatrix reportPath="build/test-results/test/*.xml" />
 
 <BuildkiteCIQuarantineSetup />
+
+### Any CI (Mergify CLI)
+
+For Maven projects:
+
+<MergifyCliUploadStep reportPath="target/surefire-reports/*.xml" testCommand="mvn test" />
+
+For Gradle projects:
+
+<MergifyCliUploadStep reportPath="build/test-results/test/*.xml" testCommand="./gradlew test" />
 
 ## Verify and Review in CI Insights
 

--- a/src/content/docs/merge-queue/scopes/bazel.mdx
+++ b/src/content/docs/merge-queue/scopes/bazel.mdx
@@ -99,6 +99,25 @@ steps:
           token: "${MERGIFY_TOKEN}"
 ```
 
+### Any CI (Mergify CLI)
+
+Install the [Mergify CLI](/cli) in your pipeline and export `MERGIFY_TOKEN`.
+Use `mergify ci git-refs` to get the merge-queue-aware base and head SHAs and
+`mergify ci scopes-send` to upload the detected scopes:
+
+```bash
+REFS=$(mergify ci git-refs)
+BASE=$(echo "$REFS" | awk '/^Base:/ {print $2}')
+HEAD=$(echo "$REFS" | awk '/^Head:/ {print $2}')
+
+bazel query --keep_going --noshow_progress --output=package \
+  "buildfiles(set($(git diff --name-only --diff-filter=ACMR \"$BASE\" \"$HEAD\" | tr '\n' ' ')))" \
+  2>/dev/null | sort -u \
+  | jq -R -s '{scopes: split("\n") | map(select(length > 0))}' > scopes.json
+
+mergify ci scopes-send --file scopes.json
+```
+
 :::note
 In the context of merge queue pull requests, the `HEAD` and `BASE` git references are specifically
 calculated to detect changed projects in the current batch only, not in the batches this one depends

--- a/src/content/docs/merge-queue/scopes/nx.mdx
+++ b/src/content/docs/merge-queue/scopes/nx.mdx
@@ -92,6 +92,23 @@ steps:
           token: "${MERGIFY_TOKEN}"
 ```
 
+### Any CI (Mergify CLI)
+
+Install the [Mergify CLI](/cli) in your pipeline and export `MERGIFY_TOKEN`.
+Use `mergify ci git-refs` to get the merge-queue-aware base and head SHAs and
+`mergify ci scopes-send` to upload the detected scopes:
+
+```bash
+REFS=$(mergify ci git-refs)
+BASE=$(echo "$REFS" | awk '/^Base:/ {print $2}')
+HEAD=$(echo "$REFS" | awk '/^Head:/ {print $2}')
+
+npx nx show projects --affected --base="$BASE" --head="$HEAD" \
+  | jq -R -s '{scopes: split("\n") | map(select(length > 0))}' > scopes.json
+
+mergify ci scopes-send --file scopes.json
+```
+
 :::note
 In the context of merge queue pull requests, the `HEAD` and `BASE` git references are specifically
 calculated to detect changed projects in the current batch only, not in the batches this one depends

--- a/src/content/docs/merge-queue/scopes/others.mdx
+++ b/src/content/docs/merge-queue/scopes/others.mdx
@@ -92,6 +92,23 @@ steps:
           token: "${MERGIFY_TOKEN}"
 ```
 
+### Any CI (Mergify CLI)
+
+Install the [Mergify CLI](/cli) in your pipeline and export `MERGIFY_TOKEN`.
+Use `mergify ci git-refs` to get the merge-queue-aware base and head SHAs and
+`mergify ci scopes-send` to upload the detected scopes:
+
+```bash
+REFS=$(mergify ci git-refs)
+BASE=$(echo "$REFS" | awk '/^Base:/ {print $2}')
+HEAD=$(echo "$REFS" | awk '/^Head:/ {print $2}')
+
+my_monorepo_command_to_get_impacted_projects "$BASE" "$HEAD" \
+  | jq -R -s '{scopes: split("\n") | map(select(length > 0))}' > scopes.json
+
+mergify ci scopes-send --file scopes.json
+```
+
 :::note
 In the context of merge queue pull requests, the `HEAD` and `BASE` git references are specifically
 calculated to detect changed projects in the current batch only, not in the batches this one depends

--- a/src/content/docs/merge-queue/scopes/turborepo.mdx
+++ b/src/content/docs/merge-queue/scopes/turborepo.mdx
@@ -24,8 +24,8 @@ queue_rules:
 
 ## Detecting Scopes with Turborepo
 
-Use the `turbo run build --dry=json` command to determine affected projects and
-upload them to Mergify.
+Use the `turbo run build --dry=json` command to determine affected projects
+and upload them to Mergify.
 
 ### GitHub Actions
 
@@ -90,6 +90,23 @@ steps:
       - mergifyio/mergify-ci#v1:
           action: scopes-upload
           token: "${MERGIFY_TOKEN}"
+```
+
+### Any CI (Mergify CLI)
+
+Install the [Mergify CLI](/cli) in your pipeline and export `MERGIFY_TOKEN`.
+Use `mergify ci git-refs` to get the merge-queue-aware base and head SHAs and
+`mergify ci scopes-send` to upload the detected scopes:
+
+```bash
+REFS=$(mergify ci git-refs)
+BASE=$(echo "$REFS" | awk '/^Base:/ {print $2}')
+HEAD=$(echo "$REFS" | awk '/^Head:/ {print $2}')
+
+npx turbo run build --dry=json --filter="[$BASE...$HEAD]" \
+  | jq '{scopes: .packages}' > scopes.json
+
+mergify ci scopes-send --file scopes.json
 ```
 
 :::note


### PR DESCRIPTION
Add a `### Any CI (Mergify CLI)` subsection to each scope detection
page (nx, bazel, turborepo, others) showing `mergify ci git-refs` +
`jq` + `mergify ci scopes-send --file scopes.json`. Add the same
heading to the 12 JUnit-upload test-framework pages via a new
MergifyCliUploadStep component wrapping `mergify ci junit-process`
with `--test-exit-code` and `set -o pipefail` so the invocation stays
correct even when the test command uses a pipe.

The CLI path works on any CI that can run a shell — GitHub Actions
and Buildkite users keep their turnkey wrappers, while Jenkins,
CircleCI, and others now have a first-class path without needing a
dedicated action or plugin.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>