### PR TITLE
refactor(design): tokenize home-discovery callout (placeholder for B)

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -891,28 +891,31 @@ article.content {
   justify-content: center;
 }
 
-/* Home page: Discovery callout */
+/* Home page: Discovery callout — placeholder styling (B-pass will redesign) */
 .home-discovery {
   display: block;
   padding: 1.25rem 1.5rem;
   margin-bottom: 2rem;
   border-radius: 12px;
-  background: linear-gradient(135deg, #0d9488 0%, #065f46 100%);
+  background: var(--theme-bg-content);
+  border: 1px solid var(--theme-border);
+  border-left: 4px solid var(--color-teal-700);
   text-decoration: none;
+  transition: border-color 0.18s ease;
 }
 
 .home-discovery:hover {
-  opacity: 0.95;
+  border-color: var(--color-teal-700);
 }
 
 .home-discovery-title {
-  font-size: var(--text-lg);
+  font-size: 1.125rem;
   font-weight: 600;
-  color: white;
+  color: var(--theme-text);
   margin-bottom: 0.25rem;
 }
 
 .home-discovery-desc {
-  font-size: var(--text-sm);
-  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.9375rem;
+  color: var(--theme-text-muted);
 }


### PR DESCRIPTION
Replace off-system teal gradient with neutral surface + 4px teal-700 left
border. Hover expands full border to teal. Title/desc colors now use semantic
text tokens. B-pass will redesign this callout entirely.

Depends-On: #11328