### PR TITLE
chore(skills): codify three proofread-style rules

### DIFF
--- a/.claude/skills/proofread-style/SKILL.md
+++ b/.claude/skills/proofread-style/SKILL.md
@@ -58,6 +58,63 @@ lines.
 10. **No "nobody" dramatic openers.** "Nobody tells
     you this" feels fake.
 
+11. **No throat-clearing intros.** The first sentence
+    of a page, section, or callout must state what
+    the reader will learn or do. Narrative framing
+    delays the payoff.
+    - Why: Readers scan. A setup paragraph before the
+      actual topic wastes the most valuable line on
+      the page.
+
+    - Flag: Openers like "As your codebase grows...",
+      "In modern software development...",
+      "When teams scale...", "In today's...",
+      historical or contextual framing before the
+      topic, or any opening sentence that doesn't
+      say what the page is about.
+
+    - Prefer: One scannable sentence stating the
+      concrete topic. "This page explains how to
+      configure priority rules." or just dive into
+      the mechanics.
+
+12. **Assume the audience knows CI, Git, and PRs.**
+    Mergify docs are read by staff engineers. Do not
+    re-explain fundamentals.
+    - Why: Defining what a pull request, CI pipeline,
+      merge conflict, or monorepo is wastes the
+      reader's time and reads as patronizing.
+
+    - Flag: Paragraphs that define PRs, CI, testing,
+      merge conflicts, monorepos, branches, reviews,
+      or other baseline concepts; sentences that
+      start with "A pull request is..." or "CI
+      stands for..." in the middle of a feature
+      page.
+
+    - Prefer: Skip the background. If context is
+      genuinely required, link to a prerequisite
+      page or glossary entry instead of restating
+      it inline.
+
+13. **One example per concept.** Do not stack minor
+    variations of the same example.
+    - Why: Three YAML snippets that differ only in
+      label name or threshold value add scroll, not
+      information. Staff engineers generalize from
+      one example.
+
+    - Flag: Sequential code blocks or config
+      snippets showing the same pattern with
+      trivial differences (different values,
+      different names, different counts); an
+      "other examples" section that repeats the
+      same structure.
+
+    - Prefer: Pick the most representative example.
+      For edge cases, link to a reference page or
+      a "variations" section at the bottom.
+
 ### Banned Words and Phrases
 
 Replace with plain alternatives.

--- a/src/content/docs/configuration/conditions.mdx
+++ b/src/content/docs/configuration/conditions.mdx
@@ -8,112 +8,63 @@ import { Image } from "astro:assets"
 import configEditorScreenshot from "../../images/configuration/config-editor.png"
 import checkSummaryScreenshot from "../../images/configuration/check-summary.png"
 
-Conditions are an essential component of Mergify rules, as they define the
-criteria that must be met for a rule to be applied. By utilizing conditions,
-you can create highly customizable and flexible rules tailored to your specific
-workflow requirements. Conditions enable you to target pull requests based on
-various factors such as their status, properties, labels, and associated
-statuses or checks.
-
-In this guide, we will explore the structure, syntax, and usage of conditions
-in Mergify rules. You will learn how to craft effective conditions that help
-you automate and streamline your pull request management process.
+A condition is a boolean expression evaluated against a pull request's attributes to determine whether a rule applies.
 
 ## Structure of a Condition
 
-A condition in Mergify rules is composed of three key components: attributes,
-operators, and values, along with optional modifiers. These components work
-together to define the criteria that must be met for the condition to be
-considered true.
-
-The grammar for a condition is as follows:
+The grammar for a condition is:
 
 `[ "-" ] [ "#" ] <attribute> [ <operator> <value> ]`
 
 ### Modifiers
 
-- The optional minus (`-`) operator at the beginning of the condition negates
-  the result of the condition, acting as a "not" operator.
-
-- The optional hash (`#`) operator is used to evaluate the length of a list
-  when the attribute is a list.
+- The optional minus (`-`) prefix negates the condition ("not").
+- The optional hash (`#`) prefix evaluates the length of a list attribute.
 
 ### Attributes
 
-Attributes represent the properties or characteristics of a pull request that
-you want to evaluate in your condition. These can include elements such as the
-number of approvals, the presence of specific labels, or the status of CI
-checks.
+Attributes represent properties of a pull request: number of approvals, labels,
+status of CI checks, and so on.
 
 ### Operators
 
-Operators are used to compare the attribute to a specified value. Mergify
-supports various comparison operators (e.g., `=`, `!=`, `<`, `>`).
-
 When the attribute is a list, comparison operators behave as if "any" is used on
-the list, meaning the condition will return true if any element of the list
-matches the given operator and value.
+the list: the condition is true if any element matches.
 
-For example:
 ```yaml
-# This is true as long as of the item in `check-success` has the name `test`.
+# True if any check named `test` succeeds.
 - check-success = test
-# This is true if one of the modified files starts with foo/
+# True if any modified file starts with foo/
 - files ~= ^foo/
 ```
 
 ### Values
 
-Values are the reference points used to evaluate the attribute. They can be
-strings, numbers, or Booleans, depending on the attribute being evaluated.
+Values can be strings, numbers, or Booleans, depending on the attribute.
 
-For example, consider the following condition:
+For example:
 
 `#approved-reviews-by >= 2`
 
-In this condition:
+- Attribute: `approved-reviews-by` (list of approved reviewers).
+- Operator: `>=`.
+- Value: `2`.
+- The `#` prefix evaluates the length of the list.
 
-- The attribute is `approved-reviews-by`, which represents the list of approved
-  reviewers for a pull request.
-
-- The operator is `>=`, which means "greater than or equal to."
-
-- The value is `2`, which indicates the minimum number of approved reviews
-  required for the condition to be true.
-
-- The hash (`#`) operator is used to evaluate the length of the list of
-  approved reviewers.
-
-Understanding the structure of a condition is crucial for creating effective
-Mergify rules that cater to your specific needs and requirements.
-
-When an attribute is a Boolean, it can only be used on its own or negated using
-the `-` operator:
+Boolean attributes are used on their own or negated with `-`:
 
 ```yaml
-# This is true if the PR is merged
+# True if the PR is merged
 - merged
-# This true if the PR is opened
+# True if the PR is open
 - -closed
 ```
 
 ## Attributes List
 
-Attributes are properties of pull requests or events used to filter and evaluate
-the conditions within rules. They can be used to create more specific and
-targeted rules for your repository.
-
 <PullRequestAttributesTable />
 
 ## Operators List
-
-Operators allow you to compare attributes with specified values in order to
-determine if a condition is true or false. Mergify supports several types of
-operators that cater to different types of comparisons. Familiarizing yourself
-with these operators is essential for crafting effective conditions in your
-Mergify rules.
-
-Here is a list of the available operators:
 
 <table>
   <thead>
@@ -227,203 +178,84 @@ Here is a list of the available operators:
   </tbody>
 </table>
 
-For example, let's consider a condition that requires a pull request to have
-a specific label:
-
-`label = bugfix`
-
-In this condition:
-
-- The attribute is `label`, which represents the labels associated with a pull
-    request.
-
-- The operator is `=`, which means "equal to."
-
-- The value is `bugfix`, which is the label we want the pull request to have.
-
 ### Operators on Lists
 
-Some [attributes](#attributes) have a type of `list`. Most
-[operators](#operators) are able to match value against lists: they will
-iterate over all the values of the list and return true if **any** of the value
-matches.
+Most [operators](#operators-list) iterate over list attributes and return true
+if **any** value matches.
 
-For example, the `label` attribute is a list of string containing the names
-of the label attached to a pull request. With a pull request whose labels are
-`(bug, work-in-progress)`, then:
+For a pull request with labels `(bug, work-in-progress)`:
 
-- `label = work-in-progress` is **true** because there is a label named
-  `work-in-progress`.
-
-- `label = enhancement` is **false** because there is no label named
-  `enhancement`.
-
-- `label != work-in-progress` is **false** because there is a label named
-  `work-in-progress`.
-
-- `label ~= ^work` is **true** because there is a label matching the regular
-  expression `^work`.
-
-- `-label ~= ^work` is **false** because there is a label matching the regular
-   expression `^work` but the condition is reversed with the `-` prefix.
-
-The same applies for the `files` attribute — which contains the list of
-modified files:
-
-- `files = README` is **true** if the file `README` is modified in the pull
-  request.
-
-- `files != README` is **true** if the file `README` is not modified in the pull
-  request.
-
-- `files ~= ^src/` is **true** if any files in the `src` directory is modified in
-  the pull request.
-
-- `-files ~= ^src/` is **true** if none of the files that are modified are in the
-  `src` directory.
-
-- `files ~= ^(README.md|CONTRIBUTING.md)$` is **true** if the file `README.md`
-  **or** `CONTRIBUTING.md` is modified in the pull requests.
+- `label = work-in-progress` is **true**.
+- `label = enhancement` is **false**.
+- `label != work-in-progress` is **false**.
+- `label ~= ^work` is **true**.
+- `-label ~= ^work` is **false** (negated with `-`).
 
 ### Examples with Operators
 
-#### Apply the rule only to pull requests with a specific milestone
-
-In this example, we use the `=` operator to match a specific milestone for the
-pull request:
-
 ```yaml
-- name: Rule for milestone "v1.0"
-  conditions:
-    - milestone = v1.0
-  actions:
-    # Your actions here
-```
+# Match a specific milestone
+- milestone = v1.0
 
-{/* lint ignore */}
+# Fewer than 50 files changed
+- "#files <= 50"
 
-#### Apply the rule only when the number of changes is less than or equal to a certain threshold
-
-In this example, we use the `<= operator` to check if the number of files
-modified in the pull request is less than or equal to 50:
-
-```yaml
-- name: Rule for small changes
-  conditions:
-    - "#files <= 50"
-  actions:
-    # Your actions here
-```
-{/* lint ignore */}
-
-#### Apply the rule only when the pull request is labeled with at least one of the specified labels
-
-In this example, we use the `!=` operator to check if the pull request does not
-have the specified labels:
-
-```yaml
-- name: Rule when not a bug
-  conditions:
-    - label != bug
-  actions:
-    # Your actions here
+# Label is not "bug"
+- label != bug
 ```
 
 ## Combining Conditions Using Logical Operators
 
-Mergify allows you to combine multiple conditions using logical operators,
-making it possible to create more intricate rules that cater to your specific
-workflow requirements. You can use the `and` and `or` logical operators to join
-conditions together.
+Combine conditions with `and`, `or`, and `not`.
 
 ### The `and` Operator
 
-The `and` operator is used to join conditions such that all conditions must be
-true for the overall condition to be true. In Mergify rules, the `and` operator
-is represented by placing conditions on separate lines within the same rule.
-
-Alternatively, you can use the `and` keyword to explicitly group conditions
-together.
-
-Example:
+Conditions on separate lines within the same rule are implicitly joined by
+`and`. The `and` keyword can also be used explicitly to group conditions.
 
 ```yaml
-pull_request_rules:
-  - name: Merge when all conditions are met
-    conditions:
-      - and:
-        - "#approved-reviews-by >= 2"
-        - "check-success = test job"
-    actions:
-      merge:
-        method: merge
+name: Require reviews and CI
+if:
+  - base = main
+success_conditions:
+  - and:
+    - "#approved-reviews-by >= 2"
+    - "check-success = test job"
 ```
-
-In this example, the pull request will only be merged if it has at least 2
-approved reviews and the `test job` check passes.
 
 ### The `or` Operator
 
-The `or` operator is used to join conditions such that if any one of the
-conditions is true, the overall condition is considered true. In Mergify rules,
-the `or` operator is represented by using the `or` keyword and specifying
-conditions as a list.
-
-Example:
-
 ```yaml
-pull_request_rules:
-  - name: Merge when either condition is met
-    conditions:
-      - or:
-        - "#approved-reviews-by >= 2"
-        - "check-success = test job"
-    actions:
-      merge:
-        method: merge
+name: Require reviews or passing CI
+if:
+  - base = main
+success_conditions:
+  - or:
+    - "#approved-reviews-by >= 2"
+    - "check-success = test job"
 ```
-
-In this example, the pull request will be merged if it has at least 2 approved
-reviews or if the `test job` check passes.
-
-Combining conditions using logical operators can help you create more
-sophisticated rules tailored to your repository's workflow and requirements.
 
 ### The `not` Operator
 
-The `not` operator is used to negate a block of conditions such that if a
-condition is true, it becomes false. In Mergify rules, the `not` operator is
-represented by using the `not` keyword and specifying the underlying condition
-block with `or` or `and`.
-
-Example
+`not` negates a block of conditions, typically wrapping an `and` or `or`.
 
 ```yaml
-pull_request_rules:
-  - name: Merge when both condition are not met
-    conditions:
-      - not:
-          and:
-            - "#approved-reviews-by >= 2"
-            - "check-success = test job"
-    actions:
-      merge:
-        method: merge
+name: Block merges missing requirements
+if:
+  - base = main
+success_conditions:
+  - not:
+      and:
+        - "#approved-reviews-by >= 2"
+        - "check-success = test job"
 ```
 
 ## Testing and Debugging Conditions
 
-When crafting conditions for your Mergify rules, it's essential to test and
-debug them to ensure they are working as intended. This section will guide you
-through the process of testing and debugging conditions in your Mergify
-configuration.
-
 ### Use the Mergify Configuration Editor
 
-The Mergify configuration editor is a useful tool to help you test your
-conditions and rules on existing pull requests without actually triggering the
-actions defined in your rules. To access the configuration editor, follow these
-steps:
+The configuration editor evaluates your conditions against existing pull
+requests without triggering actions.
 
 1. Navigate to your [Mergify dashboard](https://dashboard.mergify.com).
 2. Select the repository you want to test.
@@ -431,23 +263,15 @@ steps:
 
 <Image src={configEditorScreenshot} alt="Mergify Configuration Editor" />
 
-In the configuration editor, you can enter your conditions and see how they
-would be evaluated on your pull requests. You can also test your entire Mergify
-configuration by copying and pasting it into the configuration editor.
-
 ### Analyze the Mergify Checks
 
-Once you have created and committed your Mergify configuration file, Mergify
-will evaluate the conditions in your rules for each pull request. To debug your
-conditions and understand why a rule may not be working as expected, you can
-analyze the Mergify Checks on a pull request:
+Once your configuration is committed, Mergify evaluates conditions for each
+pull request. To inspect the evaluation:
 
 1. Navigate to the "Checks" tab of the pull request.
 2. Look for the "Mergify" check in the list of checks.
 3. Click on "Summary" to view the detailed Mergify report.
 
-In the Mergify report, you can see which rules were evaluated and whether the
-conditions were met or not. This can help you identify any issues in your
-conditions and make adjustments as necessary.
+The report shows which rules were evaluated and whether each condition was met.
 
 <Image src={checkSummaryScreenshot} alt="Mergify Check Summary" />

--- a/src/content/docs/merge-queue/performance.mdx
+++ b/src/content/docs/merge-queue/performance.mdx
@@ -5,14 +5,7 @@ description: Optimizing your merge queue for maximum efficiency.
 
 import MergeQueueCalculator from "../../../components/MergeQueueCalculator/MergeQueueCalculator"
 
-As development teams scale and the volume of pull requests grows, achieving an
-optimal balance between merge speed, reliability, and resource usage becomes a
-paramount concern. Performance bottlenecks in the merge process can
-significantly hamper a team's productivity. Leveraging the capabilities of
-Mergify's merge queue configurations can help alleviate these challenges. This
-guide dives deep into how you can tune your merge queue to strike the right
-balance, ensuring a fast, cost-efficient, and reliable merging process tailored
-to your team's needs.
+Tune parallel checks, batch size, and CI scope to balance throughput, reliability, and CI cost.
 
 :::tip
   Scaling to 20+ PRs per day? The [Merge Queue Academy's high-velocity teams
@@ -22,221 +15,70 @@ to your team's needs.
 
 ### The Trade-offs: Reliability, Cost, and Velocity (RCV Theorem)
 
-Before making any decision in configuring your merge queue, you need to
-understand the trade-off that needs to be done. In the world of merging, three
-critical properties influence the effectiveness of a merge queue:
+A merge queue can only optimize two of three properties at a time: reliability
+(merges don't break main), cost (CI jobs executed), and velocity (throughput
+and latency). We call this the **RCV theorem**, analogous to the
+[CAP theorem](https://en.wikipedia.org/wiki/CAP_theorem) for data stores.
 
-1. **Reliability:** Ensure merges are accurate and won't cause issues.
-2. **Cost:** The number of CI jobs executed.
-3. **Velocity:** Throughput and latency of your merges.
+The three viable combinations:
 
-Similar to the [CAP theorem](https://en.wikipedia.org/wiki/CAP_theorem) for
-data stores, you can only optimize two of these properties simultaneously. This
-is what we term the **RCV theorem**.
+- **Reliability + Velocity**: enable **[parallel speculative
+  checks](/merge-queue/parallel-checks)** to test predicted merge states
+  concurrently. Wasted CI runs occur when a PR ahead in the queue fails.
 
-```neato aria-label="Venn diagram showing the Reliability, Cost, Velocity trade-offs" role="img" style="max-width: 520px; margin: 2rem auto; display: block;"
-graph RCV {
-   graph [bgcolor="transparent", margin=0, overlap=true];
-   node [shape=circle, style="filled,setlinewidth(2)", fontname="Helvetica", fontsize=16, width=2.5, height=2.5, penwidth=2, fixedsize=true, pin=true];
+- **Reliability + Cost**: validate pull requests sequentially. No wasted CI,
+  but throughput is capped at one PR per CI run.
 
-   Reliability [label="Reliability", color="#2563eb", fillcolor="#2563eb33", pos="0,0!", tooltip="Maximize test confidence"];
-   Velocity [label="Velocity", color="#16a34a", fillcolor="#16a34a33", pos="2.2,0!", tooltip="Ship pull requests fast"];
-   Cost [label="Cost", color="#ea580c", fillcolor="#ea580c33", pos="1.1,1.95!", tooltip="Keep CI usage low"];
-}
-```
+- **Velocity + Cost**: use [batch mode](/merge-queue/batches) to test groups
+  of PRs as a single unit. Fewer CI runs, but hidden failures inside a passing
+  batch can land on main.
 
-<div
-   role="note"
-   aria-label="RCV legend"
-   style={{
-      display: 'flex',
-      flexWrap: 'wrap',
-      gap: '0.5rem',
-      justifyContent: 'center',
-      margin: '1rem auto 0.5rem',
-      fontSize: '0.9rem',
-   }}
->
-   <span
-      style={{
-         display: 'inline-flex',
-         alignItems: 'center',
-         gap: '0.35rem',
-         padding: '0.35rem 0.75rem',
-         borderRadius: '999px',
-         border: '1px solid #93c5fd',
-      }}
-   >
-      <span
-         style={{
-            width: '0.65rem',
-            height: '0.65rem',
-            borderRadius: '50%',
-            background: 'linear-gradient(135deg,#2563eb,#16a34a)',
-         }}
-      ></span>
-      Reliability + Velocity → Parallel Checks
-   </span>
-   <span
-      style={{
-         display: 'inline-flex',
-         alignItems: 'center',
-         gap: '0.35rem',
-         padding: '0.35rem 0.75rem',
-         borderRadius: '999px',
-         border: '1px solid #fca5a5',
-      }}
-   >
-      <span
-         style={{
-            width: '0.65rem',
-            height: '0.65rem',
-            borderRadius: '50%',
-            background: 'linear-gradient(135deg,#2563eb,#ea580c)',
-         }}
-      ></span>
-      Reliability + Cost → Sequential Validation
-   </span>
-   <span
-      style={{
-         display: 'inline-flex',
-         alignItems: 'center',
-         gap: '0.35rem',
-         padding: '0.35rem 0.75rem',
-         borderRadius: '999px',
-         border: '1px solid #86efac',
-      }}
-   >
-      <span
-         style={{
-            width: '0.65rem',
-            height: '0.65rem',
-            borderRadius: '50%',
-            background: 'linear-gradient(135deg,#16a34a,#ea580c)',
-         }}
-      ></span>
-      Velocity + Cost → Batch Mode
-   </span>
-</div>
-
-<em>Pick any two—every setup sacrifices one dimension.</em>
-
-Based on this trade-off, there are 3 scenarios that you can optimize for:
-
-- **Reliability and Velocity:** This is the standard behavior.
-  This aims to reduce latency and maximize throughput without considering CI
-  costs by enabling **[parallel speculative
-  checks](/merge-queue/parallel-checks)**. This feature lets Mergify test pull
-  requests in parallel, predicting potential merges and executing CI runs
-  simultaneously. Parallel checks can slightly increase CI cost: there might be
-  certain scenarios that are tested and whose results won't be used if a pull
-  request ahead in the queue fails.
-
-- **Reliability and Cost:** In that case, each pull request is validated
-  sequentially, ensuring reliability at a minimal CI cost. As every pull
-  request is tested one after the other, there is no room for wasted CI time.
-  However, this scenario is slow as only one PR is tested at a time.
-
-- **Velocity and Cost:** By using [batch mode](/merge-queue/batches), you can
-  merge groups of pull requests simultaneously. This reduces CI runs but merges
-  pull request that are not tested individually. There is therefore a
-  theoretical risk that a hidden failure is merged, while the whole batch
-  passes the CI.
-
-You can also combine parallel speculative checks and batching to achieve a
-balanced approach between reliability, cheapness, and velocity. This
-configuration offers a mix of both strategies, allowing you to test multiple
-batches of requests concurrently.
+Parallel checks and batching can be combined for a middle ground across all
+three dimensions.
 
 ### Determining the Right Configuration for Parallel Checks and Batching
 
-Optimizing the performance of your merge queue involves fine-tuning the number
-of parallel checks and the size of batches. The right configuration balances
-throughput, latency, and CI resource consumption. Here's a guide to help you
-determine the optimal settings:
+Weigh these factors when picking `batch_size` and `max_parallel_checks`:
 
-1. **Expected Merge Throughput**: Analyze your historical data to gauge the
-   average number of merges per hour or per day. This will help set a benchmark
-   for parallel checks and batch size, ensuring that pull requests are
-   processed at the desired rate.
+1. **Merge throughput and queue latency**: target settings that match your
+   historical merges-per-hour and keep PR wait time acceptable.
 
-2. **Queue Latency**: Consider the typical wait time in the queue for a PR. Aim
-   for settings that reduce this latency, but be mindful of the trade-offs.
-   Reducing latency might lead to increased CI consumption or decreased
-   reliability.
+2. **Peak load**: size for peak developer hours, not averages, so the queue
+   doesn't back up during busy windows.
 
-3. **Peak Load Periods**: Observe patterns to identify times when there's a
-   surge in PR merges, such as during active developer hours. Adjust your
-   settings to handle these peak periods efficiently, ensuring that the merge
-   queue remains effective during high activity periods.
+3. **CI capacity and job duration**: fast CI and abundant runners tolerate
+   higher parallelism; slow CI or constrained runners need a conservative
+   setting, since reruns on failure are expensive.
 
-4. **CI Resource Availability**: Evaluate the resources allocated to your CI
-   environment. If resources are abundant, you can lean towards higher parallel
-   checks. Conversely, if resources are limited, consider a conservative
-   approach to ensure that CI doesn't become a bottleneck.
+4. **Change stability**: repositories with frequent flaky or failing PRs
+   should lower batch size and parallelism to limit wasted work.
 
-5. **CI Job Duration**: The execution time of CI jobs can significantly
-   influence your choice. Faster CI jobs might permit a higher number of
-   parallel checks, as potential reruns won't lead to major delays. On the
-   other hand, longer CI jobs necessitate a more conservative setting.
-
-6. **Stability of Changes**: Reflect on the typical quality of pull requests in
-   your repository. For repositories with a high rate of stable PRs, you might
-   increase parallel checks or batch sizes. However, for those with frequent
-   unstable PRs, a conservative approach might be more suitable.
-
-7. **Team Size & Activity Patterns**: The size of your team and their activity
-   patterns can also dictate your settings. Larger or globally distributed
-   teams might have pull requests coming in throughout the day. Understanding
-   these patterns can help in configuring the merge queue for optimal
-   performance.
-
-8. **Feedback Loop for Developers**: Ensure that the chosen configuration
-   promotes a quick feedback loop. While parallel checks and batching can
-   enhance queue performance, they shouldn't delay critical feedback to
-   developers about the state of their PR.
-
-By carefully considering and balancing these factors, you can configure your
-merge queue to be both efficient and reliable. Remember, the right balance may
-vary over time as your team grows and your development processes evolve.
-Periodic reviews and adjustments can help maintain an optimal merge queue
-performance.
+5. **Team distribution**: globally distributed teams produce a steady PR flow;
+   concentrated teams spike and need headroom for bursts.
 
 ### Performance Configuration Calculator
 
-Optimizing your merge queue is a balancing act between throughput and CI
-resource allocation. Our calculator is here to guide you in configuring the
-optimal settings tailored to your team's workflow. Here's how to use it:
+Provide the inputs below and the calculator will suggest a configuration:
 
-1. **CI time in minutes**: Input the average time it takes for your Continuous
-   Integration to validate a change.
+1. **CI time in minutes**: average duration of a CI run.
 
-2. **Estimated CI success ratio in %**: Provide an estimate of how often your
-   CI process returns a successful result. For instance, if your CI passes 95
-   out of 100 times on average, you'd input 95%.
+2. **Estimated CI success ratio in %**: how often CI passes (e.g. 95 if 95
+   out of 100 runs succeed).
 
-3. **Desired PRs to merge per hour**: Set your target for how many pull
-   requests you'd like to merge within an hour at minimum.
+3. **Desired PRs to merge per hour**: target throughput.
 
-4. **Desired CI usage in %**: Define how intensively you'd like to utilize your
-   CI resources. A setting of 100% indicates a standard usage, matching a
-   regular merge queue. Values below 100% will aim to conserve CI resources by
-   leveraging batching, while values above 100% will prioritize higher
-   throughput and reduced latency, even if it means using more CI time than
-   usual.
-
-Once you've input your parameters, the calculator will suggest the optimal
-configuration for your merge queue, ensuring an efficient and seamless merging
-process.
+4. **Desired CI usage in %**: 100% matches a standard queue. Below 100%
+   favors batching to conserve CI; above 100% favors parallel checks for
+   lower latency at higher CI cost.
 
 <MergeQueueCalculator client:only="react"/>
 
 :::note
-  - This calculator optimizes CI usage and throughput but not latency. 
-    If you want to further optimize latency, you need to increase 
+  - This calculator optimizes CI usage and throughput but not latency.
+    If you want to further optimize latency, you need to increase
     the number of parallel checks.
 
-  - The average latency computing assumes that the number of PR merged per hour 
+  - The average latency computing assumes that the number of PR merged per hour
     enters the queue at the beginning of the hour.
 
   - CI time is an important factor in those computing. If you want to optimize
@@ -246,49 +88,29 @@ process.
 
 ## Optimizing Merge Queue Time with Efficient CI Runs
 
-To ensure your merge queue processes efficiently, it's essential that your
-Continuous Integration (CI) system runs as quickly as possible. One way to
-achieve this is by meticulously selecting the tests you run, ensuring that only
-necessary tests are executed. Remember, every minute saved in CI time can have
-a cascading positive effect on your overall merge efficiency.
+Every minute shaved off CI compounds across every queued PR. Run only the
+tests required for the change under test.
 
-A strategic approach to further optimize CI runtime is the [**Two-Step
-CI**](/merge-queue/two-step) method. This approach differentiates between:
+The [**Two-step CI**](/merge-queue/two-step) method splits validation into:
 
-1. **Preliminary Tests**: These are the tests run immediately when a PR is
-created or updated. They're designed to be quick yet effective, ensuring only
-quality PRs enter the merge queue.
+1. **Preliminary tests**: fast checks run when a PR is created or updated,
+   gating entry into the queue.
 
-2. **Comprehensive Tests**: These tests are more exhaustive and are run just
-before merging, ensuring the final quality of the code.
+2. **Pre-merge tests**: exhaustive checks run just before merge.
 
-By splitting your tests in this manner, you ensure that the merge queue is not
-held up by lengthy CI processes for every minor PR update. Instead, the more
-extensive tests are reserved for when PRs are about to be merged, providing a
-balance between speed and code quality.
+This keeps queue-time CI short without sacrificing final-merge confidence.
 
 ## Combining Batch Merging and Parallel Checks
 
-[Batch merging](/merge-queue/batches) and [parallel
-checks](/merge-queue/parallel-checks) are two powerful features that work in
-synergy to improve the efficiency of your merge queue.
-
-Batch merging allows Mergify to test multiple pull requests together as a
-single unit, reducing the amount of time waiting for individual pull request
-tests to complete. On the other hand, [parallel
-checks](/merge-queue/parallel-checks) allow for multiple batches to be tested
-in parallel, further speeding up the merge process.
-
-When both these features are enabled, Mergify creates multiple batches of pull
-requests (according to the `batch_size` option) and then runs tests on several
-of these batches at the same time (as defined by the `parallel_checks`
-option). If any pull request within a batch fails, [Mergify identifies the
-culprit through a binary search, removes it from the queue, and continues
-processing the rest of the queue](#handling-batch-failure).
+[Batch merging](/merge-queue/batches) tests multiple PRs as a single unit.
+[Parallel checks](/merge-queue/parallel-checks) run several batches
+concurrently. Together, they maximize CI utilization: if any PR in a batch
+fails, [Mergify binary-searches for the culprit, removes it, and continues
+processing](/merge-queue/batches#handling-batch-failure-or-timeout).
 
 ```yaml
 merge_queue:
-  max_parallel_check: 2
+  max_parallel_checks: 2
 
 queue_rules:
   - name: default
@@ -296,19 +118,10 @@ queue_rules:
     ...
 ```
 
-In the above example, Mergify will create up to 2 batches, each containing up
-to 3 pull requests, and test them in parallel.
-
-Combining these two features allows you to optimize the throughput of your
-merge queue. You can increase the batch size to merge more pull requests
-concurrently, while also increasing the number of parallel checks to test
-more batches in parallel. This minimizes idle time and makes full use of your
-CI resources.
-
-Suppose your queue has 7 pull requests waiting, and your CI pipeline takes
-about 10 minutes to complete. If you set `batch_size` to 3 and
-`max_parallel_checks` to 2, Mergify would create 2 batches, each containing 3
-pull requests. These batches are then tested in parallel.
+With `batch_size: 3` and `max_parallel_checks: 2`, Mergify runs up to 2
+batches of up to 3 PRs each in parallel. Given 7 queued PRs and a 10-minute
+CI pipeline, the first 6 merge in 10 minutes instead of the hour required for
+sequential validation.
 
 ```dot class="graph"
 strict digraph {
@@ -352,15 +165,3 @@ strict digraph {
     PR6 -> CI;
 }
 ```
-
-With this configuration, even if your CI time is 10 minutes, you can merge the
-first 6 pull requests in only 10 minutes, as opposed to the 1 hour it would
-typically take to test each pull request individually.
-
-### Concluding Thoughts
-
-Mergify provides a range of configurations to tailor your CI budget and merge
-queue strategy. Whether you're aiming for speed, cost-efficiency, or
-reliability, our platform caters to diverse requirements. With Mergify, the
-merging process becomes easier, faster, and safer, boosting your team's
-performance.

--- a/src/content/docs/merge-queue/two-step.mdx
+++ b/src/content/docs/merge-queue/two-step.mdx
@@ -4,15 +4,7 @@ description: Run essential tests on every PR and comprehensive tests before merg
 ---
 import Youtube from '../../../components/Youtube.astro'
 
-As your codebase grows, so does your test suite. What once took minutes can
-balloon into hour-long CI runs that slow down development and drain resources.
-But here's the insight: not all tests need to run at every stage of the PR
-lifecycle.
-
-Two-step CI is a strategy that separates your test suite into two phases—fast
-preliminary checks that run on every commit, and comprehensive validation that
-runs only before merging. Combined with Mergify's merge queue, this approach
-can dramatically reduce CI time and costs while maintaining code quality.
+Split your CI into fast preliminary checks on every PR and full tests that run only before merging.
 
 :::tip
   Understand the concepts behind two-step CI at the
@@ -21,31 +13,14 @@ can dramatically reduce CI time and costs while maintaining code quality.
 
 <Youtube video="2mVymDFMaMk" title="Using two-step CI"/>
 
-## Implementing Two-Step CI
+## The Two Phases
 
-A two-step CI approach separates tests into two phases based on when they need
-to run and what they validate:
+**Step 1: Preliminary tests** run on every PR push: linters, formatters,
+unit tests, basic compile checks. Fast feedback, cheap to run.
 
-### Step 1: Preliminary Tests (Fast Feedback)
-Run immediately when a PR is opened or updated. These are:
-- **Fast**: Complete in minutes, not hours
-- **Essential**: Code quality checks that catch obvious issues
-
-Examples: Linters, formatters, unit tests, basic compile checks
-
-These give developers rapid feedback and prevent broken code from entering the
-merge queue.
-
-### Step 2: Pre-Merge Tests (Comprehensive Validation)
-
-Run only when a PR enters the merge queue, just before merging. These are:
-
-- **Thorough**: Full test coverage including edge cases
-- **Expensive**: Integration tests, end-to-end tests, performance benchmarks
-- **Slower**: May take 30+ minutes to complete
-
-These jobs ensure code quality before merging to your main branch, without
-slowing down every PR update.
+**Step 2: Pre-merge tests** run only when a PR enters the merge queue:
+integration tests, end-to-end tests, performance benchmarks. Thorough but
+expensive.
 
 ## How It Works
 
@@ -180,246 +155,21 @@ strict digraph {
 }
 ```
 
-## Batch Processing: Even More Efficient
+## Batch Processing
 
-When you enable [batching](/merge-queue/batches) in Mergify's merge queue, you
-can achieve even greater efficiency. Instead of running pre-merge tests
-separately for each PR, Mergify:
+Enable [batching](/merge-queue/batches) to run pre-merge tests **once** for a
+group of PRs instead of per PR. For 5 PRs with a 30-minute pre-merge suite,
+that's 30 minutes instead of 2.5 hours.
 
-1. Groups multiple PRs together in a batch
-2. Runs the expensive pre-merge tests **once** for the entire batch
-3. Merges all PRs if the batch passes
+## Configuration
 
-**Example**: If you have 5 PRs ready to merge and your pre-merge tests take 30
-minutes:
-- **Without batching**: 5 × 30 minutes = 2.5 hours of CI time
-- **With batching**: 1 × 30 minutes = 30 minutes of CI time
+### CI System
 
-That's **80% reduction** in CI resource usage!
+Run pre-merge tests only on merge queue branches. Mergify creates branches
+prefixed with `mergify/merge-queue/` (customizable via `queue_branch_prefix`
+in [`queue_rules`](/configuration/file-format/#queue-rules)).
 
-```dot class="graph"
-strict digraph {
-    fontname="Inter, system-ui, sans-serif";
-    rankdir="TB";
-    bgcolor="#FAFBFC";
-
-    // Global styling
-    node [
-        style="filled,rounded",
-        shape=rect,
-        fontcolor="black",
-        fontname="Inter, system-ui, sans-serif",
-        fontsize=10,
-        margin=0.12,
-        penwidth=2,
-        width=1.8,
-        height=0.6
-    ];
-
-    edge [
-        color="#7C3AED",
-        arrowhead=normal,
-        fontname="Inter, system-ui, sans-serif",
-        fontsize=9,
-        penwidth=2
-    ];
-
-    // Subgraph for PR #1 flow
-    subgraph cluster_pr1 {
-        style="rounded,filled";
-        fillcolor="#FAF5FF";
-        color="#A855F7";
-        penwidth=1;
-        label="PR #1 Workflow";
-        fontname="Inter, system-ui, sans-serif";
-        fontsize=10;
-        fontcolor="#7C3AED";
-
-        open1 [
-            label="🔄 PR #1 opened",
-            fillcolor="#EDE9FE",
-            color="#8B5CF6",
-            fontcolor="#5B21B6"
-        ];
-
-        preliminary1 [
-            label="🧪 Tests",
-            fillcolor="#FFF4ED",
-            color="#FF8A3D",
-            fontcolor="#C2410C"
-        ];
-
-        preliminary_ok1 [
-            label="✅ Passed",
-            fillcolor="#D1FAE5",
-            color="#10B981",
-            fontcolor="#065F46"
-        ];
-
-        queue_req1 [
-            label="📝 Queue",
-            fillcolor="#F3E8FF",
-            color="#A855F7",
-            fontcolor="#6B21A8"
-        ];
-    }
-
-    // Subgraph for PR #2 flow
-    subgraph cluster_pr2 {
-        style="rounded,filled";
-        fillcolor="#FAF5FF";
-        color="#A855F7";
-        penwidth=1;
-        label="PR #2 Workflow";
-        fontname="Inter, system-ui, sans-serif";
-        fontsize=10;
-        fontcolor="#7C3AED";
-
-        open2 [
-            label="🔄 PR #2 opened",
-            fillcolor="#EDE9FE",
-            color="#8B5CF6",
-            fontcolor="#5B21B6"
-        ];
-
-        preliminary2 [
-            label="🧪 Tests",
-            fillcolor="#FFF4ED",
-            color="#FF8A3D",
-            fontcolor="#C2410C"
-        ];
-
-        preliminary_ok2 [
-            label="✅ Passed",
-            fillcolor="#D1FAE5",
-            color="#10B981",
-            fontcolor="#065F46"
-        ];
-
-        queue_req2 [
-            label="📝 Queue",
-            fillcolor="#F3E8FF",
-            color="#A855F7",
-            fontcolor="#6B21A8"
-        ];
-    }
-
-    // Shared batch processing
-    subgraph cluster_batch {
-        style="rounded,filled";
-        fillcolor="#FFF7ED";
-        color="#FF8A3D";
-        penwidth=2;
-        label="";
-        fontname="Inter, system-ui, sans-serif";
-        fontsize=10;
-        fontcolor="#C2410C";
-
-        batch_title [
-            label="📦 Batch Processing\n(Resource Efficient)",
-            fillcolor="#FFEDD5",
-            color="#FF8A3D",
-            fontcolor="#9A3412",
-            shape=note,
-            width=2.2,
-            height=0.6
-        ];
-
-        queued [
-            label="⏳ Both PRs\nqueued together",
-            shape=ellipse,
-            fillcolor="#FFEDD5",
-            color="#FF8A3D",
-            fontcolor="#9A3412",
-            width=2,
-            height=0.8
-        ];
-
-        premerge [
-            label="🔬 Single test run\n(Both PRs tested)",
-            fillcolor="#FFF4ED",
-            color="#FF8A3D",
-            fontcolor="#C2410C",
-            width=2.2
-        ];
-
-        premerge_ok [
-            label="✅ Batch passed",
-            fillcolor="#D1FAE5",
-            color="#10B981",
-            fontcolor="#065F46"
-        ];
-
-        // Internal layout
-        batch_title -> queued [style=invis];
-    }
-
-    // Final merge results
-    merged1 [
-        label="🎉 PR #1 merged",
-        fillcolor="#DDD6FE",
-        color="#7C3AED",
-        fontcolor="#5B21B6"
-    ];
-
-    merged2 [
-        label="🎉 PR #2 merged",
-        fillcolor="#DDD6FE",
-        color="#7C3AED",
-        fontcolor="#5B21B6"
-    ];
-
-    // PR #1 flow
-    open1 -> preliminary1;
-    preliminary1 -> preliminary_ok1 [color="#10B981", penwidth=3];
-    preliminary_ok1 -> queue_req1;
-    queue_req1 -> queued;
-
-    // PR #2 flow
-    open2 -> preliminary2;
-    preliminary2 -> preliminary_ok2 [color="#10B981", penwidth=3];
-    preliminary_ok2 -> queue_req2;
-    queue_req2 -> queued;
-
-    // Batch processing
-    queued -> premerge;
-    premerge -> premerge_ok [color="#10B981", penwidth=3];
-
-    // Both PRs merge from single test success
-    premerge_ok -> merged1 [color="#7C3AED", penwidth=3];
-    premerge_ok -> merged2 [color="#7C3AED", penwidth=3];
-
-    // Alignment
-    {rank=same; merged1, merged2}
-}
-```
-
-## Implementation Guide
-
-Implementing two-step CI requires coordinating your CI system with Mergify's
-merge queue. Here's how:
-
-### Overview
-
-1. **Configure CI to distinguish test phases**: Set up your CI to run
-   preliminary tests on all branches, but pre-merge tests only on merge queue
-   branches
-
-2. **Configure Mergify conditions**: Define which tests must pass to enter the
-   queue vs. which must pass to merge
-
-### Step 1: Configure Your CI System
-
-The key is to run pre-merge tests **only on merge queue branches**. By default,
-Mergify creates branches prefixed with `mergify/merge-queue/` for queued PRs
-(customizable via `queue_branch_prefix` in
-[`queue_rules`](/configuration/file-format/#queue-rules)).
-
-**Pattern**:
-- ✅ Preliminary tests: Run on **all** branches
-- ✅ Pre-merge tests: Run **only** on branches matching `mergify/merge-queue/*`
-
-#### Example: GitHub Actions
+#### GitHub Actions
 
 ```yaml
 name: CI
@@ -454,26 +204,13 @@ jobs:
       run: make benchmark
 ```
 
-How it works:
+#### Other CI Systems
 
-- `preliminary-tests` runs on **every PR** (fast feedback)
+- **CircleCI**: Branch filter regex `/^mergify\/merge-queue\/.*/`
+- **Jenkins**: Conditional execution on `BRANCH_NAME`
+- **GitLab CI**: `only: /^mergify\/merge-queue\/.*/`
 
-- `pre-merge-tests` runs **only when** the branch name starts with
-  `mergify/merge-queue/` (comprehensive validation before merge)
-
-#### Example: Other CI Systems
-
-The same principle applies to any CI system. Just configure the pre-merge job
-to run only on merge queue branches:
-
-- **CircleCI**: Use branch filters with regex `/^mergify\/merge-queue\/.*/`
-- **Jenkins**: Add conditional execution based on `BRANCH_NAME`
-- **GitLab CI**: Use `only: /^mergify\/merge-queue\/.*/`
-
-### Step 2: Configure Mergify
-
-Set up your `queue_rules` to define when PRs can enter the queue and when they
-can merge:
+### Mergify
 
 ```yaml
 queue_rules:
@@ -487,9 +224,5 @@ queue_rules:
       - check-success=pre-merge-tests
 ```
 
-What this means:
-- `queue_conditions`: Preliminary tests must pass before a PR can enter the
-   merge queue
-
-- `merge_conditions`: Pre-merge tests must pass before the PR actually merges
-  to main
+`queue_conditions` gates entry into the queue; `merge_conditions` gates the
+final merge to main.


### PR DESCRIPTION
Adds three hard rules to the proofread-style skill so future docs work
(and the subagent proofreading pipeline) catches the systemic verbosity
patterns the recent docs audit uncovered:

- No throat-clearing intros. The first sentence must state what the
  reader will learn or do.
- Assume the audience knows CI, Git, and pull requests. Mergify docs
  are read by staff engineers.
- One example per concept. Do not stack minor variations.

Each rule includes a Why, a Flag (pattern to catch), and a Prefer
(recommended alternative).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #11198