### PR TITLE
fix(design): migrate orphan --theme-dim* and --theme-text-accent refs

### DIFF
--- a/src/components/Header/SidebarToggle.css
+++ b/src/components/Header/SidebarToggle.css
@@ -5,7 +5,7 @@
 }
 
 .mobile-sidebar-toggle #menu-toggle {
-  --background-color-default: var(--theme-dim-lighter);
+  --background-color-default: var(--theme-divider);
   --text-color-default: var(--text-color-hocus);
   --border-color-default: var(--border-color-hocus);
 }

--- a/src/components/ScrollToTop.astro
+++ b/src/components/ScrollToTop.astro
@@ -46,7 +46,7 @@
   }
 
   .scroll-to-top:focus-visible {
-    outline: 2px solid var(--theme-text-accent);
+    outline: 2px solid var(--theme-link);
     outline-offset: 2px;
   }
 

--- a/src/components/Search/Search.astro
+++ b/src/components/Search/Search.astro
@@ -35,7 +35,7 @@ import SearchBar from './SearchBar';
 	/** Style search header button */
 	:global(#docsearch-search-button) {
 		background-color: var(--theme-bg-content);
-		border: 1px solid var(--theme-dim-lighter);
+		border: 1px solid var(--theme-divider);
 		border-radius: 0.5rem;
 		position: relative;
 		display: flex;
@@ -66,7 +66,7 @@ import SearchBar from './SearchBar';
 		letter-spacing: 0.125rem;
 		line-height: 14px;
 		pointer-events: none;
-		border-color: var(--theme-dim-lighter);
+		border-color: var(--theme-divider);
 		border-style: solid;
 		border-width: 1px;
 		border-radius: 0.25rem;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -11,7 +11,7 @@
 
 /* Firefox */
 * {
-  scrollbar-color: var(--theme-dim-light) transparent;
+  scrollbar-color: var(--theme-border) transparent;
 }
 
 /* Webkit */
@@ -27,7 +27,7 @@ body::-webkit-scrollbar-track {
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: var(--theme-dim-light);
+  background-color: var(--theme-border);
   border: 4px solid transparent;
   background-clip: content-box;
   border-radius: 10px;
@@ -223,7 +223,7 @@ article > section iframe {
 
 a > code {
   position: relative;
-  color: var(--theme-text-accent);
+  color: var(--theme-link);
   text-underline-offset: var(--padding-block);
 }
 


### PR DESCRIPTION
Phase 4's primitive removal dropped --theme-dim, --theme-dim-light,
--theme-dim-lighter, and --theme-text-accent from theme.css's semantic
layer, but a handful of consumers still referenced these tokens.
With the definitions gone, the references would silently fall back to
their initial values (transparent / inherit), causing invisible
scrollbars, broken focus outlines, and lost border affordances.

Migrate the orphan references to live semantic tokens:
- --theme-dim-light  → --theme-border  (scrollbar tones)
- --theme-dim-lighter → --theme-divider (subtle borders)
- --theme-text-accent → --theme-link   (code-in-link, focus outline)

Affected files:
- src/styles/index.css
- src/components/Search/Search.astro
- src/components/ScrollToTop.astro
- src/components/Header/SidebarToggle.css

Depends-On: #11331