### PR TITLE
docs(ci-insights): Document glob support in mergify ci junit-process

### DIFF
--- a/src/content/docs/ci-insights/setup/jenkins.mdx
+++ b/src/content/docs/ci-insights/setup/jenkins.mdx
@@ -142,7 +142,9 @@ pipeline {
             # npm test -- --reporters=default --reporters=jest-junit --outputFile=test-results-$i.xml
           done
           set -e
-          mergify ci junit-process test-results-*.xml
+          # Quote the glob so Mergify expands it rather than the shell —
+          # recommended when many reports match.
+          mergify ci junit-process 'test-results-*.xml'
         '''
       }
     }


### PR DESCRIPTION
The Jenkins setup example passed `test-results-*.xml` unquoted, so the
inner shell expanded it before mergify saw it — exactly the ARG_MAX
failure mode the new CLI behaviour avoids. Quote the pattern so Mergify
expands it internally.

Also add a changelog entry announcing the supported feature.


References: MRGFY-7036