### PR TITLE
refactor(docs): redesign "On this page" as an inline toolbar button

### DIFF
--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -14,19 +14,6 @@ const suppressTitle = content.suppressTitle;
 ---
 
 <div dir={'ltr'} lang={'en'}>
-	{
-		// For best cross-browser support of sticky or fixed elements, they must not be nested
-		// inside elements that hide any overflow axis. The article hides `overflow-x`,
-		// so we must place fixed UI elements like the mobile TOC here.
-		Astro.slots.has('before-article') && (
-			<>
-				<div class="fixed-mobile-bar" dir={'ltr'}>
-					<slot name="before-article" />
-				</div>
-				<div class="spacer" />
-			</>
-		)
-	}
 	<article id="article" class="content">
 		<section class="main-section">
 			<header>
@@ -45,18 +32,6 @@ const suppressTitle = content.suppressTitle;
 </div>
 
 <style>
-	.fixed-mobile-bar {
-		display: block;
-		position: fixed;
-		inset-inline: 0;
-		top: calc(var(--theme-navbar-height));
-		z-index: 2;
-	}
-
-	.spacer {
-		height: var(--theme-mobile-toc-height);
-	}
-
 	.content-subtitle {
 		font-weight: 400;
 		font-size: 1.5rem;
@@ -143,21 +118,8 @@ const suppressTitle = content.suppressTitle;
 	}
 
 	@media (min-width: 50em) {
-		.fixed-mobile-bar {
-			inset-inline-start: var(--theme-left-sidebar-width);
-			margin-top: 0;
-		}
 		.content {
 			overflow-x: visible;
-		}
-	}
-
-	@media (min-width: 82em) {
-		.fixed-mobile-bar {
-			display: none;
-		}
-		.spacer {
-			height: 0;
 		}
 	}
 

--- a/src/components/RightSidebar/TableOfContents.css
+++ b/src/components/RightSidebar/TableOfContents.css
@@ -1,120 +1,86 @@
-/* The mobile container is a <details> element wrapping the mobile TOC */
-.toc-mobile-container > .toc-mobile-header::marker,
-.toc-mobile-container > .toc-mobile-header::-webkit-details-marker {
-  display: none;
-}
-
-.toc-mobile-container[open] > .toc-mobile-header svg {
-  transform: rotate(90deg);
-}
+/*
+  Compact TOC trigger + popover. The trigger reuses the global
+  `.docs-toolbar-button` styling (defined in CopyForLLMButton.astro) so it
+  stays in sync with the other toolbar pills (Copy for LLM, View as Markdown).
+  This file only adds the bits unique to the TOC: chevron rotation, panel
+  positioning, and current-section indicator inside the popover.
+*/
 
 .toc-mobile-container {
-  --header-bottom-padding: 1.5rem;
+  position: relative;
+  display: inline-block;
 }
 
-@media (min-width: 50em) {
-  /* Improve toggle & title alignment with left sidebar */
-  .toc-mobile-container {
-    --header-bottom-padding: 0.5rem;
-  }
-}
-
-/*
-	The mobile header is the clickable <summary> heading.
-
-	It has a opaque background and covers the entire viewport width
-	to ensure that page content scrolling underneath is hidden.
-*/
-.toc-mobile-header {
-  display: block;
-  cursor: pointer;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  background: var(--theme-bg-gradient-top);
-  -webkit-tap-highlight-color: transparent;
-}
-
-.toc-mobile-header-content {
-  display: flex;
-  align-items: center;
-  height: var(--theme-mobile-toc-height);
-  max-width: 80ch;
-  padding-bottom: var(--header-bottom-padding);
-  padding-inline: var(--min-spacing-inline);
-}
-
-.toc-toggle {
-  margin-inline-end: 0.5rem;
-  border-radius: 0.5rem;
-  border: 1px solid var(--theme-shade-subtle);
-  padding: 0.25rem 0.75rem;
-  padding-inline-end: 0.5rem;
-  font-size: var(--theme-text-sm);
+.toc-toggle__label {
+  line-height: 1;
 }
 
 .toc-toggle svg {
-  margin-inline-start: 0.25rem;
-}
-
-.toc-current-heading {
-  text-overflow: ellipsis;
-  overflow: hidden;
-  color: var(--theme-text-light);
-  unicode-bidi: plaintext;
-}
-
-.toc-mobile-container[open] .toc-toggle {
-  background-color: var(--theme-bg-offset);
-}
-
-.toc-mobile-header h2 {
-  margin: 0;
-  display: inline;
-}
-
-.toc-mobile-header span {
-  margin-inline-start: 0.2rem;
-}
-
-.toc-mobile-header svg {
   transform: rotate(0);
-  transition: 0.15s transform ease;
+  transition: transform 0.15s ease;
   vertical-align: middle;
-  fill: var(--theme-accent-secondary);
-  stroke: var(--theme-accent-secondary);
+  fill: var(--theme-text-light);
+  stroke: var(--theme-text-light);
+}
+
+.toc-mobile-container[data-open] .toc-toggle svg {
+  transform: rotate(180deg);
 }
 
 @media (forced-colors: active) {
-  .toc-mobile-header svg {
+  .toc-toggle svg {
     fill: Highlight;
     stroke: Highlight;
   }
 }
 
-.toc-mobile-container ul.toc-root {
-  margin-inline: var(--min-spacing-inline);
-  max-height: calc(
-    var(--cur-viewport-height) -
-    var(--theme-navbar-height) -
-    var(--theme-mobile-toc-height) -
-    1rem
-  );
-  overflow-y: auto;
-  border: 1px solid var(--theme-shade-subtle);
-  border-radius: 0.5rem;
+/* Dropdown panel — overlays content */
+.toc-mobile-panel {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  inset-inline-end: 0;
+  width: 20rem;
+  max-width: calc(100vw - 2rem);
+  border: 1px solid var(--theme-border-color);
+  border-radius: 0.75rem;
+  background: var(--theme-bg-content);
+  box-shadow: 0 12px 32px -12px rgba(15, 23, 42, 0.18);
+  z-index: 50;
+  overflow: hidden;
+}
+
+.toc-mobile-panel ul.toc-root {
+  margin: 0;
   padding: 0.5rem 0;
+  max-height: calc(var(--cur-viewport-height) - var(--theme-navbar-height) - 6rem);
+  overflow-y: auto;
   font-size: var(--theme-text-sm);
-  background:
-    linear-gradient(var(--theme-bg-offset), var(--theme-bg-offset)), var(--theme-bg-gradient);
-  transform: translateY(calc(-0.5rem - 0.5 * var(--header-bottom-padding)));
+  list-style: none;
 }
 
 .toc-mobile-container .header-link {
   border: 0;
 }
 
-.toc-mobile-container .header-link a {
-  /* Add block padding to mobile header links to increase tap zones */
+/*
+  In the desktop right-sidebar the current-section highlight is a section-tinted
+  background. In the dropdown a full-width tinted band reads as a banner, so use
+  a slim left rail + bolder text instead.
+*/
+.toc-mobile-container a.current-header-link {
+  background-color: transparent !important;
+  border-inline-start: 2px solid var(--theme-accent) !important;
+  font-weight: 600;
+}
+
+/* Larger tap zones for dropdown links */
+.toc-mobile-container a.header-link {
   padding-block: 0.3125rem;
+}
+
+/* Hide the inline TOC button when the right sidebar is showing */
+@media (min-width: 82em) {
+  .page-heading-bar__toc {
+    display: none;
+  }
 }

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -1,5 +1,5 @@
-import type { JSX, ReactNode, SyntheticEvent } from 'react';
-import { useEffect, useState } from 'react';
+import type { SyntheticEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { TocItem } from '../../util/generateToc';
 import { unescape } from '../../util/html-entities';
 import './TableOfContents.css';
@@ -12,6 +12,58 @@ interface Props {
   isMobile?: boolean;
 }
 
+const ChevronIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 16 16"
+    width="14"
+    height="14"
+    aria-hidden="true"
+  >
+    <path
+      fillRule="evenodd"
+      d="M3.22 5.97a.75.75 0 011.06 0L8 9.69l3.72-3.72a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.03a.75.75 0 010-1.06z"
+    />
+  </svg>
+);
+
+const TableOfContentsItem = ({
+  heading,
+  currentSlug,
+  onLinkClick,
+}: {
+  heading: TocItem;
+  currentSlug: string;
+  onLinkClick: (e: SyntheticEvent<HTMLAnchorElement>) => void;
+}) => {
+  const { depth, slug, text, children } = heading;
+  return (
+    <li>
+      <a
+        className={`header-link depth-${depth} ${
+          currentSlug === slug ? 'current-header-link' : ''
+        }`.trim()}
+        href={`#${slug}`}
+        onClick={onLinkClick}
+      >
+        {unescape(text)}
+      </a>
+      {children.length > 0 ? (
+        <ul>
+          {children.map((child) => (
+            <TableOfContentsItem
+              key={child.slug}
+              heading={child}
+              currentSlug={currentSlug}
+              onLinkClick={onLinkClick}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+};
+
 const TableOfContents = ({ toc = [], labels, isMobile }: Props) => {
   const [currentHeading, setCurrentHeading] = useState({
     slug: toc[0].slug,
@@ -19,49 +71,7 @@ const TableOfContents = ({ toc = [], labels, isMobile }: Props) => {
   });
   const [open, setOpen] = useState(!isMobile);
   const onThisPageID = 'on-this-page-heading';
-
-  const Container = ({ children }: { children: ReactNode }) => {
-    return isMobile ? (
-      <details
-        {...{ open }}
-        onToggle={(e: SyntheticEvent<HTMLDetailsElement>) => setOpen(e.currentTarget.open)}
-        className="toc-mobile-container"
-      >
-        {children}
-      </details>
-    ) : (
-      <>{children}</>
-    );
-  };
-
-  const HeadingContainer = ({ children }: { children: JSX.Element }) => {
-    return isMobile ? (
-      <summary className="toc-mobile-header">
-        <div className="toc-mobile-header-content">
-          <div className="toc-toggle">
-            {children}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 1 16 16"
-              width="16"
-              height="16"
-              aria-hidden="true"
-            >
-              <path
-                fillRule="evenodd"
-                d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"
-              ></path>
-            </svg>
-          </div>
-          {!open && currentHeading?.slug !== 'overview' && (
-            <span className="toc-current-heading">{unescape(currentHeading?.text || '')}</span>
-          )}
-        </div>
-      </summary>
-    ) : (
-      children
-    );
-  };
+  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const setCurrent: IntersectionObserverCallback = (entries) => {
@@ -87,14 +97,32 @@ const TableOfContents = ({ toc = [], labels, isMobile }: Props) => {
 
     const headingsObserver = new IntersectionObserver(setCurrent, observerOptions);
 
-    // Observe all the headings in the main page content, skipping ones marked to ignore.
     document
       .querySelectorAll('article :is(h1,h2,h3):not([data-toc-ignore])')
       .forEach((h) => headingsObserver.observe(h));
 
-    // Stop observing when the component is unmounted.
     return () => headingsObserver.disconnect();
   }, []);
+
+  // Close the mobile dropdown when clicking outside or pressing Escape.
+  useEffect(() => {
+    if (!isMobile || !open) return;
+    const handlePointer = (event: MouseEvent) => {
+      const root = containerRef.current;
+      if (root && !root.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [isMobile, open]);
 
   const onLinkClick = (e: SyntheticEvent<HTMLAnchorElement>) => {
     if (!isMobile) return;
@@ -105,43 +133,52 @@ const TableOfContents = ({ toc = [], labels, isMobile }: Props) => {
     });
   };
 
-  const TableOfContentsItem = ({ heading }: { heading: TocItem }) => {
-    const { depth, slug, text, children } = heading;
-    return (
-      <li>
-        <a
-          className={`header-link depth-${depth} ${
-            currentHeading.slug === slug ? 'current-header-link' : ''
-          }`.trim()}
-          href={`#${slug}`}
-          onClick={onLinkClick}
-        >
-          {unescape(text)}
-        </a>
-        {children.length > 0 ? (
-          <ul>
-            {children.map((heading) => (
-              <TableOfContentsItem key={heading.slug} heading={heading} />
-            ))}
-          </ul>
-        ) : null}
-      </li>
-    );
-  };
+  const list = (
+    <ul className="toc-root">
+      {toc.map((item) => (
+        <TableOfContentsItem
+          key={item.slug}
+          heading={item}
+          currentSlug={currentHeading.slug}
+          onLinkClick={onLinkClick}
+        />
+      ))}
+    </ul>
+  );
 
-  return (
-    <Container>
-      <HeadingContainer>
+  if (!isMobile) {
+    return (
+      <>
         <h2 className="heading" id={onThisPageID}>
           {labels.onThisPage}
         </h2>
-      </HeadingContainer>
-      <ul className="toc-root">
-        {toc.map((heading2) => (
-          <TableOfContentsItem key={heading2.slug} heading={heading2} />
-        ))}
-      </ul>
-    </Container>
+        {list}
+      </>
+    );
+  }
+
+  const onTriggerClick = () => {
+    setOpen((prev) => !prev);
+  };
+
+  return (
+    <div className="toc-mobile-container" data-open={open || undefined} ref={containerRef}>
+      <button
+        type="button"
+        className="docs-toolbar-button docs-toolbar-button--compact toc-toggle"
+        aria-expanded={open}
+        aria-controls="toc-mobile-list"
+        onClick={onTriggerClick}
+      >
+        <span className="toc-toggle__label">{labels.onThisPage}</span>
+        <ChevronIcon />
+      </button>
+      {open && (
+        <div id="toc-mobile-list" className="toc-mobile-panel">
+          {list}
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -32,32 +32,32 @@ const { content, headings, breadcrumbTitle, showMarkdownActions = true } = Astro
 						<div class="page-heading-bar__breadcrumbs">
 							<Breadcrumbs breadcrumbTitle={breadcrumbTitle} />
 						</div>
-						{showMarkdownActions && (
+						{(headings || showMarkdownActions) && (
 							<div class="docs-toolbar-actions docs-toolbar-actions--heading">
-								<CopyForLLMButton size="compact" />
-								<ViewMarkdownButton size="compact" />
+								{headings && (
+									<nav class="page-heading-bar__toc" aria-label="Secondary">
+										<TableOfContents
+											client:media="(max-width: 81.99em)"
+											toc={generateToc(headings)}
+											labels={{
+												onThisPage: 'On this page',
+											}}
+											isMobile={true}
+										/>
+									</nav>
+								)}
+								{showMarkdownActions && (
+									<>
+										<CopyForLLMButton size="compact" />
+										<ViewMarkdownButton size="compact" />
+									</>
+								)}
 							</div>
 						)}
 					</div>
 				</Fragment>
 			)
 		}
-		<Fragment slot="before-article">
-			{
-				headings && (
-					<nav>
-						<TableOfContents
-							client:media="(max-width: 82em)"
-							toc={generateToc(headings)}
-							labels={{
-								onThisPage: 'On this page',
-							}}
-							isMobile={true}
-						/>
-					</nav>
-				)
-			}
-		</Fragment>
 		<Fragment slot="after-title"><slot name="header" /></Fragment>
 		<slot />
 		{

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -779,15 +779,7 @@ a.current-header-link {
 	due to lack of iOS Safari browser support.
 */
 html {
-  /* Mobile TOC is displayed above page content */
-  scroll-padding-top: calc(1.5rem + var(--theme-navbar-height) + var(--theme-mobile-toc-height));
-}
-
-@media (min-width: 72em) {
-  html {
-    /* Regular TOC is displayed as a sidebar */
-    scroll-padding-top: calc(1.5rem + var(--theme-navbar-height));
-  }
+  scroll-padding-top: calc(1.5rem + var(--theme-navbar-height));
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Move the "On this page" affordance out of its dedicated full-width fixed
bar and into the existing page-heading toolbar alongside Copy for LLM and
View as Markdown.

- Drops the floating mobile TOC bar, which eliminates the gray strip and
  the "white leaf" artifact caused by the left sidebar's rounded-corner
  ::after overlapping the bar at 50em–82em viewports.
- Rewrites the React component to drop the <details>/<summary> wrapper
  in favor of a <div role="button"> + conditional panel. The <details>
  element inherited the global .content details border/padding/background
  meant for inline MDX collapsibles, and the nested local Container
  components caused remount-on-render that broke the controlled-open
  pattern.
- Styles the trigger to match .docs-toolbar-button so it reads as a
  sibling of the existing toolbar pills.
- Renders the dropdown as an absolute-positioned popover anchored to the
  trigger. Closes on outside click and Escape.
- Hides the inline button when the right sidebar takes over (>=82em).