### PR TITLE
fix(design): address Phase 4 code review findings

### DIFF
--- a/src/components/AcademyCallout.astro
+++ b/src/components/AcademyCallout.astro
@@ -28,9 +28,9 @@ const { title = 'Merge Queue Academy', href = 'https://merge-queue.academy/' } =
 
 <style>
   .academy-callout {
-    border-inline-start: 4px solid var(--section-merge-queue-accent);
+    border-inline-start: 4px solid var(--color-teal-700);
     padding: 1rem;
-    background-color: var(--section-merge-queue-accent-bg);
+    background-color: color-mix(in srgb, var(--color-teal-400) 25%, transparent);
     outline: 1px solid transparent;
     margin: 1rem 0;
   }
@@ -42,7 +42,7 @@ const { title = 'Merge Queue Academy', href = 'https://merge-queue.academy/' } =
     letter-spacing: 0.05em;
     font-weight: bold;
     text-transform: uppercase;
-    color: var(--section-merge-queue-accent);
+    color: var(--color-teal-700);
   }
 
   .icon svg {
@@ -54,7 +54,7 @@ const { title = 'Merge Queue Academy', href = 'https://merge-queue.academy/' } =
 
   .academy-callout :global(a),
   .academy-callout :global(a > code:not([class*='language'])) {
-    color: var(--section-merge-queue-accent);
+    color: var(--color-teal-700);
   }
 
   .academy-callout :global(p),

--- a/src/content/docs/merge-queue.mdx
+++ b/src/content/docs/merge-queue.mdx
@@ -41,13 +41,13 @@ export const No = ({children}) => (
     flex: '1 1 200px',
     padding: '1rem 1.25rem',
     borderRadius: '8px',
-    background: 'var(--section-merge-queue-accent-bg)',
-    borderLeft: '4px solid var(--section-merge-queue-accent)'
+    background: 'color-mix(in srgb, var(--color-teal-400) 25%, transparent)',
+    borderLeft: '4px solid var(--color-teal-700)'
   }}>
     <div style={{
       fontSize: '1.5rem',
       fontWeight: 'bold',
-      color: 'var(--section-merge-queue-accent)'
+      color: 'var(--color-teal-700)'
     }}>3-5x</div>
     <div style={{
       fontSize: '0.9rem',
@@ -58,13 +58,13 @@ export const No = ({children}) => (
     flex: '1 1 200px',
     padding: '1rem 1.25rem',
     borderRadius: '8px',
-    background: 'var(--section-merge-queue-accent-bg)',
-    borderLeft: '4px solid var(--section-merge-queue-accent)'
+    background: 'color-mix(in srgb, var(--color-teal-400) 25%, transparent)',
+    borderLeft: '4px solid var(--color-teal-700)'
   }}>
     <div style={{
       fontSize: '1.5rem',
       fontWeight: 'bold',
-      color: 'var(--section-merge-queue-accent)'
+      color: 'var(--color-teal-700)'
     }}>60-90%</div>
     <div style={{
       fontSize: '0.9rem',
@@ -75,13 +75,13 @@ export const No = ({children}) => (
     flex: '1 1 200px',
     padding: '1rem 1.25rem',
     borderRadius: '8px',
-    background: 'var(--section-merge-queue-accent-bg)',
-    borderLeft: '4px solid var(--section-merge-queue-accent)'
+    background: 'color-mix(in srgb, var(--color-teal-400) 25%, transparent)',
+    borderLeft: '4px solid var(--color-teal-700)'
   }}>
     <div style={{
       fontSize: '1.5rem',
       fontWeight: 'bold',
-      color: 'var(--section-merge-queue-accent)'
+      color: 'var(--color-teal-700)'
     }}>Zero</div>
     <div style={{
       fontSize: '0.9rem',

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -407,71 +407,71 @@ const description = 'Latest product updates from Mergify.';
 
   /* Product-specific pill colors */
   .pill[data-tag="Workflow Automation"] {
-    background: var(--section-workflow-accent-bg);
-    color: var(--section-workflow-accent);
-    border-color: var(--section-workflow-accent);
+    background: color-mix(in srgb, var(--color-rose-400) 25%, transparent);
+    color: var(--color-rose-700);
+    border-color: var(--color-rose-700);
   }
 
   .pill[data-tag="Workflow Automation"]:hover {
-    background: var(--section-workflow-accent);
+    background: var(--color-rose-700);
     color: #fff;
   }
 
   .pill[data-tag="Workflow Automation"].active {
-    background: var(--section-workflow-accent);
+    background: var(--color-rose-700);
     color: #fff;
-    border-color: var(--section-workflow-accent);
+    border-color: var(--color-rose-700);
   }
 
   .pill[data-tag="Merge Queue"] {
-    background: var(--section-merge-queue-accent-bg);
-    color: var(--section-merge-queue-accent);
-    border-color: var(--section-merge-queue-accent);
+    background: color-mix(in srgb, var(--color-teal-400) 25%, transparent);
+    color: var(--color-teal-700);
+    border-color: var(--color-teal-700);
   }
 
   .pill[data-tag="Merge Queue"]:hover {
-    background: var(--section-merge-queue-accent);
+    background: var(--color-teal-700);
     color: #fff;
   }
 
   .pill[data-tag="Merge Queue"].active {
-    background: var(--section-merge-queue-accent);
+    background: var(--color-teal-700);
     color: #fff;
-    border-color: var(--section-merge-queue-accent);
+    border-color: var(--color-teal-700);
   }
 
   .pill[data-tag="CI Insights"] {
-    background: var(--section-ci-insights-accent-bg);
-    color: var(--section-ci-insights-accent);
-    border-color: var(--section-ci-insights-accent);
+    background: color-mix(in srgb, var(--color-purple-400) 25%, transparent);
+    color: var(--color-purple-700);
+    border-color: var(--color-purple-700);
   }
 
   .pill[data-tag="CI Insights"]:hover {
-    background: var(--section-ci-insights-accent);
+    background: var(--color-purple-700);
     color: #fff;
   }
 
   .pill[data-tag="CI Insights"].active {
-    background: var(--section-ci-insights-accent);
+    background: var(--color-purple-700);
     color: #fff;
-    border-color: var(--section-ci-insights-accent);
+    border-color: var(--color-purple-700);
   }
 
   .pill[data-tag="Merge Protections"] {
-    background: var(--section-merge-protections-accent-bg);
-    color: var(--section-merge-protections-accent);
-    border-color: var(--section-merge-protections-accent);
+    background: color-mix(in srgb, var(--color-blue-400) 25%, transparent);
+    color: var(--color-blue-700);
+    border-color: var(--color-blue-700);
   }
 
   .pill[data-tag="Merge Protections"]:hover {
-    background: var(--section-merge-protections-accent);
+    background: var(--color-blue-700);
     color: #fff;
   }
 
   .pill[data-tag="Merge Protections"].active {
-    background: var(--section-merge-protections-accent);
+    background: var(--color-blue-700);
     color: #fff;
-    border-color: var(--section-merge-protections-accent);
+    border-color: var(--color-blue-700);
   }
   /* Deprecations category (yellow) */
   .pill[data-tag="Deprecations"] {
@@ -517,10 +517,10 @@ const description = 'Latest product updates from Mergify.';
   .entry { position: relative; margin: 0; padding: 1.25rem 0 1.25rem 1.25rem; border-bottom: 1px solid var(--theme-border-color); }
   .entry:last-child { border-bottom: 0; }
   .entry::before { content: ''; position: absolute; left: -6px; top: 1.4rem; width: 10px; height: 10px; background: var(--theme-text-muted); border-radius: 50%; box-shadow: 0 0 0 2px var(--theme-bg); }
-  .entry-release::before { background: var(--section-merge-queue-accent, var(--theme-accent)); box-shadow: 0 0 0 2px var(--theme-bg), 0 0 0 6px rgba(27, 99, 243, 0.15); }
+  .entry-release::before { background: var(--color-teal-700); box-shadow: 0 0 0 2px var(--theme-bg), 0 0 0 6px rgba(27, 99, 243, 0.15); }
   .entry-release + .entry { border-top: 1px solid var(--theme-border-color); }
   .entry-release .release-title { display: inline-flex; align-items: center; gap: .4rem; font-weight: 600; font-size: 1rem; }
-  .entry-release .release-icon { width: 1rem; height: 1rem; color: var(--section-merge-queue-accent, var(--theme-accent)); }
+  .entry-release .release-icon { width: 1rem; height: 1rem; color: var(--color-teal-700); }
   .entry-release .release-summary { margin: .35rem 0 0; font-size: .85rem; color: var(--theme-text-secondary); }
   .tag-enterprise {
     background: #111;
@@ -537,27 +537,27 @@ const description = 'Latest product updates from Mergify.';
 
   /* Product-specific label colors */
   .tag[data-tag="Workflow Automation"] {
-    background: var(--section-workflow-accent-bg);
-    color: var(--section-workflow-accent);
-    border: 1px solid var(--section-workflow-accent);
+    background: color-mix(in srgb, var(--color-rose-400) 25%, transparent);
+    color: var(--color-rose-700);
+    border: 1px solid var(--color-rose-700);
   }
 
   .tag[data-tag="Merge Queue"] {
-    background: var(--section-merge-queue-accent-bg);
-    color: var(--section-merge-queue-accent);
-    border: 1px solid var(--section-merge-queue-accent);
+    background: color-mix(in srgb, var(--color-teal-400) 25%, transparent);
+    color: var(--color-teal-700);
+    border: 1px solid var(--color-teal-700);
   }
 
   .tag[data-tag="CI Insights"] {
-    background: var(--section-ci-insights-accent-bg);
-    color: var(--section-ci-insights-accent);
-    border: 1px solid var(--section-ci-insights-accent);
+    background: color-mix(in srgb, var(--color-purple-400) 25%, transparent);
+    color: var(--color-purple-700);
+    border: 1px solid var(--color-purple-700);
   }
 
   .tag[data-tag="Merge Protections"] {
-    background: var(--section-merge-protections-accent-bg);
-    color: var(--section-merge-protections-accent);
-    border: 1px solid var(--section-merge-protections-accent);
+    background: color-mix(in srgb, var(--color-blue-400) 25%, transparent);
+    color: var(--color-blue-700);
+    border: 1px solid var(--color-blue-700);
   }
   .tag[data-tag="Deprecations"] {
     background: #FEFCBF; /* yellow-100 */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -11,7 +11,7 @@
 
 /* Firefox */
 * {
-  scrollbar-color: var(--theme-border) transparent;
+  scrollbar-color: var(--theme-divider) transparent;
 }
 
 /* Webkit */
@@ -27,7 +27,7 @@ body::-webkit-scrollbar-track {
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: var(--theme-border);
+  background-color: var(--theme-divider);
   border: 4px solid transparent;
   background-clip: content-box;
   border-radius: 10px;
@@ -275,12 +275,8 @@ thead {
   font-family: var(--font-body);
   text-transform: uppercase;
   font-size: small;
-  color: #4a5568;
+  color: var(--theme-text-secondary);
   font-weight: 100;
-}
-
-.theme-dark thead {
-  color: #a0aec0;
 }
 
 table {


### PR DESCRIPTION
- Migrate orphan section-accent references in AcademyCallout, the
  merge-queue inline-style stat cards, and changelog/index.astro to
  direct product palette tokens (teal-700/400, rose-700/400,
  purple-700/400, blue-700/400 with color-mix bg variants). Phase 4's
  collapse of the per-section accent block deleted the named tokens
  these consumers were reading; without this fix they would silently
  render as transparent.

- Replace Chakra-era thead hex literals (#4a5568, #a0aec0) with
  var(--theme-text-secondary). The semantic token already remaps in
  dark mode so the .theme-dark override block becomes redundant.

- Use var(--theme-divider) for the scrollbar thumb and Firefox track
  color instead of var(--theme-border). The previous mapping was a
  visible regression in dark mode where --theme-border resolves to
  gray-700 (medium dark gray, very visible) rather than the original
  near-invisible scrollbar tone.

Depends-On: #11332