### PR TITLE
fix(theme): persist dark/light mode across view transitions

### DIFF
--- a/src/components/HeadCommon.astro
+++ b/src/components/HeadCommon.astro
@@ -34,21 +34,31 @@ import '../styles/index.css';
 
 <!-- This is intentionally inlined to avoid FOUC -->
 <script is:inline>
-	const root = document.documentElement;
-	const theme = (() => {
-		if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
-			return localStorage.getItem('theme');
+	const applyTheme = (root) => {
+		const theme = (() => {
+			if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
+				return localStorage.getItem('theme');
+			}
+			if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+				return 'dark';
+			}
+			return 'light';
+		})();
+		if (theme === 'light') {
+			root.classList.remove('theme-dark');
+			root.classList.remove('dark');
+		} else {
+			root.classList.add('theme-dark');
+			root.classList.add('dark');
 		}
-		if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-			return 'dark';
-		}
-		return 'light';
-	})();
-	if (theme === 'light') {
-		root.classList.remove('theme-dark');
-	} else {
-		root.classList.add('theme-dark');
-	}
+	};
+	applyTheme(document.documentElement);
+	// ClientRouter view transitions replace the <html> class attribute with the
+	// server-rendered "initial" value, dropping the theme classes. Re-apply the
+	// theme to the incoming document before the swap to avoid a flash.
+	document.addEventListener('astro:before-swap', (event) => {
+		applyTheme(event.newDocument.documentElement);
+	});
 </script>
 
 <!-- Restore sidebar nav-group open/closed state from localStorage to avoid FOUC.

--- a/src/components/HeadCommon.test.ts
+++ b/src/components/HeadCommon.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as vm from 'node:vm';
+import { describe, expect, test } from 'vitest';
+
+// Extract the FOUC-prevention theme script from HeadCommon.astro so the test
+// exercises the exact code that ships, not a copy.
+function extractThemeScript(): string {
+  const path = fileURLToPath(new URL('./HeadCommon.astro', import.meta.url));
+  const source = readFileSync(path, 'utf-8');
+  const match = source.match(
+    /<!-- This is intentionally inlined to avoid FOUC -->\s*<script is:inline>([\s\S]*?)<\/script>/
+  );
+  if (!match) throw new Error('Could not locate theme init script in HeadCommon.astro');
+  return match[1];
+}
+
+interface FakeRoot {
+  classList: {
+    add: (c: string) => void;
+    remove: (c: string) => void;
+    has: (c: string) => boolean;
+  };
+  classes: Set<string>;
+}
+
+function makeRoot(): FakeRoot {
+  const classes = new Set<string>();
+  return {
+    classes,
+    classList: {
+      add: (c) => classes.add(c),
+      remove: (c) => classes.delete(c),
+      has: (c) => classes.has(c),
+    },
+  };
+}
+
+interface RunOptions {
+  storedTheme: string | null;
+  prefersDark: boolean;
+}
+
+function runScript({ storedTheme, prefersDark }: RunOptions) {
+  const root = makeRoot();
+  const listeners = new Map<string, (event: unknown) => void>();
+  const context: Record<string, unknown> = {
+    document: {
+      documentElement: root,
+      addEventListener: (name: string, fn: (event: unknown) => void) => {
+        listeners.set(name, fn);
+      },
+    },
+    localStorage: {
+      getItem: (k: string) => (k === 'theme' ? storedTheme : null),
+    },
+    window: {
+      matchMedia: () => ({ matches: prefersDark }),
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(extractThemeScript(), context);
+  return { root, listeners };
+}
+
+describe('HeadCommon theme init script', () => {
+  test('applies theme-dark and dark classes when localStorage="dark"', () => {
+    const { root } = runScript({ storedTheme: 'dark', prefersDark: false });
+    expect(root.classList.has('theme-dark')).toBe(true);
+    expect(root.classList.has('dark')).toBe(true);
+  });
+
+  test('removes theme classes when localStorage="light"', () => {
+    const { root } = runScript({ storedTheme: 'light', prefersDark: true });
+    expect(root.classList.has('theme-dark')).toBe(false);
+    expect(root.classList.has('dark')).toBe(false);
+  });
+
+  test('falls back to prefers-color-scheme when localStorage is empty', () => {
+    const { root } = runScript({ storedTheme: null, prefersDark: true });
+    expect(root.classList.has('theme-dark')).toBe(true);
+    expect(root.classList.has('dark')).toBe(true);
+  });
+
+  // Regression test for the bug where ClientRouter view transitions
+  // replaced <html class="initial">, dropping the theme classes — and the
+  // inline script never re-ran to restore them on subsequent navigations.
+  test('reapplies the theme to the incoming document on astro:before-swap', () => {
+    const { listeners } = runScript({ storedTheme: 'dark', prefersDark: false });
+    const handler = listeners.get('astro:before-swap');
+    expect(handler).toBeDefined();
+    const newDocRoot = makeRoot();
+    handler?.({ newDocument: { documentElement: newDocRoot } });
+    expect(newDocRoot.classList.has('theme-dark')).toBe(true);
+    expect(newDocRoot.classList.has('dark')).toBe(true);
+  });
+
+  test('astro:before-swap clears theme classes when user switched to light', () => {
+    const { listeners } = runScript({ storedTheme: 'light', prefersDark: false });
+    const handler = listeners.get('astro:before-swap');
+    const newDocRoot = makeRoot();
+    newDocRoot.classList.add('theme-dark');
+    newDocRoot.classList.add('dark');
+    handler?.({ newDocument: { documentElement: newDocRoot } });
+    expect(newDocRoot.classList.has('theme-dark')).toBe(false);
+    expect(newDocRoot.classList.has('dark')).toBe(false);
+  });
+});


### PR DESCRIPTION
Theme classes (theme-dark, dark) were lost on every navigation because
ClientRouter swaps the <html> element and the server renders it with
class="initial". The inline FOUC-prevention script only runs on initial
page load (Astro deduplicates identical inline scripts across
navigations), so nothing reapplied the theme after a swap.

Re-run the theme detection on astro:before-swap, applying the classes
to event.newDocument.documentElement so the swap completes with the
correct theme and no flash. Also handle both `theme-dark` and `dark`
classes for parity with ThemeToggleButton, since theme.css uses both
selectors.