### PR TITLE
feat(changelog): add getPrevNextEntries helper

### DIFF
--- a/src/util/changelog.test.ts
+++ b/src/util/changelog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { getProductAccent } from './changelog';
+import type { CollectionEntry } from 'astro:content';
+import { getProductAccent, getPrevNextEntries } from './changelog';
 
 describe('getProductAccent', () => {
   test('maps Merge Queue to teal-700', () => {
@@ -70,5 +71,59 @@ describe('getProductAccent', () => {
       bar: 'var(--theme-text-muted)',
       text: 'var(--theme-text-secondary)',
     });
+  });
+});
+
+function fakeEntry(id: string, dateISO: string): CollectionEntry<'changelog'> {
+  return {
+    id,
+    collection: 'changelog',
+    data: {
+      title: id,
+      date: new Date(dateISO),
+      description: '',
+      tags: [],
+    },
+    // Other CollectionEntry fields are not used by the helper
+  } as unknown as CollectionEntry<'changelog'>;
+}
+
+describe('getPrevNextEntries', () => {
+  const entries = [
+    fakeEntry('a', '2026-05-06'),
+    fakeEntry('b', '2026-05-05'),
+    fakeEntry('c', '2026-05-04'),
+    fakeEntry('d', '2026-05-03'),
+  ];
+
+  test('returns previous (older) and next (newer) for a middle entry', () => {
+    const result = getPrevNextEntries(entries, 'b');
+    expect(result.previous?.id).toBe('c');
+    expect(result.next?.id).toBe('a');
+  });
+
+  test('returns null for previous when entry is the oldest', () => {
+    const result = getPrevNextEntries(entries, 'd');
+    expect(result.previous).toBeNull();
+    expect(result.next?.id).toBe('c');
+  });
+
+  test('returns null for next when entry is the newest', () => {
+    const result = getPrevNextEntries(entries, 'a');
+    expect(result.previous?.id).toBe('b');
+    expect(result.next).toBeNull();
+  });
+
+  test('returns both null when entry id is not found', () => {
+    const result = getPrevNextEntries(entries, 'missing');
+    expect(result.previous).toBeNull();
+    expect(result.next).toBeNull();
+  });
+
+  test('works on an unsorted input array (sorts internally)', () => {
+    const shuffled = [entries[2], entries[0], entries[3], entries[1]];
+    const result = getPrevNextEntries(shuffled, 'b');
+    expect(result.previous?.id).toBe('c');
+    expect(result.next?.id).toBe('a');
   });
 });

--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -153,3 +153,26 @@ export function getProductAccent(tag: string | undefined): ProductAccent {
   if (!tag) return NEUTRAL_ACCENT;
   return PRODUCT_ACCENTS[tag] ?? NEUTRAL_ACCENT;
 }
+
+export interface PrevNext {
+  previous: CollectionEntry<'changelog'> | null;
+  next: CollectionEntry<'changelog'> | null;
+}
+
+/**
+ * Given a sorted-or-unsorted list of changelog entries and a current entry id,
+ * return the chronologically previous (older) and next (newer) entries.
+ */
+export function getPrevNextEntries(
+  entries: CollectionEntry<'changelog'>[],
+  currentId: string
+): PrevNext {
+  const sorted = sortChangelog(entries);
+  const idx = sorted.findIndex((e) => e.id === currentId);
+  if (idx === -1) return { previous: null, next: null };
+  return {
+    // sorted is newest-first, so previous (older) is at idx + 1
+    previous: sorted[idx + 1] ?? null,
+    next: sorted[idx - 1] ?? null,
+  };
+}


### PR DESCRIPTION
Returns chronologically adjacent entries for the redesigned detail
page's prev/next navigation. Sorts internally so callers don't need
to pre-sort.

Depends-On: #11416