### PR TITLE
feat(docs): add Terraform integration page

### DIFF
--- a/src/content/docs/integrations.mdx
+++ b/src/content/docs/integrations.mdx
@@ -47,3 +47,11 @@ import Monitoring from './integrations/_monitoring.mdx'
     How to automate your dependencies update using Mergify.
   </Docset>
 </DocsetGrid>
+
+## Infrastructure as Code
+
+<DocsetGrid>
+  <Docset title="Terraform" path="/integrations/terraform" icon="simple-icons:terraform">
+    Manage Mergify product enablement declaratively with the official Terraform provider.
+  </Docset>
+</DocsetGrid>

--- a/src/content/docs/integrations/terraform.mdx
+++ b/src/content/docs/integrations/terraform.mdx
@@ -1,0 +1,105 @@
+---
+title: Managing Mergify with Terraform
+description: How to manage Mergify configuration declaratively with the official Terraform provider.
+---
+
+import terraformLogo from "../../images/integrations/terraform/logo.svg"
+import IntegrationLogo from "../../../components/IntegrationLogo.astro"
+
+<IntegrationLogo src={terraformLogo} alt="Terraform logo"/>
+
+The official [Mergify Terraform provider][registry] lets you manage your
+Mergify configuration as code, alongside the rest of your infrastructure.
+
+## Prerequisites
+
+1. The [Mergify GitHub App](/integrations/github) is installed on your
+   repositories.
+
+2. A Mergify application key or a GitHub personal access token. See
+   [Authentication](#authentication) below.
+
+## Installation
+
+Declare the provider in your Terraform configuration:
+
+```hcl
+terraform {
+  required_providers {
+    mergify = {
+      source  = "Mergifyio/mergify"
+      version = "~> 0.1"
+    }
+  }
+}
+
+provider "mergify" {
+  # Token resolution order:
+  #   1. the `token` attribute set here
+  #   2. the MERGIFY_TOKEN environment variable
+  #   3. the GITHUB_TOKEN environment variable
+}
+```
+
+Then run:
+
+```bash
+terraform init
+```
+
+## Authentication
+
+The provider authenticates against the [Mergify API](/api) with a bearer
+token. Both Mergify application keys and GitHub personal access tokens
+are accepted.
+
+Tokens are read from, in priority order:
+
+1. The `token` attribute on the `provider` block.
+2. The `MERGIFY_TOKEN` environment variable.
+3. The `GITHUB_TOKEN` environment variable.
+
+:::caution
+  The `GITHUB_TOKEN` fallback expects a **personal access token**
+  (classic `ghp_*` or fine-grained `github_pat_*`). It is **not** the
+  built-in `GITHUB_TOKEN` secret that GitHub Actions exposes to
+  workflows — that one is a short-lived installation token (`ghs_*`)
+  which the Mergify API does not accept. In CI, store a PAT or a
+  Mergify application key in a dedicated secret (commonly
+  `MERGIFY_TOKEN`).
+:::
+
+## Resources
+
+### `mergify_repository_products`
+
+Manage which Mergify products are enabled on a single GitHub repository.
+
+```hcl
+resource "mergify_repository_products" "monorepo" {
+  owner      = "Mergifyio"
+  repository = "monorepo"
+  products   = ["merge_queue", "merge_protections", "ci_insights", "workflow_automation"]
+}
+```
+
+The `products` attribute is **declarative** — applying the resource
+sets the exact set of enabled products on the repository, removing any
+that are not listed.
+
+### `mergify_organization_default_products`
+
+Manage the default set of Mergify products enabled when a new
+repository of an organization is discovered by Mergify.
+
+```hcl
+resource "mergify_organization_default_products" "defaults" {
+  organization = "Mergifyio"
+  products     = ["merge_queue", "merge_protections"]
+}
+```
+
+This only affects **new** repositories. Existing ones are managed via
+`mergify_repository_products`.
+
+[registry]: https://registry.terraform.io/providers/Mergifyio/mergify/latest

--- a/src/content/images/integrations/terraform/logo.svg
+++ b/src/content/images/integrations/terraform/logo.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Terraform</title><path d="M1.44 0v7.575l6.561 3.79V3.787zm21.12 4.227l-6.561 3.791v7.574l6.56-3.787zM8.72 4.23v7.575l6.561 3.787V8.018zm0 8.405v7.575L15.28 24v-7.578z"/></svg>

--- a/src/content/navItems.tsx
+++ b/src/content/navItems.tsx
@@ -372,6 +372,7 @@ const navItems: NavItem[] = [
       { title: 'Datadog', path: '/integrations/datadog', icon: 'simple-icons:datadog' },
       { title: 'Slack', path: '/integrations/slack', icon: 'simple-icons:slack' },
       { title: 'Dependabot', path: '/integrations/dependabot', icon: 'simple-icons:dependabot' },
+      { title: 'Terraform', path: '/integrations/terraform', icon: 'simple-icons:terraform' },
     ],
   },
   {


### PR DESCRIPTION
Documents the Mergifyio/mergify Terraform provider — installation,
authentication, and the two product-enablement resources.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>