### PR TITLE
fix(design): address Phase 3 code review findings

### DIFF
--- a/src/components/Search/Search.scss
+++ b/src/components/Search/Search.scss
@@ -6,7 +6,7 @@
    so these styles must NOT be nested under #search-bar. */
 .modal-content {
 	mark {
-		color: #003dff;
+		color: var(--theme-link);
 		background: transparent;
 		font-weight: 500;
 	}
@@ -48,6 +48,5 @@
 	background: var(--theme-bg-hover) !important;
 }
 
-.theme-dark .modal-content mark {
-	color: #5468ff;
-}
+/* Dark mode mark color comes from --theme-link's dark-mode remap;
+   no separate override needed. */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -880,7 +880,7 @@ pre {
   color: var(--theme-text-muted);
 }
 
-#main-content h2:not(.content-subtitle):not(.home-title) {
+#main-content h2:not(.content-subtitle) {
   font-size: 1.5rem;
   font-weight: 500;
   line-height: 1.3;
@@ -921,7 +921,7 @@ article.content {
   position: relative;
 }
 
-.content h2:not(.content-subtitle, .home-title):not(.no-counter)::before {
+.content h2:not(.content-subtitle):not(.no-counter)::before {
   content: counter(h2-section);
   font-weight: 500;
   margin-right: 0.55rem;


### PR DESCRIPTION
- Remove dead :not(.home-title) guard clauses in src/styles/index.css.
  The .home-title class was removed from the homepage MDX in Phase 3,
  so the guards now reference a class that no longer exists in the DOM.

- Replace hard-coded hex colors in Search.scss search-highlight marks
  (#003dff in light, #5468ff in dark) with var(--theme-link). The token
  is already mode-aware so the dark override is redundant.

Depends-On: #11325