### PR TITLE
docs(enterprise): consolidate CI Insights storage setup and prefer standard AWS env vars

### DIFF
--- a/src/content/docs/enterprise/advanced-features.mdx
+++ b/src/content/docs/enterprise/advanced-features.mdx
@@ -109,18 +109,27 @@ Requirements:
 
 - An IAM identity with read/write/delete rights on those buckets
 
-Common settings:
+Common settings. Mergify reads the standard AWS environment variables, so no `MERGIFYENGINE_`
+prefix is required:
 
 ```ini
 MERGIFYENGINE_CI_TRACES_BACKEND="s3"
 MERGIFYENGINE_CI_TRACES_INCOMING_BUCKET="<mycompany>-mergify-ci-traces-incoming"
 MERGIFYENGINE_CI_TRACES_DONE_BUCKET="<mycompany>-mergify-ci-traces-done"
-MERGIFYENGINE_AWS_ACCOUNT_ID=1234567
+AWS_ACCOUNT_ID=123456789012
 # Optional
-MERGIFYENGINE_AWS_REGION_NAME=us-west-2
+AWS_REGION=us-west-2
 # Custom S3 implementation endpoint
-MERGIFYENGINE_AWS_ENDPOINT_URL_S3=s3://my-s3-domain.example.com:1234/
+AWS_ENDPOINT_URL_S3=https://my-s3-domain.example.com:1234/
 ```
+
+:::note
+  The `MERGIFYENGINE_AWS_*` variants (`MERGIFYENGINE_AWS_ACCOUNT_ID`,
+  `MERGIFYENGINE_AWS_ACCESS_KEY_ID`, `MERGIFYENGINE_AWS_SECRET_ACCESS_KEY`,
+  `MERGIFYENGINE_AWS_REGION_NAME`, `MERGIFYENGINE_AWS_ENDPOINT_URL_S3`) are still accepted for
+  backwards compatibility but are deprecated. Prefer the unprefixed `AWS_*` names. They are the
+  same variables the AWS CLI and SDKs use.
+:::
 
 #### Option A: IAM user access key
 
@@ -128,14 +137,14 @@ Create an IAM user, attach a policy granting access to the two buckets, generate
 and provide it to the engine:
 
 ```ini
-MERGIFYENGINE_AWS_ACCESS_KEY_ID=<access-key-id>
-MERGIFYENGINE_AWS_SECRET_ACCESS_KEY=<secret-access-key>
+AWS_ACCESS_KEY_ID=<access-key-id>
+AWS_SECRET_ACCESS_KEY=<secret-access-key>
 ```
 
 #### Option B: IAM role discovery
 
-Leave both `MERGIFYENGINE_AWS_ACCESS_KEY_ID` and `MERGIFYENGINE_AWS_SECRET_ACCESS_KEY` unset.
-Mergify falls back to the standard
+Leave both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` unset. Mergify falls back to the
+standard
 [boto3 credential chain](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html),
 which can resolve credentials from any of:
 

--- a/src/content/docs/enterprise/installation.mdx
+++ b/src/content/docs/enterprise/installation.mdx
@@ -158,54 +158,12 @@ corresponding credentials when starting the engine.
   This step is optional. Skip it if you do not plan to use CI Insights or Test Insights.
 :::
 
-Both providers support two authentication modes: a static credential set you manage yourself, or
-automatic discovery through your cloud workload identity (recommended when running on GKE, EKS,
-GCE, or EC2 to avoid manual key rotation). The examples below use static credentials; see
-[Advanced Features](/enterprise/advanced-features/#ci-insights-and-test-insights-object-storage)
-for the workload-identity setup and the full list of provider requirements.
-
-### Google Cloud Storage
-
-Create two buckets and a Service Account with the `Storage Object User` role scoped to them.
-
-Base64-encode the JSON key:
-
-```sh
-base64 < credentials.json | tr -d '\n'
-```
-
-Add these environment variables when starting the engine:
-
-```ini
-MERGIFYENGINE_CI_TRACES_BACKEND="gcs"
-MERGIFYENGINE_CI_TRACES_INCOMING_BUCKET="<mycompany>-mergify-ci-traces-incoming"
-MERGIFYENGINE_CI_TRACES_DONE_BUCKET="<mycompany>-mergify-ci-traces-done"
-MERGIFYENGINE_GCS_CREDENTIALS="base64-encoded-credentials-json"
-```
-
-To use Application Default Credentials instead (GKE Workload Identity, GCE metadata server, or a
-local key path), set `MERGIFYENGINE_GCS_CREDENTIALS="auto"` and skip the JSON key.
-
-### Amazon S3
-
-Create two buckets and IAM credentials with read/write/delete rights on them.
-
-```ini
-MERGIFYENGINE_CI_TRACES_BACKEND="s3"
-MERGIFYENGINE_CI_TRACES_INCOMING_BUCKET="<mycompany>-mergify-ci-traces-incoming"
-MERGIFYENGINE_CI_TRACES_DONE_BUCKET="<mycompany>-mergify-ci-traces-done"
-MERGIFYENGINE_AWS_ACCOUNT_ID=1234567
-MERGIFYENGINE_AWS_ACCESS_KEY_ID=123567
-MERGIFYENGINE_AWS_SECRET_ACCESS_KEY=<secret>
-# Optional
-MERGIFYENGINE_AWS_REGION_NAME=us-west-2
-# Custom S3 implementation endpoint
-MERGIFYENGINE_AWS_ENDPOINT_URL_S3=s3://my-s3-domain.example.com:1234/
-```
-
-To use IAM role discovery instead (IRSA, EKS Pod Identity, ECS task role, or EC2 instance
-profile), omit `MERGIFYENGINE_AWS_ACCESS_KEY_ID` and `MERGIFYENGINE_AWS_SECRET_ACCESS_KEY` and
-attach an IAM role granting bucket access to the workload running the engine.
+Mergify supports both Google Cloud Storage and Amazon S3, with either static credentials or
+automatic discovery through your cloud workload identity (GKE Workload Identity, IRSA, EKS Pod
+Identity, instance profile). See
+[Advanced Features → CI Insights and Test Insights Object Storage](/enterprise/advanced-features/#ci-insights-and-test-insights-object-storage)
+for bucket requirements, the full list of environment variables, and side-by-side examples for
+each authentication mode.
 
 ## Start Mergify in Normal Mode
 


### PR DESCRIPTION
Move all the GCS / S3 detail to the Advanced Features reference and shrink
the install guide section to an intro paragraph plus a link, eliminating
the duplicated wording between the two pages.

In the S3 reference, recommend the standard unprefixed `AWS_*` env vars
(`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`,
`AWS_ACCOUNT_ID`, `AWS_ENDPOINT_URL_S3`) — boto3 reads them natively.
Mark the `MERGIFYENGINE_AWS_*` variants as accepted-but-deprecated.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>