### PR TITLE
refactor(design): migrate --color-mergify-blue consumers to semantic tokens

### DIFF
--- a/src/components/Header/ThemeToggleButton.css
+++ b/src/components/Header/ThemeToggleButton.css
@@ -28,12 +28,12 @@
 }
 
 .theme-toggle .checked {
-  color: var(--color-mergify-blue-dark);
+  color: var(--theme-text-secondary);
   opacity: 1;
 }
 
 .theme-dark .theme-toggle .checked {
-  color: var(--color-mergify-blue-light);
+  color: var(--theme-text-secondary);
   opacity: 1;
 }
 

--- a/src/components/PageFeedback.astro
+++ b/src/components/PageFeedback.astro
@@ -69,7 +69,7 @@
   }
 
   .page-feedback__btn:focus-visible {
-    outline: 2px solid var(--color-mergify-blue);
+    outline: 2px solid var(--theme-link);
     outline-offset: 2px;
   }
 
@@ -79,14 +79,14 @@
   }
 
   .page-feedback__btn[data-selected] {
-    border-color: var(--color-mergify-blue);
-    color: var(--color-mergify-blue);
+    border-color: var(--theme-link);
+    color: var(--theme-link);
     background: var(--theme-bg-offset);
   }
 
   .page-feedback__thanks {
     margin: 0;
-    color: var(--color-mergify-blue);
+    color: var(--theme-link);
     font-weight: 450;
   }
 </style>

--- a/src/components/PageMeta.astro
+++ b/src/components/PageMeta.astro
@@ -52,6 +52,6 @@ const editUrl = getEditPath(pathname);
   }
 
   .page-meta__edit:hover {
-    color: var(--color-mergify-blue);
+    color: var(--theme-link);
   }
 </style>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -38,7 +38,7 @@ import Header from '../components/Header/Header.astro';
 				font-weight: 800;
 				letter-spacing: -0.04em;
 				line-height: 1;
-				color: var(--color-mergify-blue);
+				color: var(--theme-link);
 				margin: 0 0 1rem;
 				opacity: 0.25;
 			}
@@ -79,8 +79,8 @@ import Header from '../components/Header/Header.astro';
 			}
 
 			.search-prompt:hover {
-				border-color: var(--color-mergify-blue);
-				box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-mergify-blue) 12%, transparent);
+				border-color: var(--theme-link);
+				box-shadow: 0 0 0 3px color-mix(in srgb, var(--theme-link) 12%, transparent);
 			}
 
 			.search-prompt svg {
@@ -120,8 +120,8 @@ import Header from '../components/Header/Header.astro';
 			}
 
 			.home-link:hover {
-				color: var(--color-mergify-blue);
-				border-color: var(--color-mergify-blue);
+				color: var(--theme-link);
+				border-color: var(--theme-link);
 				background: var(--theme-bg-offset);
 			}
 		</style>

--- a/src/styles/api-reference.css
+++ b/src/styles/api-reference.css
@@ -104,8 +104,8 @@
 }
 
 .endpoint:target {
-  border-color: var(--color-mergify-blue);
-  box-shadow: 0 0 0 1px var(--color-mergify-blue);
+  border-color: var(--theme-link);
+  box-shadow: 0 0 0 1px var(--theme-link);
 }
 
 .endpoint-heading {
@@ -147,7 +147,7 @@
 }
 
 .endpoint-path .path-param {
-  color: var(--color-mergify-blue-darker);
+  color: var(--theme-link);
   font-style: italic;
 }
 
@@ -358,7 +358,7 @@
 }
 
 .schema-expandable > .schema-property-header:hover {
-  color: var(--color-mergify-blue-darker);
+  color: var(--theme-link);
 }
 
 .schema-property-name {
@@ -508,7 +508,7 @@ details[open] > .schema-property-header > .schema-chevron {
 .schema-type-ref {
   font-family: var(--font-mono);
   font-size: 0.8rem;
-  color: var(--color-mergify-blue-darker);
+  color: var(--theme-link);
 }
 
 .schema-variant-more {
@@ -728,8 +728,8 @@ details[open] > .schema-property-header > .schema-chevron {
 }
 
 .api-section-card:hover {
-  border-color: var(--color-mergify-blue);
-  box-shadow: 0 2px 8px hsla(var(--color-base-blue), 50%, 0.1);
+  border-color: var(--theme-link);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--theme-link) 10%, transparent);
   color: inherit;
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -62,7 +62,7 @@ body {
 }
 
 a {
-  color: var(--color-mergify-blue-darker);
+  color: var(--theme-link);
   text-decoration: none;
 }
 
@@ -605,7 +605,7 @@ a.current-header-link {
   transform: translateY(1px);
 }
 .quick-links .ql:focus-visible {
-  outline: 2px solid var(--color-mergify-blue-darker);
+  outline: 2px solid var(--theme-link);
   outline-offset: 2px;
 }
 @media (hover: hover) {
@@ -738,7 +738,7 @@ pre {
   transform: translateY(0);
 }
 .home-hero .quick-links .ql:focus-visible {
-  outline: 2px solid var(--color-mergify-blue-darker);
+  outline: 2px solid var(--theme-link);
   outline-offset: 2px;
 }
 


### PR DESCRIPTION
Replace all --color-mergify-blue* references across styles and components with
semantic tokens: link affordances → --theme-link, theme toggle checked state →
--theme-text-secondary. Only the definitions in theme.css remain (removed next).

Depends-On: #11329