### PR TITLE
docs(enterprise): source on-premise version from data file

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -19,6 +19,7 @@ import { PagefindIndex } from './integrations/pagefind-index';
 import { autolinkConfig } from './plugins/rehype-autolink-config';
 import { rehypeOptimizeStatic } from './plugins/rehype-optimize-static';
 import { rehypeTasklistEnhancer } from './plugins/rehype-tasklist-enhancer';
+import { remarkEnterpriseVersionPlugin } from './plugins/remark-enterprise-version';
 import { remarkGraphvizPlugin } from './plugins/remark-graphviz';
 
 dotenv.config({
@@ -132,6 +133,7 @@ export default defineConfig({
     // Override with our own config
     smartypants: false,
     remarkPlugins: [
+      remarkEnterpriseVersionPlugin(),
       remarkGraphvizPlugin(),
       [
         remarkSmartypants as RemarkPlugin,

--- a/plugins/remark-enterprise-version.ts
+++ b/plugins/remark-enterprise-version.ts
@@ -1,0 +1,32 @@
+import type * as mdast from 'mdast';
+import type * as unified from 'unified';
+import { visit } from 'unist-util-visit';
+import enterpriseReleases from '../src/data/enterprise-releases.json';
+
+const SENTINEL = '@@ENTERPRISE_VERSION@@';
+
+export function remarkEnterpriseVersionPlugin(): unified.Plugin<[], mdast.Root> {
+  const latestVersion = enterpriseReleases[0]?.version;
+  if (!latestVersion) {
+    throw new Error('remark-enterprise-version: no version found in enterprise-releases.json');
+  }
+
+  const transformer: unified.Transformer<mdast.Root> = (tree) => {
+    visit(tree, (node) => {
+      if (
+        (node.type === 'text' || node.type === 'inlineCode' || node.type === 'code') &&
+        typeof (node as { value?: string }).value === 'string' &&
+        (node as { value: string }).value.includes(SENTINEL)
+      ) {
+        (node as { value: string }).value = (node as { value: string }).value.replaceAll(
+          SENTINEL,
+          latestVersion
+        );
+      }
+    });
+  };
+
+  return function attacher() {
+    return transformer;
+  };
+}

--- a/src/content/docs/enterprise/installation.mdx
+++ b/src/content/docs/enterprise/installation.mdx
@@ -28,7 +28,7 @@ You will run the installer mode first to generate a `mergify.env` file, then res
 normal mode with that configuration plus your subscription token.
 
 :::note
-Always pick the latest Enterprise image. Examples below use `8.15.0`; replace it with the newest
+Always pick the latest Enterprise image. Examples below use `@@ENTERPRISE_VERSION@@`; replace it with the newest
 tag from the releases page.
 :::
 
@@ -46,7 +46,7 @@ Download the Docker image using `docker pull`:
 cat mergify_registry_key.json | base64 | \
   docker login -u _json_key_base64 --password-stdin "https://registry.mergify.com"
 
-docker pull registry.mergify.com/enterprise:8.15.0
+docker pull registry.mergify.com/enterprise:@@ENTERPRISE_VERSION@@
 ```
 
 ## Start Installer Mode
@@ -57,7 +57,7 @@ docker run --rm -d \
   -p 5000:5000 \
   -e PORT=5000 \
   -e MERGIFYENGINE_INSTALLER=1 \
-  registry.mergify.com/enterprise:8.15.0
+  registry.mergify.com/enterprise:@@ENTERPRISE_VERSION@@
 ```
 
 :::note\[Security Note]
@@ -188,7 +188,7 @@ docker run \
   -e MERGIFYENGINE_CI_TRACES_INCOMING_BUCKET="<mycompany>-mergify-ci-traces-incoming" \
   -e MERGIFYENGINE_CI_TRACES_DONE_BUCKET="<mycompany>-mergify-ci-traces-done" \
   -e MERGIFYENGINE_GCS_CREDENTIALS="base64-encoded-credentials-json" \
-  registry.mergify.com/enterprise:8.15.0
+  registry.mergify.com/enterprise:@@ENTERPRISE_VERSION@@
 ```
 
 Check logs:

--- a/src/content/docs/enterprise/manual-installation-legacy.mdx
+++ b/src/content/docs/enterprise/manual-installation-legacy.mdx
@@ -5,7 +5,7 @@ description: 'Legacy process for provisioning the Mergify GitHub App and engine 
 
 > ⚙️ These steps mirror the older manual workflow. Adapt them into infrastructure-as-code if needed.
 
-> 🔼 Replace the `8.15.0` tag with the latest Enterprise release.
+> 🔼 Replace the `@@ENTERPRISE_VERSION@@` tag with the latest Enterprise release.
 
 ## 1. Create the GitHub App
 
@@ -116,7 +116,7 @@ ruby -rsecurerandom -e 'puts SecureRandom.hex(42)'
 cat mergify_registry_key.json | base64 | \
   docker login -u _json_key_base64 --password-stdin "https://registry.mergify.com"
 
-docker pull registry.mergify.com/enterprise:8.15.0
+docker pull registry.mergify.com/enterprise:@@ENTERPRISE_VERSION@@
 ```
 
 ## 5. Start Mergify
@@ -134,7 +134,7 @@ docker run \
   -e MERGIFYENGINE_SUBSCRIPTION_TOKEN=<mergify-subscription-token> \
   -e MERGIFYENGINE_REDIS_URL=rediss://:password@my-redis:6363 \
   -e MERGIFYENGINE_DATABASE_URL=postgresql://postgres:password@postgres:5432/postgres \
-  registry.mergify.com/enterprise:8.15.0
+  registry.mergify.com/enterprise:@@ENTERPRISE_VERSION@@
 ```
 
 Verify logs:


### PR DESCRIPTION
Replace hard-coded `8.15.0` literals with a `@@ENTERPRISE_VERSION@@`
sentinel resolved at build time from `src/data/enterprise-releases.json`
(already CI-synced). Future release syncs now propagate to the docs
without a manual MDX bump.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #11273