### PR TITLE
docs(stacks): add Graphite comparison to navbar

### DIFF
--- a/src/content/navItems.tsx
+++ b/src/content/navItems.tsx
@@ -239,6 +239,11 @@ const navItems: NavItem[] = [
         children: [
           { title: 'Overview', path: '/stacks/compare', icon: 'fa6-regular:lightbulb' },
           { title: 'vs gh-stack', path: '/stacks/compare/gh-stack', icon: 'simple-icons:github' },
+          {
+            title: 'vs Graphite',
+            path: '/stacks/compare/graphite',
+            icon: 'simple-icons:graphite',
+          },
         ],
       },
     ],


### PR DESCRIPTION
The Graphite comparison page was added but never wired into the
sidebar nav. Add it alongside the gh-stack entry.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>