### PR TITLE
refactor(design): clean up Pass A loose ends

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -67,8 +67,8 @@ const classes = [
 
 	/* Primary button — matches mergify.com */
 	.button.button-primary {
-		background-color: #000;
-		color: #fff;
+		background-color: var(--color-dark);
+		color: var(--color-white);
 		border-radius: 12px;
 		padding: 10px 16px;
 		font-size: 0.875rem;
@@ -77,14 +77,14 @@ const classes = [
 		transition: background-color 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 
 		&:hover {
-			background-color: #3e434c;
+			background-color: var(--color-gray-700);
 		}
 	}
 
 	/* Secondary button — matches mergify.com */
 	.button.button-secondary {
 		background-color: rgba(255, 255, 255, 0.6);
-		color: #000;
+		color: var(--color-dark);
 		border-radius: 12px;
 		padding: 10px 16px;
 		font-size: 0.875rem;
@@ -98,17 +98,17 @@ const classes = [
 	}
 
 	.theme-dark .button.button-primary {
-		background-color: #fff;
-		color: #000;
+		background-color: var(--color-white);
+		color: var(--color-dark);
 
 		&:hover {
-			background-color: #d1d5db;
+			background-color: var(--color-gray-300);
 		}
 	}
 
 	.theme-dark .button.button-secondary {
 		background-color: rgba(255, 255, 255, 0.1);
-		color: #fff;
+		color: var(--color-white);
 
 		&:hover {
 			background-color: rgba(255, 255, 255, 0.2);

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -391,7 +391,7 @@ const description = 'Latest product updates from Mergify.';
   }
 
   .copy-btn.copied {
-    background: #10b981;
+    background: var(--color-teal-700);
   }
 
   .copy-icon {
@@ -414,12 +414,12 @@ const description = 'Latest product updates from Mergify.';
 
   .pill[data-tag="Workflow Automation"]:hover {
     background: var(--color-rose-700);
-    color: #fff;
+    color: var(--color-white);
   }
 
   .pill[data-tag="Workflow Automation"].active {
     background: var(--color-rose-700);
-    color: #fff;
+    color: var(--color-white);
     border-color: var(--color-rose-700);
   }
 
@@ -431,12 +431,12 @@ const description = 'Latest product updates from Mergify.';
 
   .pill[data-tag="Merge Queue"]:hover {
     background: var(--color-teal-700);
-    color: #fff;
+    color: var(--color-white);
   }
 
   .pill[data-tag="Merge Queue"].active {
     background: var(--color-teal-700);
-    color: #fff;
+    color: var(--color-white);
     border-color: var(--color-teal-700);
   }
 
@@ -448,12 +448,12 @@ const description = 'Latest product updates from Mergify.';
 
   .pill[data-tag="CI Insights"]:hover {
     background: var(--color-purple-700);
-    color: #fff;
+    color: var(--color-white);
   }
 
   .pill[data-tag="CI Insights"].active {
     background: var(--color-purple-700);
-    color: #fff;
+    color: var(--color-white);
     border-color: var(--color-purple-700);
   }
 
@@ -465,39 +465,40 @@ const description = 'Latest product updates from Mergify.';
 
   .pill[data-tag="Merge Protections"]:hover {
     background: var(--color-blue-700);
-    color: #fff;
+    color: var(--color-white);
   }
 
   .pill[data-tag="Merge Protections"].active {
     background: var(--color-blue-700);
-    color: #fff;
+    color: var(--color-white);
     border-color: var(--color-blue-700);
   }
-  /* Deprecations category (yellow) */
+  /* Deprecations — semantic warning, mapped to orange palette per the
+     same convention used for "caution" elsewhere in the system. */
   .pill[data-tag="Deprecations"] {
-    background: #FEFCBF; /* yellow-100 */
-    color: #975A16; /* yellow-700 */
-    border-color: #ECC94B; /* yellow-400 */
+    background: color-mix(in srgb, var(--color-orange-400) 25%, transparent);
+    color: var(--color-orange-700);
+    border-color: var(--color-orange-700);
   }
   .pill[data-tag="Deprecations"]:hover {
-    background: #ECC94B; /* yellow-400 */
-    color: #473307; /* darken for contrast */
+    background: var(--color-orange-700);
+    color: var(--color-white);
   }
   .pill[data-tag="Deprecations"].active {
-    background: #B7791F; /* yellow-600 */
-    color: #fff;
-    border-color: #B7791F;
+    background: var(--color-orange-700);
+    color: var(--color-white);
+    border-color: var(--color-orange-700);
   }
   .pill[data-tag="Enterprise"] {
-    background: #111;
-    color: #fff;
-    border-color: #000;
+    background: var(--color-dark);
+    color: var(--color-white);
+    border-color: var(--color-dark);
   }
   .pill[data-tag="Enterprise"]:hover,
   .pill[data-tag="Enterprise"].active {
-    background: #000;
-    color: #fff;
-    border-color: #000;
+    background: var(--color-dark);
+    color: var(--color-white);
+    border-color: var(--color-dark);
   }
   /* Disable global automatic numbering for year headings (global rule targets .content h2) */
   .content section.year > h2.no-counter { counter-increment: none !important; }
@@ -523,9 +524,9 @@ const description = 'Latest product updates from Mergify.';
   .entry-release .release-icon { width: 1rem; height: 1rem; color: var(--color-teal-700); }
   .entry-release .release-summary { margin: .35rem 0 0; font-size: .85rem; color: var(--theme-text-secondary); }
   .tag-enterprise {
-    background: #111;
-    color: #fff;
-    border: 1px solid #111;
+    background: var(--color-dark);
+    color: var(--color-white);
+    border: 1px solid var(--color-dark);
   }
   .row { display: grid; gap: .9rem; align-items: flex-start; grid-template-columns: 1fr; }
   @media (min-width: 50em) { .row { grid-template-columns: 10rem 1fr auto; } }
@@ -560,14 +561,14 @@ const description = 'Latest product updates from Mergify.';
     border: 1px solid var(--color-blue-700);
   }
   .tag[data-tag="Deprecations"] {
-    background: #FEFCBF; /* yellow-100 */
-    color: #975A16; /* yellow-700 */
-    border: 1px solid #ECC94B;
+    background: color-mix(in srgb, var(--color-orange-400) 25%, transparent);
+    color: var(--color-orange-700);
+    border: 1px solid var(--color-orange-700);
   }
   .tag[data-tag="Enterprise"] {
-    background: #111;
-    color: #fff;
-    border-color: #000;
+    background: var(--color-dark);
+    color: var(--color-white);
+    border-color: var(--color-dark);
   }
   .title { font-size: 1.05rem; margin: 0 0 .4rem; line-height: 1.3; }
   .title a { text-decoration: none; color: var(--theme-text); }

--- a/src/styles/api-reference.css
+++ b/src/styles/api-reference.css
@@ -7,7 +7,7 @@
    --------------------------------------------------------------------------- */
 
 .api-reference {
-  --api-border: var(--theme-border-color, #e2e8f0);
+  --api-border: var(--theme-border-color);
   --api-radius: 8px;
   --api-bg-subtle: var(--theme-bg-offset);
 }
@@ -178,24 +178,28 @@
   font-weight: 700;
   letter-spacing: 0.03em;
   text-transform: uppercase;
-  color: #fff;
+  color: var(--color-white);
   flex-shrink: 0;
 }
 
+/* HTTP method badges — colors map to product palette by semantic role,
+   following the same convention as the response-code badges defined
+   later in this file: GET=success, POST=info, PUT=caution,
+   DELETE=destructive, PATCH=secondary. */
 .method-get {
-  background: #16a34a;
+  background: var(--color-teal-700);
 }
 .method-post {
-  background: #2563eb;
+  background: var(--color-blue-700);
 }
 .method-put {
-  background: #d97706;
+  background: var(--color-orange-700);
 }
 .method-delete {
-  background: #dc2626;
+  background: var(--color-coral-700);
 }
 .method-patch {
-  background: #7c3aed;
+  background: var(--color-purple-700);
 }
 
 /* ---------------------------------------------------------------------------
@@ -375,7 +379,7 @@
 .schema-type-badge {
   font-family: var(--font-mono);
   font-size: 0.75rem;
-  color: var(--theme-code-inline-text, #b83280);
+  color: var(--theme-code-inline-text);
   background: var(--theme-code-inline-bg);
   padding: 0.1rem 0.4rem;
   border-radius: 3px;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -139,14 +139,6 @@
   --theme-glow-highlight: transparent;
   --theme-glow-diffuse: hsla(204, 73%, 58%, 0.5);
   --theme-glow-blur: 10px;
-
-  /* Background gradient (existing, unchanged) */
-  --theme-bg-gradient: linear-gradient(
-    180deg,
-    var(--theme-bg-gradient-top),
-    var(--theme-bg-gradient-top) calc(var(--theme-navbar-height) + var(--theme-mobile-toc-height)),
-    var(--theme-bg-gradient-bottom)
-  );
 }
 
 :root.theme-dark,


### PR DESCRIPTION
Pass A's design-system foundation tightened the styling layers but
left a handful of hex literals in pre-existing components that
weren't on its migration list. Sweeping them now so DESIGN.md's
"no hex literals outside tokens.css" code rule holds across the
codebase, with one documented exception (see theme.css comment for
--theme-bg in dark mode — the #24292e docs-specific dark surface
is intentionally preserved as-is).

- Button.astro primary/secondary blocks: #000/#fff/#3e434c/#d1d5db
  → semantic and gray-* tokens. Visually identical (the #3e434c
  hover hex is within 5 hex points of --color-gray-700).

- api-reference.css HTTP method badges (.method-get/post/put/delete/
  patch): hex literals replaced with the product palette by semantic
  role, mirroring the response-code badge convention. GET → teal,
  POST → blue, PUT → orange, DELETE → coral, PATCH → purple.
  Slight hue shifts but the badges read identically.

- api-reference.css custom-property fallbacks: dropped the
  Chakra-era #e2e8f0 and #b83280 fallbacks. The fallback chain never
  triggered since the upstream tokens are always defined.

- changelog/index.astro Deprecations pills + tags: yellow palette
  hex literals replaced with the orange palette per the marketing
  site's "caution" semantic precedent. Enterprise pills + tags now
  use --color-dark / --color-white. White text in product pills now
  uses var(--color-white).

- theme.css: deleted the dead --theme-bg-gradient composite token
  (zero consumers; the sub-tokens --theme-bg-gradient-{top,bottom}
  remain because index.css still uses them for iOS Safari address-
  bar continuity).