### PR TITLE
refactor(design): remove --color-mergify-blue and HSLA primitives

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
           tooltipSuccessBackground: 'var(--theme-link)',
           tooltipSuccessForeground: '#fff',
           inlineButtonBorder: 'var(--theme-divider)',
-          inlineButtonForeground: 'var(--theme-text-lighter)',
+          inlineButtonForeground: 'var(--theme-text-muted)',
           inlineButtonBackgroundIdleOpacity: '0',
           inlineButtonBackgroundHoverOrFocusOpacity: '0.08',
         },

--- a/src/components/Aside.astro
+++ b/src/components/Aside.astro
@@ -49,26 +49,20 @@ const { viewBox, d } = icons[type];
 </aside>
 
 <style>
+	/* note (default) */
 	aside {
-		--aside-color-base: var(--color-base-blue);
-		--aside-color-lightness: 65%;
-		--aside-accent-color: hsl(var(--aside-color-base), var(--aside-color-lightness));
-		--aside-text-lightness: 20%;
-		--aside-text-accent-color: hsl(var(--aside-color-base), var(--aside-text-lightness));
+		--aside-accent-color: var(--color-blue-400);
+		--aside-text-accent-color: var(--color-blue-700);
 
 		border-inline-start: 4px solid var(--aside-accent-color);
 		padding: 1rem;
-		background-color: hsla(
-			var(--aside-color-base),
-			var(--aside-color-lightness),
-			var(--theme-accent-opacity)
-		);
+		background-color: color-mix(in srgb, var(--aside-accent-color) 10%, transparent);
 		/* Indicates the aside boundaries for forced colors users, transparent is changed to a solid color */
 		outline: 1px solid transparent;
 	}
 
 	:global(.theme-dark) aside {
-		--aside-text-lightness: 85%;
+		--aside-text-accent-color: var(--color-blue-400);
 	}
 
 	.title {
@@ -108,17 +102,29 @@ const { viewBox, d } = icons[type];
 	}
 
 	.tip {
-		--aside-color-lightness: 42%;
-		--aside-color-base: var(--color-base-teal);
+		--aside-accent-color: var(--color-teal-400);
+		--aside-text-accent-color: var(--color-teal-700);
+	}
+
+	:global(.theme-dark) .tip {
+		--aside-text-accent-color: var(--color-teal-400);
 	}
 
 	.caution {
-		--aside-color-lightness: 59%;
-		--aside-color-base: var(--color-base-yellow);
+		--aside-accent-color: var(--color-orange-400);
+		--aside-text-accent-color: var(--color-orange-700);
+	}
+
+	:global(.theme-dark) .caution {
+		--aside-text-accent-color: var(--color-orange-400);
 	}
 
 	.danger {
-		--aside-color-lightness: 54%;
-		--aside-color-base: var(--color-base-red);
+		--aside-accent-color: var(--color-coral-400);
+		--aside-text-accent-color: var(--color-coral-700);
+	}
+
+	:global(.theme-dark) .danger {
+		--aside-text-accent-color: var(--color-coral-400);
 	}
 </style>

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -93,11 +93,11 @@ if (matchedTrail.length >= 2) {
 		letter-spacing: 0.02em; /* slightly tighter at larger size */
 		font-weight: 500;
 		margin: 0 0 2rem;
-		color: var(--theme-text-lighter);
+		color: var(--theme-text-muted);
 		line-height: 1.35;
 	}
 	.theme-dark .breadcrumbs {
-		color: var(--theme-text-light);
+		color: var(--theme-text-secondary);
 	}
 
 	.breadcrumbs ol {
@@ -132,10 +132,10 @@ if (matchedTrail.length >= 2) {
 		font-weight: 600;
 		opacity: 0.45;
 		margin: 0 0.45rem; /* symmetric spacing */
-		color: var(--theme-text-light);
+		color: var(--theme-text-secondary);
 	}
 	.theme-dark .breadcrumbs li + li:before {
-		color: var(--theme-text-lighter);
+		color: var(--theme-text-muted);
 	}
 
 	.breadcrumbs a {

--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -52,7 +52,7 @@ import { defaultConfig as footerConfig } from './footer';
 				color: inherit;
 				text-decoration: none;
 				transition: color 0.2s ease-in-out;
-				color: var(--theme-text-lighter);
+				color: var(--theme-text-muted);
 
 				&:hover {
 					color: var(--theme-text);

--- a/src/components/Header/HeaderButton.css
+++ b/src/components/Header/HeaderButton.css
@@ -1,7 +1,7 @@
 .header-button {
   --border-color-default: var(--theme-shade-subtle);
-  --border-color-hocus: var(--theme-text-light);
-  --text-color-default: var(--theme-text-light);
+  --border-color-hocus: var(--theme-text-secondary);
+  --text-color-default: var(--theme-text-secondary);
   --text-color-hocus: var(--theme-text);
   box-sizing: border-box;
   margin: 0;

--- a/src/components/Header/HeaderLink.astro
+++ b/src/components/Header/HeaderLink.astro
@@ -21,7 +21,7 @@ const { href, icon, target } = Astro.props as Props;
 		display: flex;
 		height: 42px;
 		font-size: 14px;
-		color: var(--theme-text-lighter);
+		color: var(--theme-text-muted);
 		white-space: nowrap;
 		margin-right: 0.75rem;
 		padding: 0 10px;
@@ -38,7 +38,7 @@ const { href, icon, target } = Astro.props as Props;
 		color: inherit;
 	}
 	.theme-dark .header-btn .button {
-		color: var(--theme-text-lighter);
+		color: var(--theme-text-muted);
 	}
 	.theme-dark .header-btn .button:hover,
 	.theme-dark .header-btn .button:focus {

--- a/src/components/LeftSidebar/NavGroup.astro
+++ b/src/components/LeftSidebar/NavGroup.astro
@@ -182,12 +182,12 @@ const IconComponent = !isStringIcon ? navGroup.icon : null;
 		:global(.left-icon) {
 			min-width: 16px;
 			min-height: 16px;
-			color: var(--theme-text-lighter);
+			color: var(--theme-text-muted);
 		}
 	}
 
 	:global(:root.theme-dark) .nav-link a[aria-current='page'] {
-		color: hsla(var(--color-base-white), 100%, 1);
+		color: var(--color-white);
 	}
 
 	.nav-group-content {

--- a/src/components/LeftSidebar/NavLink.astro
+++ b/src/components/LeftSidebar/NavLink.astro
@@ -28,7 +28,7 @@ const IconComponent = !isStringIcon ? navItem.icon : null;
 	.left-icon {
 		min-width: 16px;
 		min-height: 16px;
-		color: var(--theme-text-lighter);
+		color: var(--theme-text-muted);
 	}
 
 	.nav-link a {
@@ -36,7 +36,7 @@ const IconComponent = !isStringIcon ? navItem.icon : null;
 		padding: 0.5rem 0.75rem;
 		font: inherit;
 		font-size: 14px;
-		color: var(--theme-text-lighter);
+		color: var(--theme-text-muted);
 		text-decoration: none;
 		display: flex;
 		gap: 8px;

--- a/src/components/MergeQueueCalculator/LogSliderInput.tsx
+++ b/src/components/MergeQueueCalculator/LogSliderInput.tsx
@@ -37,7 +37,7 @@ export default function LogSliderInput({
     <label style={{ display: 'flex', flexDirection: 'column', gap: 8, height: '100%' }}>
       <span style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         {label}
-        <span style={{ color: 'var(--theme-text-light)' }}>
+        <span style={{ color: 'var(--theme-text-secondary)' }}>
           {value}
           {unit}
         </span>

--- a/src/components/MergeQueueCalculator/MergeQueueCalculator.scss
+++ b/src/components/MergeQueueCalculator/MergeQueueCalculator.scss
@@ -38,7 +38,7 @@
 		padding: 0;
 		margin: 0;
 		padding-left: 20px;
-		border: 1px solid var(--theme-text-lighter);
+		border: 1px solid var(--theme-text-muted);
 		border-radius: 4px;
 	}
 
@@ -64,10 +64,10 @@
 		position: relative;
 		cursor: pointer;
 		border: none;
-		border-left: 1px solid var(--theme-text-lighter);
+		border-left: 1px solid var(--theme-text-muted);
 		width: 20px;
 		text-align: center;
-		color: var(--theme-text-light);
+		color: var(--theme-text-secondary);
 		font-size: 13px;
 		line-height: 1.7;
 		-webkit-transform: translateX(-100%);
@@ -83,7 +83,7 @@
 		position: absolute;
 		height: 50%;
 		top: 0;
-		border-bottom: 1px solid var(--theme-text-lighter);
+		border-bottom: 1px solid var(--theme-text-muted);
 	}
 
 	.input-number-button.input-number-down {

--- a/src/components/MergeQueueCalculator/MergeQueueCalculator.tsx
+++ b/src/components/MergeQueueCalculator/MergeQueueCalculator.tsx
@@ -85,7 +85,7 @@ function MergeQueueCalculator() {
   return (
     <div
       id="calculator"
-      style={{ padding: 16, border: '1px solid var(--theme-text-lighter)', borderRadius: 4 }}
+      style={{ padding: 16, border: '1px solid var(--theme-text-muted)', borderRadius: 4 }}
     >
       <div>
         <div>

--- a/src/components/MergeQueueCalculator/SliderInput.tsx
+++ b/src/components/MergeQueueCalculator/SliderInput.tsx
@@ -23,7 +23,7 @@ export default function SliderInput({
     <label style={{ display: 'flex', flexDirection: 'column', gap: 8, height: '100%' }}>
       <span style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         {label}
-        <span style={{ color: 'var(--theme-text-light)' }}>
+        <span style={{ color: 'var(--theme-text-secondary)' }}>
           {value}
           {unit}
         </span>

--- a/src/components/MergeQueueCalculator/Stat.tsx
+++ b/src/components/MergeQueueCalculator/Stat.tsx
@@ -29,10 +29,10 @@ export default function Stat({
         <h3 style={{ margin: 0, display: 'flex', alignItems: 'baseline', gap: 6 }}>
           {stat ?? 0}
           {unit && (
-            <span style={{ fontSize: '0.6em', color: 'var(--theme-text-light)' }}>{unit}</span>
+            <span style={{ fontSize: '0.6em', color: 'var(--theme-text-secondary)' }}>{unit}</span>
           )}
         </h3>
-        <span style={{ color: 'var(--theme-text-light)' }}>{helperText}</span>
+        <span style={{ color: 'var(--theme-text-secondary)' }}>{helperText}</span>
       </div>
       {typeof indicatorPct === 'number' && (
         <div className="meter" title={`${Math.round(indicatorPct)}%`}>
@@ -40,7 +40,7 @@ export default function Stat({
             className="meter-fill"
             style={{
               width: `${Math.max(0, Math.min(100, indicatorPct))}%`,
-              background: indicatorColor || 'var(--theme-text-light)',
+              background: indicatorColor || 'var(--theme-text-secondary)',
             }}
           />
         </div>

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -27,7 +27,7 @@
 }
 
 .close {
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   float: right;
   font-size: 28px;
   font-weight: bold;

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -50,7 +50,7 @@ const suppressTitle = content.suppressTitle;
 
 	.content-title :global(.scope) {
 		font-weight: 300;
-		color: var(--theme-text-lighter);
+		color: var(--theme-text-muted);
 	}
 	.content {
 		padding-top: calc(var(--theme-navbar-height) + var(--doc-padding-block));

--- a/src/components/PageFeedback.astro
+++ b/src/components/PageFeedback.astro
@@ -34,7 +34,7 @@
     margin-top: 2rem;
     padding-top: 1rem;
     font-size: var(--theme-text-sm);
-    color: var(--theme-text-lighter);
+    color: var(--theme-text-muted);
   }
 
   .page-feedback__question {
@@ -55,7 +55,7 @@
     border: 1px solid var(--theme-divider);
     border-radius: 6px;
     background: transparent;
-    color: var(--theme-text-lighter);
+    color: var(--theme-text-muted);
     font-family: var(--font-body);
     font-size: var(--theme-text-xs);
     cursor: pointer;

--- a/src/components/PageMeta.astro
+++ b/src/components/PageMeta.astro
@@ -39,14 +39,14 @@ const editUrl = getEditPath(pathname);
     padding-top: 1.5rem;
     border-top: 1px solid var(--theme-divider);
     font-size: var(--theme-text-sm);
-    color: var(--theme-text-lighter);
+    color: var(--theme-text-muted);
   }
 
   .page-meta__edit {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
-    color: var(--theme-text-lighter);
+    color: var(--theme-text-muted);
     text-decoration: none;
     transition: color 0.15s ease;
   }

--- a/src/components/RightSidebar/TableOfContents.css
+++ b/src/components/RightSidebar/TableOfContents.css
@@ -19,8 +19,8 @@
   transform: rotate(0);
   transition: transform 0.15s ease;
   vertical-align: middle;
-  fill: var(--theme-text-light);
-  stroke: var(--theme-text-light);
+  fill: var(--theme-text-secondary);
+  stroke: var(--theme-text-secondary);
 }
 
 .toc-mobile-container[data-open] .toc-toggle svg {

--- a/src/components/ScrollToTop.astro
+++ b/src/components/ScrollToTop.astro
@@ -22,7 +22,7 @@
     border-radius: 50%;
     border: 1px solid var(--theme-divider);
     background: var(--theme-bg);
-    color: var(--theme-text-lighter);
+    color: var(--theme-text-muted);
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -42,7 +42,7 @@
   .scroll-to-top:hover {
     background: var(--theme-bg-hover);
     color: var(--theme-text);
-    border-color: var(--theme-text-lighter);
+    border-color: var(--theme-text-muted);
   }
 
   .scroll-to-top:focus-visible {

--- a/src/components/Search/Results.tsx
+++ b/src/components/Search/Results.tsx
@@ -69,7 +69,7 @@ function PageResult({ entry, query, onHover, onNavigate, active }: PageResultPro
               width: '100%',
               margin: 0,
               fontSize: '0.875rem',
-              color: 'var(--theme-text-light)',
+              color: 'var(--theme-text-secondary)',
             }}
           >
             {breadcrumb}
@@ -154,7 +154,7 @@ export default function Results({ results, query, onNavigate }: ResultsProps) {
         style={{
           padding: '32px 16px',
           textAlign: 'center',
-          color: 'var(--theme-text-light)',
+          color: 'var(--theme-text-secondary)',
           fontSize: '0.9375rem',
         }}
       >

--- a/src/components/Search/Search.astro
+++ b/src/components/Search/Search.astro
@@ -43,7 +43,7 @@ import SearchBar from './SearchBar';
 		gap: 0.25em;
 		white-space: nowrap;
 		font-size: 14px;
-		color: var(--theme-text-lighter);
+		color: var(--theme-text-muted);
 		width: 5rem;
 	}
 

--- a/src/components/Search/Search.scss
+++ b/src/components/Search/Search.scss
@@ -27,14 +27,14 @@
 	}
 
 	.result-description {
-		color: var(--theme-text-lighter);
+		color: var(--theme-text-muted);
 		font-weight: 300;
 		text-decoration: none !important;
 	}
 
 	.table-of-content {
 		a {
-			color: var(--theme-text-lighter);
+			color: var(--theme-text-muted);
 			transition: color 0.115s;
 
 			&:hover {

--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -63,7 +63,7 @@ function RecentSearches({ onSelect }: { onSelect: (q: string) => void }) {
         style={{
           padding: '4px 16px',
           fontSize: '0.75rem',
-          color: 'var(--theme-text-light)',
+          color: 'var(--theme-text-secondary)',
           textTransform: 'uppercase',
           letterSpacing: '0.05em',
         }}
@@ -284,7 +284,7 @@ export default function SearchBar() {
             style={{
               padding: '2px 16px 6px',
               fontSize: '0.75rem',
-              color: 'var(--theme-text-light)',
+              color: 'var(--theme-text-secondary)',
             }}
           >
             {searchResults.length} result{searchResults.length !== 1 ? 's' : ''}

--- a/src/content/docs/merge-queue.mdx
+++ b/src/content/docs/merge-queue.mdx
@@ -51,7 +51,7 @@ export const No = ({children}) => (
     }}>3-5x</div>
     <div style={{
       fontSize: '0.9rem',
-      color: 'var(--theme-text-light)'
+      color: 'var(--theme-text-secondary)'
     }}>merge throughput</div>
   </div>
   <div style={{
@@ -68,7 +68,7 @@ export const No = ({children}) => (
     }}>60-90%</div>
     <div style={{
       fontSize: '0.9rem',
-      color: 'var(--theme-text-light)'
+      color: 'var(--theme-text-secondary)'
     }}>CI cost reduction</div>
   </div>
   <div style={{
@@ -85,7 +85,7 @@ export const No = ({children}) => (
     }}>Zero</div>
     <div style={{
       fontSize: '0.9rem',
-      color: 'var(--theme-text-light)'
+      color: 'var(--theme-text-secondary)'
     }}>broken builds</div>
   </div>
 </div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -54,7 +54,7 @@ import Header from '../components/Header/Header.astro';
 
 			.error-description {
 				font-size: var(--theme-text-base);
-				color: var(--theme-text-lighter);
+				color: var(--theme-text-muted);
 				margin: 0 0 2rem;
 				line-height: 1.6;
 			}
@@ -71,7 +71,7 @@ import Header from '../components/Header/Header.astro';
 				border: 1px solid var(--theme-divider);
 				border-radius: 8px;
 				background: var(--theme-bg);
-				color: var(--theme-text-lighter);
+				color: var(--theme-text-muted);
 				font-size: var(--theme-text-sm);
 				cursor: pointer;
 				transition: border-color 0.15s ease, box-shadow 0.15s ease;
@@ -100,7 +100,7 @@ import Header from '../components/Header/Header.astro';
 				border: 1px solid var(--theme-shade-subtle);
 				border-radius: 4px;
 				background: var(--theme-bg-offset);
-				color: var(--theme-text-lighter);
+				color: var(--theme-text-muted);
 				line-height: 1;
 			}
 

--- a/src/pages/changelog/[slug].astro
+++ b/src/pages/changelog/[slug].astro
@@ -149,7 +149,7 @@ const { title, description, date, tags } = entry.data;
   .lead {
     font-size: 1.25rem;
     line-height: 1.6;
-    color: var(--theme-text-light);
+    color: var(--theme-text-secondary);
     margin: 0;
     font-weight: 400;
   }
@@ -244,7 +244,7 @@ const { title, description, date, tags } = entry.data;
     padding: 1rem 1.25rem;
     border-left: 4px solid var(--theme-border);
     background: var(--theme-bg-offset);
-    color: var(--theme-text-light);
+    color: var(--theme-text-secondary);
     font-style: italic;
   }
 

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -273,7 +273,7 @@ const description = 'Latest product updates from Mergify.';
       max-width: 400px;
     }
     .lead {
-      color: var(--theme-text-light);
+      color: var(--theme-text-secondary);
       margin: 0;
       font-size: 1rem;
     }
@@ -508,7 +508,7 @@ const description = 'Latest product updates from Mergify.';
   .month-heading {
     font-size: 1.125rem;
     font-weight: 600;
-    color: var(--theme-text-light);
+    color: var(--theme-text-secondary);
     margin: 0 0 1rem 0;
     padding-left: 1.25rem;
     position: relative;
@@ -521,7 +521,7 @@ const description = 'Latest product updates from Mergify.';
   .entry-release + .entry { border-top: 1px solid var(--theme-border-color); }
   .entry-release .release-title { display: inline-flex; align-items: center; gap: .4rem; font-weight: 600; font-size: 1rem; }
   .entry-release .release-icon { width: 1rem; height: 1rem; color: var(--section-merge-queue-accent, var(--theme-accent)); }
-  .entry-release .release-summary { margin: .35rem 0 0; font-size: .85rem; color: var(--theme-text-light); }
+  .entry-release .release-summary { margin: .35rem 0 0; font-size: .85rem; color: var(--theme-text-secondary); }
   .tag-enterprise {
     background: #111;
     color: #fff;
@@ -530,7 +530,7 @@ const description = 'Latest product updates from Mergify.';
   .row { display: grid; gap: .9rem; align-items: flex-start; grid-template-columns: 1fr; }
   @media (min-width: 50em) { .row { grid-template-columns: 10rem 1fr auto; } }
   .date-tags { display: flex; flex-direction: column; gap: .5rem; align-items: flex-start; }
-  .date { font-size: .65rem; font-weight: 600; letter-spacing: .5px; text-transform: uppercase; color: var(--theme-text-lighter); background: var(--theme-bg-offset); padding: 3px 8px; border-radius: 6px; width: fit-content; }
+  .date { font-size: .65rem; font-weight: 600; letter-spacing: .5px; text-transform: uppercase; color: var(--theme-text-muted); background: var(--theme-bg-offset); padding: 3px 8px; border-radius: 6px; width: fit-content; }
   .tag-list { list-style: none; display: flex; flex-direction: column; gap: .4rem; padding: 0; margin: 0; }
   .tag-list li { margin: 0; padding: 0; display: block; line-height: 1; }
   .tag { background: var(--theme-bg-offset); color: var(--theme-text); font-size: .6rem; padding: 4px 10px; border-radius: 999px; text-transform: uppercase; letter-spacing: .5px; font-weight: 600; display: inline-block; line-height: 1; overflow-wrap: anywhere; border: 1px solid var(--theme-border-color); }
@@ -572,7 +572,7 @@ const description = 'Latest product updates from Mergify.';
   .title { font-size: 1.05rem; margin: 0 0 .4rem; line-height: 1.3; }
   .title a { text-decoration: none; color: var(--theme-text); }
   .title a:hover { text-decoration: underline; color: var(--theme-text-secondary); }
-  .summary { font-size: .85rem; margin: .1rem 0 0; color: var(--theme-text-light); line-height: 1.5; }
+  .summary { font-size: .85rem; margin: .1rem 0 0; color: var(--theme-text-secondary); line-height: 1.5; }
   .more-col { align-self: center; justify-self: start; }
   .read-more { display: inline-flex; align-items: center; gap: .35rem; font-size: .8rem; text-decoration: none; font-weight: 700; padding: .4rem .7rem; border-radius: .6rem; background: var(--theme-bg-offset); color: var(--theme-text); transition: background .15s, color .15s, transform .15s; box-shadow: 0 1px 2px rgba(0,0,0,.05); }
   .read-more .read-icon { transition: transform .15s ease; }

--- a/src/styles/api-reference.css
+++ b/src/styles/api-reference.css
@@ -9,7 +9,7 @@
 .api-reference {
   --api-border: var(--theme-border-color, #e2e8f0);
   --api-radius: 8px;
-  --api-bg-subtle: hsl(var(--color-base-gray), 96%);
+  --api-bg-subtle: var(--theme-bg-offset);
 }
 
 /* Reset global .content details styles that conflict with our details elements */
@@ -38,9 +38,7 @@
   border-bottom: none;
 }
 
-:root.theme-dark .api-reference {
-  --api-bg-subtle: hsl(var(--color-base-gray), 14%);
-}
+/* --api-bg-subtle resolves through --theme-bg-offset which remaps in dark mode */
 
 .api-label {
   display: block;
@@ -48,7 +46,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   margin-bottom: 0.5rem;
 }
 
@@ -160,7 +158,7 @@
 
 .endpoint-description {
   font-size: 0.875rem;
-  color: var(--theme-text-light);
+  color: var(--theme-text-secondary);
   margin: 0 0 0.75rem;
   line-height: 1.6;
 }
@@ -213,9 +211,9 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  background: hsla(var(--color-base-orange), 50%, 0.12);
-  color: hsl(var(--color-base-orange), 40%);
-  border: 1px solid hsla(var(--color-base-orange), 50%, 0.25);
+  background: color-mix(in srgb, var(--color-orange-400) 20%, transparent);
+  color: var(--color-orange-700);
+  border: 1px solid color-mix(in srgb, var(--color-orange-400) 35%, transparent);
 }
 
 .endpoint-auth {
@@ -238,7 +236,7 @@
   font-weight: 500;
   background: var(--api-bg-subtle);
   border: 1px solid var(--api-border);
-  color: var(--theme-text-light);
+  color: var(--theme-text-secondary);
 }
 
 .auth-badge svg {
@@ -271,7 +269,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   margin-bottom: 0.5rem;
 }
 
@@ -287,7 +285,7 @@
 
 .param-row {
   padding: 0.5rem 0;
-  border-bottom: 1px solid hsla(var(--color-base-gray), 90%, 0.5);
+  border-bottom: 1px solid var(--theme-divider);
 }
 
 .param-row:last-child {
@@ -310,7 +308,7 @@
 
 .param-description {
   font-size: 0.8rem;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   margin: 0.2rem 0 0;
   line-height: 1.5;
 }
@@ -318,7 +316,7 @@
 .param-constraints {
   font-size: 0.75rem;
   font-family: var(--font-mono);
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   margin: 0.15rem 0 0;
   opacity: 0.8;
 }
@@ -338,7 +336,7 @@
 
 .schema-property {
   padding: 0.5rem 0;
-  border-bottom: 1px solid hsla(var(--color-base-gray), 90%, 0.5);
+  border-bottom: 1px solid var(--theme-divider);
 }
 
 .schema-property:last-child {
@@ -371,14 +369,14 @@
 .schema-property-name.schema-additional {
   font-style: italic;
   font-weight: 400;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
 }
 
 .schema-type-badge {
   font-family: var(--font-mono);
   font-size: 0.75rem;
   color: var(--theme-code-inline-text, #b83280);
-  background: var(--theme-code-inline-bg, hsl(var(--color-base-gray), 95%));
+  background: var(--theme-code-inline-bg);
   padding: 0.1rem 0.4rem;
   border-radius: 3px;
 }
@@ -388,12 +386,12 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: hsl(var(--color-base-orange), 40%);
+  color: var(--color-orange-700);
 }
 
 .schema-property-description {
   font-size: 0.8rem;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   margin: 0.2rem 0 0;
   line-height: 1.5;
 }
@@ -401,7 +399,7 @@
 /* Nested / expandable schemas */
 
 .schema-expandable {
-  border-bottom: 1px solid hsla(var(--color-base-gray), 90%, 0.5);
+  border-bottom: 1px solid var(--theme-divider);
 }
 
 .schema-expandable:last-child {
@@ -411,7 +409,7 @@
 .schema-chevron {
   transition: transform 0.15s;
   flex-shrink: 0;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
 }
 
 details[open] > summary > .schema-chevron,
@@ -428,14 +426,14 @@ details[open] > .schema-property-header > .schema-chevron {
 
 .schema-enum {
   font-size: 0.8rem;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   margin-top: 0.2rem;
 }
 
 .schema-constraints {
   font-size: 0.75rem;
   font-family: var(--font-mono);
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   margin-top: 0.15rem;
   opacity: 0.8;
 }
@@ -459,7 +457,7 @@ details[open] > .schema-property-header > .schema-chevron {
 
 .schema-circular {
   font-size: 0.8rem;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   font-style: italic;
   padding: 0.25rem 0;
 }
@@ -472,7 +470,7 @@ details[open] > .schema-property-header > .schema-chevron {
 
 .schema-discriminator {
   font-size: 0.8rem;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   margin-bottom: 0.5rem;
 }
 
@@ -502,7 +500,7 @@ details[open] > .schema-property-header > .schema-chevron {
 }
 
 .schema-variant-arrow {
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
 }
 
 .schema-type-ref {
@@ -513,13 +511,13 @@ details[open] > .schema-property-header > .schema-chevron {
 
 .schema-variant-more {
   font-size: 0.8rem;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   font-style: italic;
   padding: 0.2rem 0;
 }
 
 .schema-variant-expandable {
-  border: 1px solid hsla(var(--color-base-gray), 90%, 0.3);
+  border: 1px solid var(--theme-divider);
   border-radius: 6px;
   margin-bottom: 0.35rem;
   padding: 0 0.75rem;
@@ -556,7 +554,7 @@ details[open] > .schema-property-header > .schema-chevron {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   display: block;
   margin-bottom: 0.25rem;
 }
@@ -572,7 +570,7 @@ details[open] > .schema-property-header > .schema-chevron {
 }
 
 .response-item {
-  border: 1px solid hsla(var(--color-base-gray), 90%, 0.3);
+  border: 1px solid var(--theme-divider);
   border-radius: 6px;
   padding: 0 0.75rem;
 }
@@ -600,27 +598,27 @@ details[open] > .schema-property-header > .schema-chevron {
 }
 
 .response-2xx {
-  background: hsla(var(--color-base-green), 50%, 0.12);
-  color: hsl(var(--color-base-green), 32%);
+  background: color-mix(in srgb, var(--color-teal-400) 20%, transparent);
+  color: var(--color-teal-700);
 }
 
 .response-3xx {
-  background: hsla(var(--color-base-blue), 50%, 0.12);
-  color: hsl(var(--color-base-blue), 35%);
+  background: color-mix(in srgb, var(--color-blue-400) 20%, transparent);
+  color: var(--color-blue-700);
 }
 
 .response-4xx {
-  background: hsla(var(--color-base-yellow), 50%, 0.12);
-  color: hsl(var(--color-base-yellow), 35%);
+  background: color-mix(in srgb, var(--color-orange-400) 20%, transparent);
+  color: var(--color-orange-700);
 }
 
 .response-5xx {
-  background: hsla(var(--color-base-red), 50%, 0.12);
-  color: hsl(var(--color-base-red), 38%);
+  background: color-mix(in srgb, var(--color-coral-400) 20%, transparent);
+  color: var(--color-coral-700);
 }
 
 .response-description {
-  color: var(--theme-text-light);
+  color: var(--theme-text-secondary);
 }
 
 .response-body {
@@ -634,7 +632,7 @@ details[open] > .schema-property-header > .schema-chevron {
 .response-example summary {
   font-size: 0.8rem;
   font-weight: 500;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   cursor: pointer;
   padding: 0.25rem 0;
   list-style: none;
@@ -680,7 +678,7 @@ details[open] > .schema-property-header > .schema-chevron {
   gap: 0.35rem;
   font-size: 0.8rem;
   font-weight: 500;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   cursor: pointer;
   padding: 0.25rem 0;
   list-style: none;
@@ -752,7 +750,7 @@ details[open] > .schema-property-header > .schema-chevron {
 .api-section-count {
   font-size: 0.7rem;
   font-weight: 600;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   background: var(--api-bg-subtle);
   border-radius: 10px;
   padding: 0.15rem 0.5rem;
@@ -761,7 +759,7 @@ details[open] > .schema-property-header > .schema-chevron {
 
 .api-section-description {
   font-size: 0.85rem;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   margin: 0;
   line-height: 1.5;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -162,7 +162,7 @@ nav ul {
   margin-inline-end: calc(-1 * var(--icon-size-x));
   width: var(--icon-size-x);
   height: var(--icon-size-y);
-  color: var(--theme-text-light);
+  color: var(--theme-text-secondary);
   text-decoration: none;
   justify-content: center;
   vertical-align: baseline;
@@ -209,7 +209,7 @@ article > section li > :is(p, pre, .expressive-code, blockquote):not(:first-chil
 
 article > section ::marker {
   font-weight: bold;
-  color: var(--theme-text-light);
+  color: var(--theme-text-secondary);
 }
 
 article > section iframe {
@@ -412,7 +412,7 @@ a.header-link {
   padding-top: 0.4rem;
   padding-bottom: 0.4rem;
   line-height: 1.3;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   text-decoration: none;
   unicode-bidi: plaintext;
 }
@@ -808,7 +808,7 @@ article.content {
   content: counter(h2-section);
   font-weight: 500;
   margin-right: 0.55rem;
-  color: var(--theme-text-lighter);
+  color: var(--theme-text-muted);
   opacity: 0.6;
 }
 
@@ -836,7 +836,7 @@ article.content {
 
 .home-metric-label {
   font-size: var(--text-sm);
-  color: var(--theme-text-light);
+  color: var(--theme-text-secondary);
 }
 
 /* Home page: Problem-solution cards */
@@ -869,7 +869,7 @@ article.content {
 
 .home-problem-desc {
   font-size: var(--text-sm);
-  color: var(--theme-text-light);
+  color: var(--theme-text-secondary);
   margin-bottom: 1rem;
   line-height: 1.5;
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -72,64 +72,11 @@
   --text-2xl: 1.5rem;
   --text-3xl: 1.875rem;
   --text-4xl: 2rem;
-
-  /*
-		Variables with --color-base prefix define
-		the hue, and saturation values to be used for
-		hsla colors.
-
-		Example:
-		--color-base-{color}: {hue}, {saturation};
-	*/
-
-  --color-base-white: 0, 0%;
-  --color-base-black: 240, 100%;
-  --color-base-gray: 250, 14%;
-  --color-base-blue: 202, 65%;
-  --color-base-blue-dark: 202, 72%;
-  --color-base-teal: 180, 80%;
-  --color-base-green: 158, 79%;
-  --color-base-orange: 22, 100%;
-  --color-base-red: 351, 100%;
-  --color-base-yellow: 41, 100%;
-
-  /*
-		Color palettes are made using --color-base 
-		variables, along with a lightness value to
-		define different variants.
-	*/
-
-  --color-gray-5: var(--color-base-gray), 5%;
-  --color-gray-10: var(--color-base-gray), 10%;
-  --color-gray-20: var(--color-base-gray), 20%;
-  --color-gray-30: var(--color-base-gray), 30%;
-  --color-gray-40: var(--color-base-gray), 40%;
-  --color-gray-50: var(--color-base-gray), 50%;
-  --color-gray-60: var(--color-base-gray), 60%;
-  --color-gray-70: var(--color-base-gray), 70%;
-  --color-gray-80: var(--color-base-gray), 80%;
-  --color-gray-90: var(--color-base-gray), 90%;
-  --color-gray-95: var(--color-base-gray), 95%;
-
-  --color-blue: var(--color-base-blue), 59%;
-  --color-blue-dark: var(--color-base-blue-dark), 23%;
-  --color-green: var(--color-base-green), 42%;
-  --color-orange: var(--color-base-orange), 50%;
-  --color-red: var(--color-base-red), 54%;
-  --color-yellow: var(--color-base-yellow), 59%;
-
-  --color-mergify-blue: #53a9db;
-  --color-mergify-blue-light: #ddeef8;
-  --color-mergify-blue-darker: #237caf;
-  --color-mergify-blue-dark: #113c55;
 }
 
 /* -----------------------------------------------------------------------
-   Semantic tokens. Three :root, ::backdrop blocks share this selector:
-   1. Sizing/font block above (line 4): stable, not remapped per mode.
-   2. Semantic color tokens (this block): consume --color-* primitives.
-   3. Chakra legacy block below (line 199): deleted in Phase 3.
-   Dark-mode overrides for #2 follow in :root.theme-dark.
+   Semantic tokens. Consume primitives from tokens.css.
+   Dark-mode overrides follow in :root.theme-dark below.
    ----------------------------------------------------------------------- */
 :root,
 ::backdrop {
@@ -139,9 +86,6 @@
   --theme-text: var(--color-gray-900);
   --theme-text-secondary: var(--color-gray-700);
   --theme-text-muted: var(--color-gray-500);
-  /* Legacy aliases — kept until Phase 4 sweeps consumers, then deleted. */
-  --theme-text-light: var(--color-gray-700);
-  --theme-text-lighter: var(--color-gray-500);
 
   /* Surfaces */
   --theme-bg: var(--color-gray-50);
@@ -213,9 +157,6 @@
   --theme-text: var(--color-gray-50);
   --theme-text-secondary: var(--color-gray-300);
   --theme-text-muted: var(--color-gray-400);
-  /* Legacy aliases — kept until Phase 4 sweeps consumers, then deleted. */
-  --theme-text-light: var(--color-gray-300);
-  --theme-text-lighter: var(--color-gray-400);
 
   /* Surfaces */
   /* Preserved hex: docs-specific dark surface, intentionally NOT mapped to


### PR DESCRIPTION
4.4a: Migrate all remaining --theme-text-light → --theme-text-secondary and
--theme-text-lighter → --theme-text-muted across 25 files (api-reference.css,
index.css, components, pages, changelog pages, merge-queue.mdx, astro.config.ts).
Also migrate --color-base-* consumers: Aside.astro refactored from HSLA ramp
to direct product palette tokens, NavGroup.astro and api-reference.css updated.

4.4b: Delete the HSLA --color-base-* block, HSLA lightness-suffix ramps,
--color-mergify-blue* definitions, and legacy --theme-text-light/lighter aliases
from both light-mode and dark-mode blocks in theme.css.

Depends-On: #11330