### PR TITLE
chore(ci): Skip slack.mergify.com in broken-link check

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "biome format --write .",
     "format:check": "biome format src integrations plugins scripts",
     "check": "astro check && eslint . && biome check .",
-    "check:links": "linkinator dist/ --recurse --retry-errors --retry-errors-count 3 --timeout 30000 --concurrency 25 --verbosity error --skip 'github.com/.*/edit/' --skip 'https://docs.mergify.com'"
+    "check:links": "linkinator dist/ --recurse --retry-errors --retry-errors-count 3 --timeout 30000 --concurrency 25 --verbosity error --skip 'github.com/.*/edit/' --skip 'https://docs.mergify.com' --skip 'https://slack.mergify.com'"
   },
   "devDependencies": {
     "@actions/core": "^3.0.1",


### PR DESCRIPTION
Slack's invite host returns 403 to linkinator's requests, flagging the
globally-linked Slack Community URL as broken on every page. The link
is live (301 redirect); skip it like the existing docs.mergify.com
entry.


Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>