### PR TITLE
test(changelog): rename Deprecations test for clarity

### DIFF
--- a/src/util/changelog.test.ts
+++ b/src/util/changelog.test.ts
@@ -44,7 +44,7 @@ describe('getProductAccent', () => {
     });
   });
 
-  test('maps Deprecations to a neutral gray', () => {
+  test('falls back to neutral for Deprecations (no explicit mapping)', () => {
     expect(getProductAccent('Deprecations')).toEqual({
       bar: 'var(--theme-text-muted)',
       text: 'var(--theme-text-secondary)',


### PR DESCRIPTION
Description now reflects that Deprecations falls through to the neutral
fallback rather than having an explicit map entry — addresses review
feedback that the previous name implied an explicit mapping.

Depends-On: #11415