### PR TITLE
feat(changelog): add getProductAccent helper

### DIFF
--- a/src/util/changelog.test.ts
+++ b/src/util/changelog.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest';
+import { getProductAccent } from './changelog';
+
+describe('getProductAccent', () => {
+  test('maps Merge Queue to teal-700', () => {
+    expect(getProductAccent('Merge Queue')).toEqual({
+      bar: 'var(--color-teal-700)',
+      text: 'var(--color-teal-700)',
+    });
+  });
+
+  test('maps Workflow Automation to rose-700', () => {
+    expect(getProductAccent('Workflow Automation')).toEqual({
+      bar: 'var(--color-rose-700)',
+      text: 'var(--color-rose-700)',
+    });
+  });
+
+  test('maps CI Insights to purple-700', () => {
+    expect(getProductAccent('CI Insights')).toEqual({
+      bar: 'var(--color-purple-700)',
+      text: 'var(--color-purple-700)',
+    });
+  });
+
+  test('maps Test Insights to orange-700', () => {
+    expect(getProductAccent('Test Insights')).toEqual({
+      bar: 'var(--color-orange-700)',
+      text: 'var(--color-orange-700)',
+    });
+  });
+
+  test('maps Merge Protections to blue-700', () => {
+    expect(getProductAccent('Merge Protections')).toEqual({
+      bar: 'var(--color-blue-700)',
+      text: 'var(--color-blue-700)',
+    });
+  });
+
+  test('maps Stacks to coral-700', () => {
+    expect(getProductAccent('Stacks')).toEqual({
+      bar: 'var(--color-coral-700)',
+      text: 'var(--color-coral-700)',
+    });
+  });
+
+  test('maps Deprecations to a neutral gray', () => {
+    expect(getProductAccent('Deprecations')).toEqual({
+      bar: 'var(--theme-text-muted)',
+      text: 'var(--theme-text-secondary)',
+    });
+  });
+
+  test('maps Enterprise to dark neutral', () => {
+    expect(getProductAccent('Enterprise')).toEqual({
+      bar: 'var(--theme-text)',
+      text: 'var(--theme-text)',
+    });
+  });
+
+  test('falls back to neutral for unknown tag', () => {
+    expect(getProductAccent('Some New Product')).toEqual({
+      bar: 'var(--theme-text-muted)',
+      text: 'var(--theme-text-secondary)',
+    });
+  });
+
+  test('handles undefined as fallback', () => {
+    expect(getProductAccent(undefined)).toEqual({
+      bar: 'var(--theme-text-muted)',
+      text: 'var(--theme-text-secondary)',
+    });
+  });
+});

--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -124,3 +124,32 @@ export function formatMonthYear(date: Date | string): string {
     month: 'long',
   });
 }
+
+export interface ProductAccent {
+  bar: string;
+  text: string;
+}
+
+const PRODUCT_ACCENTS: Record<string, ProductAccent> = {
+  'Merge Queue': { bar: 'var(--color-teal-700)', text: 'var(--color-teal-700)' },
+  'Workflow Automation': { bar: 'var(--color-rose-700)', text: 'var(--color-rose-700)' },
+  'CI Insights': { bar: 'var(--color-purple-700)', text: 'var(--color-purple-700)' },
+  'Test Insights': { bar: 'var(--color-orange-700)', text: 'var(--color-orange-700)' },
+  'Merge Protections': { bar: 'var(--color-blue-700)', text: 'var(--color-blue-700)' },
+  Stacks: { bar: 'var(--color-coral-700)', text: 'var(--color-coral-700)' },
+  Enterprise: { bar: 'var(--theme-text)', text: 'var(--theme-text)' },
+};
+
+const NEUTRAL_ACCENT: ProductAccent = {
+  bar: 'var(--theme-text-muted)',
+  text: 'var(--theme-text-secondary)',
+};
+
+/**
+ * Map a changelog tag to its left-bar accent color and detail-page eyebrow color.
+ * Unknown tags (and Deprecations) fall back to a neutral gray.
+ */
+export function getProductAccent(tag: string | undefined): ProductAccent {
+  if (!tag) return NEUTRAL_ACCENT;
+  return PRODUCT_ACCENTS[tag] ?? NEUTRAL_ACCENT;
+}


### PR DESCRIPTION
Returns the CSS token pair (bar color + text color) for a given product
tag. Unknown tags and Deprecations fall back to a neutral gray. Used by
the redesigned ChangelogCard for the left-bar accent.

Depends-On: #11414