### PR TITLE
refactor(design): collapse per-section accent rules into single tokenized rule

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -454,19 +454,57 @@ a.header-link:focus {
 }
 
 body {
-  /* Set a section-specific accent for product pages */
-  --section-merge-queue-accent: #1cb893;
-  --section-merge-queue-accent-bg: rgba(28, 184, 147, 0.15);
-  --section-ci-insights-accent: #4d59e0;
-  --section-ci-insights-accent-bg: rgba(77, 89, 224, 0.15);
-  --section-test-insights-accent: #f27b2a;
-  --section-test-insights-accent-bg: rgba(242, 123, 42, 0.15);
-  --section-merge-protections-accent: #43a7e5;
-  --section-merge-protections-accent-bg: rgba(67, 167, 229, 0.15);
-  --section-stacks-accent: #e53935;
-  --section-stacks-accent-bg: rgba(229, 57, 53, 0.15);
-  --section-workflow-accent: #e62474;
-  --section-workflow-accent-bg: rgba(230, 36, 116, 0.15);
+  --section-accent: var(--theme-link);
+  --section-accent-bg: color-mix(in srgb, var(--theme-link) 15%, transparent);
+}
+
+body.section-merge-queue {
+  --section-accent: var(--color-teal-700);
+  --section-accent-bg: color-mix(in srgb, var(--color-teal-400) 25%, transparent);
+}
+body.section-ci-insights {
+  --section-accent: var(--color-purple-700);
+  --section-accent-bg: color-mix(in srgb, var(--color-purple-400) 25%, transparent);
+}
+body.section-test-insights {
+  --section-accent: var(--color-orange-700);
+  --section-accent-bg: color-mix(in srgb, var(--color-orange-400) 25%, transparent);
+}
+body.section-merge-protections {
+  --section-accent: var(--color-blue-700);
+  --section-accent-bg: color-mix(in srgb, var(--color-blue-400) 25%, transparent);
+}
+body.section-stacks {
+  --section-accent: var(--color-coral-700);
+  --section-accent-bg: color-mix(in srgb, var(--color-coral-400) 25%, transparent);
+}
+body.section-workflow {
+  --section-accent: var(--color-rose-700);
+  --section-accent-bg: color-mix(in srgb, var(--color-rose-400) 25%, transparent);
+}
+
+.header-link {
+  border-inline-start-color: var(--section-accent-bg);
+}
+
+.header-link:hover,
+.header-link:focus,
+.header-link:focus-within {
+  border-inline-start-color: var(--section-accent);
+}
+
+a.current-header-link {
+  border-inline-start-color: var(--section-accent);
+  background-color: var(--section-accent-bg);
+}
+
+#left-sidebar [class^="nav-group-"] .nav-link a:hover,
+#left-sidebar [class^="nav-group-"] .nav-link a:focus {
+  background-color: transparent;
+}
+
+#left-sidebar [class^="nav-group-"] .nav-link a[aria-current="page"] {
+  background-color: hsla(0, 0%, 0%, 0.05);
 }
 
 .nav-link a:hover,
@@ -474,172 +512,17 @@ body {
   color: inherit;
 }
 
-/* Merge Queue section: override ToC highlight color */
-body.section-merge-queue .header-link {
-  border-inline-start-color: var(--section-merge-queue-accent-bg);
-}
-
-body.section-merge-queue .header-link:hover,
-body.section-merge-queue .header-link:focus,
-body.section-merge-queue .header-link:focus-within {
-  border-inline-start-color: var(--section-merge-queue-accent);
-}
-
-body.section-merge-queue a.current-header-link {
-  border-inline-start-color: var(--section-merge-queue-accent);
-  background-color: var(--section-merge-queue-accent-bg);
-}
-
-/* Left sidebar: Merge Queue active uses left border */
-#left-sidebar .nav-group-merge-queue .nav-link a:hover,
-#left-sidebar .nav-group-merge-queue .nav-link a:focus {
-  background-color: transparent;
-}
-
-#left-sidebar .nav-group-merge-queue .nav-link a[aria-current="page"] {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-/* CI Insights section: ToC and nav colors */
-body.section-ci-insights .header-link {
-  border-inline-start-color: var(--section-ci-insights-accent-bg);
-}
-
-body.section-ci-insights .header-link:hover,
-body.section-ci-insights .header-link:focus,
-body.section-ci-insights .header-link:focus-within {
-  border-inline-start-color: var(--section-ci-insights-accent);
-}
-
-body.section-ci-insights a.current-header-link {
-  border-inline-start-color: var(--section-ci-insights-accent);
-  background-color: var(--section-ci-insights-accent-bg);
-}
-
-#left-sidebar .nav-group-ci-insights .nav-link a:hover,
-#left-sidebar .nav-group-ci-insights .nav-link a:focus {
-  background-color: transparent;
-}
-
-#left-sidebar .nav-group-ci-insights .nav-link a[aria-current="page"] {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-/* Merge Protections section: ToC and nav colors */
-body.section-merge-protections .header-link {
-  border-inline-start-color: var(--section-merge-protections-accent-bg);
-}
-
-body.section-merge-protections .header-link:hover,
-body.section-merge-protections .header-link:focus,
-body.section-merge-protections .header-link:focus-within {
-  border-inline-start-color: var(--section-merge-protections-accent);
-}
-
-body.section-merge-protections a.current-header-link {
-  border-inline-start-color: var(--section-merge-protections-accent);
-  background-color: var(--section-merge-protections-accent-bg);
-}
-
-#left-sidebar .nav-group-merge-protections .nav-link a:hover,
-#left-sidebar .nav-group-merge-protections .nav-link a:focus {
-  background-color: transparent;
-}
-
-#left-sidebar .nav-group-merge-protections .nav-link a[aria-current="page"] {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-/* Test Insights section: ToC and nav colors */
-body.section-test-insights .header-link {
-  border-inline-start-color: var(--section-test-insights-accent-bg);
-}
-
-body.section-test-insights .header-link:hover,
-body.section-test-insights .header-link:focus,
-body.section-test-insights .header-link:focus-within {
-  border-inline-start-color: var(--section-test-insights-accent);
-}
-
-body.section-test-insights a.current-header-link {
-  border-inline-start-color: var(--section-test-insights-accent);
-  background-color: var(--section-test-insights-accent-bg);
-}
-
-#left-sidebar .nav-group-test-insights .nav-link a:hover,
-#left-sidebar .nav-group-test-insights .nav-link a:focus {
-  background-color: transparent;
-}
-
-#left-sidebar .nav-group-test-insights .nav-link a[aria-current="page"] {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-/* Stacks section: ToC and nav colors */
-body.section-stacks .header-link {
-  border-inline-start-color: var(--section-stacks-accent-bg);
-}
-
-body.section-stacks .header-link:hover,
-body.section-stacks .header-link:focus,
-body.section-stacks .header-link:focus-within {
-  border-inline-start-color: var(--section-stacks-accent);
-}
-
-body.section-stacks a.current-header-link {
-  border-inline-start-color: var(--section-stacks-accent);
-  background-color: var(--section-stacks-accent-bg);
-}
-
-#left-sidebar .nav-group-stacks .nav-link a:hover,
-#left-sidebar .nav-group-stacks .nav-link a:focus {
-  background-color: transparent;
-}
-
-#left-sidebar .nav-group-stacks .nav-link a[aria-current="page"] {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-/* Workflow Automation section: ToC and nav colors */
-body.section-workflow .header-link {
-  border-inline-start-color: var(--section-workflow-accent-bg);
-}
-
-body.section-workflow .header-link:hover,
-body.section-workflow .header-link:focus,
-body.section-workflow .header-link:focus-within {
-  border-inline-start-color: var(--section-workflow-accent);
-}
-
-body.section-workflow a.current-header-link {
-  border-inline-start-color: var(--section-workflow-accent);
-  background-color: var(--section-workflow-accent-bg);
-}
-
-#left-sidebar .nav-group-workflow .nav-link a:hover,
-#left-sidebar .nav-group-workflow .nav-link a:focus {
-  background-color: transparent;
-}
-
-#left-sidebar .nav-group-workflow .nav-link a[aria-current="page"] {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
 /* Highlight TOC header link matching the current scroll position */
 a.current-header-link {
-  background-color: var(--theme-bg-hover);
   /* Indicates the current heading for forced colors users in older browsers */
   outline: 1px solid transparent;
+  color: var(--theme-text);
 }
 
 @media (forced-colors: active) {
   a.current-header-link {
     border: 1px solid CanvasText;
   }
-}
-
-a.current-header-link {
-  color: var(--theme-text);
 }
 
 /* Home page specific styles moved from inline MDX */


### PR DESCRIPTION
Replace ~150 lines of per-section body.section-* ToC and sidebar rules with
~30 lines driven by --section-accent and --section-accent-bg custom properties.
Each section body class sets those two tokens; a single set of .header-link
and a.current-header-link rules consumes them.

Depends-On: #11326