### PR TITLE
docs(api): Add CI Insights tag to API Reference

### DIFF
--- a/src/components/ApiReference/openapi.ts
+++ b/src/components/ApiReference/openapi.ts
@@ -167,6 +167,7 @@ export const TAG_LABELS: Record<string, string> = {
   scheduled_freeze: 'Scheduled Freeze',
   merge_queue: 'Merge Queue',
   pull_requests: 'Pull Requests',
+  ci_insights: 'CI Insights',
 };
 
 // Tag descriptions for sub-page intros
@@ -180,6 +181,7 @@ export const TAG_DESCRIPTIONS: Record<string, string> = {
   scheduled_freeze: 'Schedule merge queue freezes for maintenance or release windows.',
   merge_queue: 'Control merge queue state — pause, unpause, and inspect status.',
   pull_requests: 'Push scopes and other per-pull-request data to Mergify.',
+  ci_insights: 'Access data from CI Insights.',
 };
 
 export function humanizeTag(tag: string): string {

--- a/src/content/navItems.tsx
+++ b/src/content/navItems.tsx
@@ -345,6 +345,7 @@ const navItems: NavItem[] = [
           { title: 'Event Logs', path: '/api/eventlogs' },
           { title: 'Badges', path: '/api/badges' },
           { title: 'Scheduled Freeze', path: '/api/scheduled-freeze' },
+          { title: 'CI Insights', path: '/api/ci-insights' },
         ],
       },
     ],


### PR DESCRIPTION
Surface the new ci_insights endpoints (quarantined tests) in the API
Reference sidebar and add matching tag label and description.


Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>