### PR TITLE
fix(design): address Phase 1 code review findings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,6 @@ export default [
       'node_modules/**',
       '.github/**',
       '.claude/**',
-      '*.md',
       'public/scalar-api-reference.js',
       'src/content/changelog/',
     ],
@@ -136,10 +135,12 @@ export default [
     },
   },
 
-  // MDX files
+  // MDX files. Note: `files` must follow the spread to override
+  // `mdxPlugin.flat`'s default glob (which matches both .md and .mdx)
+  // and restrict linting to .mdx only.
   {
-    files: ['**/*.mdx'],
     ...mdxPlugin.flat,
+    files: ['**/*.mdx'],
     plugins: {
       mdx: fixupPluginRules(mdxPlugin),
     },

--- a/src/components/HeadCommon.astro
+++ b/src/components/HeadCommon.astro
@@ -6,6 +6,8 @@ import '@fontsource/inter/500.css';
 import '@fontsource/inter/600.css';
 import '@fontsource/inter/700.css';
 
+// Order matters: tokens (primitives) → theme (semantic layer using primitives)
+// → typography (consumes semantic tokens) → index (consumes both layers).
 import '../styles/tokens.css';
 import '../styles/theme.css';
 import '../styles/typography.css';


### PR DESCRIPTION
- Add explanatory comment in HeadCommon.astro for the import order
  (tokens → theme → typography → index) so future editors know it
  is load-bearing, not arbitrary.
- Replace the blanket *.md ESLint ignore with a scoped fix to the
  MDX block: place 'files' AFTER the mdxPlugin.flat spread to
  override its default '**/*.{md,mdx}' glob and restrict remark
  linting to .mdx only. This avoids silently suppressing future
  *.md linting at the repo root.

Depends-On: #11304