### PR TITLE
fix(layout): remove left-sidebar rounded scoop

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -101,16 +101,6 @@ const canonicalURL = new URL(Astro.url.pathname.replace(/([^/])$/, '$1/'), Astro
 					top: var(--theme-navbar-height);
 					width: var(--theme-left-sidebar-width);
 					background: var(--theme-bg);
-
-					&::after {
-						content: '';
-						position: absolute;
-						top: 0;
-						right: -32px;
-						width: 32px;
-						height: 32px;
-						background: radial-gradient(circle at 100% 100%, var(--theme-bg-content) 32px, var(--theme-bg) 32px);
-					}
 				}
 			}
 


### PR DESCRIPTION
The ::after radial-gradient scoop at the top-right of the left sidebar
created a curved transition between the gray body bg and the white
content area. With Phase 4's navbar redesign — solid white surface plus
soft drop shadow — the scoop conflicts visually with the shadow line and
no longer reads as a deliberate curve. Drop the scoop; the surface
contrast alone defines the boundary.

Depends-On: #11333