### PR TITLE
fix(lint): exclude root *.md files from remark-lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,7 @@ export default [
       'node_modules/**',
       '.github/**',
       '.claude/**',
+      '*.md',
       'public/scalar-api-reference.js',
       'src/content/changelog/',
     ],


### PR DESCRIPTION
DESIGN.md, AGENTS.md, and CLAUDE.md are documentation artifacts, not
MDX content pages. The remark-lint list-item-spacing rule fails on
compact bullet lists with long wrapped lines in these files.

Depends-On: #11303