### PR TITLE
chore: migrate from deprecated autoqueue to auto_merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,6 @@
 extends: .github
 shared:
   DefaultQueueOptions: &DefaultQueueOptions
-    autoqueue: true
     commit_message_template: |
       {{ title }} (#{{ number }})
 
@@ -125,4 +124,5 @@ merge_queue:
   max_parallel_checks: 5
 
 merge_protections_settings:
+  auto_merge: true
   reporting_method: deployments


### PR DESCRIPTION
Replace the per-queue `autoqueue: true` flag (deprecated, removal
2026-07-16) with the global `auto_merge: true` under
`merge_protections_settings`. All queues previously enabled autoqueue
via the shared YAML anchor, so the global setting preserves behavior.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>