### PR TITLE
fix(header): solid distinct navbar surface for light-mode readability

### DIFF
--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -124,8 +124,12 @@ const primaryLink = isEnterpriseSection
 		height: var(--theme-navbar-height);
 		z-index: 11;
 		padding: 0.75rem 0;
-		background-color: color-mix(in srgb, var(--theme-navbar-bg) 95%, transparent);
-		backdrop-filter: blur(5px);
+		background-color: var(--theme-navbar-bg);
+		/* Soft shadow instead of a hard border so the rounded ::after scoop
+		   on the left sidebar (BaseLayout) flows continuously into the
+		   navbar's bottom edge. Near-invisible in dark mode (where navbar
+		   bg matches body bg), which matches the original behaviour. */
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 		display: flex;
 		align-items: center;
 		justify-content: left;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -186,8 +186,10 @@
   --theme-code-del-border: hsl(338, 46%, 53%);
   --theme-code-del-text: hsl(338, 36%, 70%);
 
-  /* Navbar */
-  --theme-navbar-bg: var(--theme-bg);
+  /* Navbar — content surface (white in light) so it reads as a distinct
+     elevated zone over the body bg. Dark mode aliases --theme-bg-content
+     to --theme-bg, so this is unchanged from the previous behaviour there. */
+  --theme-navbar-bg: var(--theme-bg-content);
 
   /* Glow */
   --theme-glow-highlight: transparent;


### PR DESCRIPTION
The previous navbar styling — body-bg-tinted color-mix at 95% opacity
plus a backdrop blur — collapsed against the cleaner light gray
introduced by the design-system token migration: links became hard to
read because the navbar visually merged into the body bg.

- Map --theme-navbar-bg to --theme-bg-content (white in light mode).
  Dark mode is unaffected because --theme-bg-content aliases --theme-bg
  there.
- Drop the color-mix transparency and the backdrop-filter blur. The
  navbar is now a solid surface; the modern feel comes from the surface
  contrast plus the divider, not from glassmorphism.
- Add a 1px bottom border using --theme-divider for clear separation.

Depends-On: #11307