### PR TITLE
ci(mergify): make sure automated update go in right queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -82,6 +82,9 @@ queue_rules:
 
   - name: default
     <<: *DefaultQueueOptions
+    queue_conditions:
+      - author != mergify-ci-bot
+      - author != dependabot[bot]
     merge_conditions:
       - schedule=Mon-Fri 09:00-17:30[Europe/Paris]
 
@@ -91,7 +94,7 @@ queue_rules:
     queue_conditions:
       - or:
           - author = mergify-ci-bot
-          - author=dependabot[bot]
+          - author = dependabot[bot]
     batch_size: 10
     batch_max_wait_time: 5min
     commit_message_template:


### PR DESCRIPTION
Right now they match the default queue so they enter it.