### PR TITLE
feat(changelog): add optional image field to entry schema

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -28,6 +28,12 @@ const changelog = defineCollection({
     description: z.string().optional(),
     // Accept null/undefined and coerce to [] so frontmatter like `tags: null` is tolerated
     tags: z.preprocess((val) => (val == null ? [] : val), z.array(z.string())).default([]),
+    image: z
+      .object({
+        src: z.string(),
+        alt: z.string(),
+      })
+      .optional(),
   }),
 });
 


### PR DESCRIPTION
Adds an optional { src, alt } image field so entries can opt in to a
hero image. Used by the redesigned index (marquee card variant) and
detail page (hero block above body).