### PR TITLE
feat(changelog): clickable cards, always-show tags, RSS copy button

### DIFF
--- a/src/components/changelog/ChangelogCard.astro
+++ b/src/components/changelog/ChangelogCard.astro
@@ -10,7 +10,6 @@ const { entry } = Astro.props;
 const { title, description, date, tags } = entry.data;
 const primaryTag = tags[0];
 const accent = getProductAccent(primaryTag);
-const showPills = tags.length >= 2;
 
 const monthDay = new Date(date).toLocaleDateString('en-US', {
   month: 'short',
@@ -32,7 +31,7 @@ const monthDay = new Date(date).toLocaleDateString('en-US', {
   </div>
   <div class="card-aside">
     <time datetime={formatDate(date)} class="card-date">{monthDay}</time>
-    {showPills && (
+    {tags.length > 0 && (
       <div class="pills-stack">
         {tags.map((t) => <span class="card-pill">{t}</span>)}
       </div>
@@ -84,6 +83,13 @@ const monthDay = new Date(date).toLocaleDateString('en-US', {
   }
   .card-title a:hover {
     color: var(--card-accent-text);
+  }
+  /* Stretched-link: title <a> covers the whole card, so the entire card is clickable. */
+  .card-title a::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
   }
   .card-desc {
     font-size: 0.8125rem;

--- a/src/components/changelog/ChangelogMarquee.astro
+++ b/src/components/changelog/ChangelogMarquee.astro
@@ -23,11 +23,7 @@ const monthDay = new Date(date).toLocaleDateString('en-US', {
   data-title={title.toLowerCase()}
   style={`--card-accent: ${accent.bar}; --card-accent-text: ${accent.text};`}
 >
-  {image && (
-    <a href={`/changelog/${entry.id}/`} class="marquee-hero-link" aria-label={title}>
-      <img src={image.src} alt={image.alt} class="marquee-hero" loading="lazy" />
-    </a>
-  )}
+  {image && <img src={image.src} alt={image.alt} class="marquee-hero" loading="lazy" />}
   <div class="marquee-body">
     <div class="marquee-content">
       {primaryTag && (
@@ -55,10 +51,6 @@ const monthDay = new Date(date).toLocaleDateString('en-US', {
     border-color: var(--theme-text-muted);
     box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
     transform: translateY(-1px);
-  }
-  .marquee-hero-link {
-    display: block;
-    line-height: 0;
   }
   .marquee-hero {
     width: 100%;
@@ -118,6 +110,13 @@ const monthDay = new Date(date).toLocaleDateString('en-US', {
   }
   .marquee-title a:hover {
     color: var(--card-accent-text);
+  }
+  /* Stretched-link: title <a> covers the whole marquee, hero included. */
+  .marquee-title a::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
   }
   .marquee-desc {
     font-size: 0.9375rem;

--- a/src/components/changelog/ChangelogSubscribePopover.astro
+++ b/src/components/changelog/ChangelogSubscribePopover.astro
@@ -18,16 +18,18 @@ const slackCommand = `/feed subscribe ${import.meta.env.SITE}/changelog/rss.xml`
   </button>
   <div class="popover" role="dialog" aria-label="Subscribe options" hidden data-subscribe-popover>
     <h6 class="pop-h">RSS</h6>
-    <a class="pop-rss" href="/changelog/rss.xml">
+    <p class="pop-desc">Paste this URL into your feed reader.</p>
+    <div class="pop-cmd">
       <Icon name="heroicons:rss" class="pop-icon" />
-      <span>{import.meta.env.SITE}/changelog/rss.xml</span>
-    </a>
+      <code data-copy-source>{import.meta.env.SITE}/changelog/rss.xml</code>
+      <button type="button" class="pop-copy" data-copy-target="prev">Copy</button>
+    </div>
     <div class="pop-divider"></div>
     <h6 class="pop-h">Slack</h6>
     <p class="pop-desc">Run this in any Slack channel to subscribe.</p>
     <div class="pop-cmd">
-      <code data-slack-command>{slackCommand}</code>
-      <button type="button" class="pop-copy" data-slack-copy>Copy</button>
+      <code data-copy-source>{slackCommand}</code>
+      <button type="button" class="pop-copy" data-copy-target="prev">Copy</button>
     </div>
   </div>
 </div>
@@ -36,8 +38,6 @@ const slackCommand = `/feed subscribe ${import.meta.env.SITE}/changelog/rss.xml`
   function initSubscribePopover() {
     const toggle = document.querySelector('[data-subscribe-toggle]');
     const popover = document.querySelector('[data-subscribe-popover]');
-    const copyBtn = document.querySelector('[data-slack-copy]');
-    const cmd = document.querySelector('[data-slack-command]');
     if (!toggle || !popover) return;
 
     function setOpen(open) {
@@ -63,21 +63,23 @@ const slackCommand = `/feed subscribe ${import.meta.env.SITE}/changelog/rss.xml`
       }
     });
 
-    if (copyBtn && cmd) {
-      copyBtn.addEventListener('click', function () {
-        const text = cmd.textContent || '';
+    popover.querySelectorAll('[data-copy-target="prev"]').forEach(function (btn) {
+      const source = btn.previousElementSibling;
+      if (!source) return;
+      btn.addEventListener('click', function () {
+        const text = (source.textContent || '').trim();
         if (!navigator.clipboard || !navigator.clipboard.writeText) return;
         navigator.clipboard.writeText(text).then(function () {
-          const original = copyBtn.textContent;
-          copyBtn.textContent = 'Copied!';
-          copyBtn.classList.add('copied');
+          const original = btn.textContent;
+          btn.textContent = 'Copied!';
+          btn.classList.add('copied');
           setTimeout(function () {
-            copyBtn.textContent = original;
-            copyBtn.classList.remove('copied');
+            btn.textContent = original;
+            btn.classList.remove('copied');
           }, 2000);
         });
       });
-    }
+    });
   }
 
   initSubscribePopover();
@@ -154,21 +156,6 @@ const slackCommand = `/feed subscribe ${import.meta.env.SITE}/changelog/rss.xml`
     color: var(--theme-text-secondary);
     margin: 0 0 10px;
     line-height: 1.5;
-  }
-  .pop-rss {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 9px 12px;
-    border: 1px solid var(--theme-border);
-    border-radius: 8px;
-    font-size: 0.8125rem;
-    color: var(--theme-text);
-    text-decoration: none;
-    word-break: break-all;
-  }
-  .pop-rss:hover {
-    border-color: var(--theme-text-muted);
   }
   .pop-icon {
     width: 14px;


### PR DESCRIPTION
- Standard card and marquee become fully clickable via stretched-link
  on the title <a> (no nested anchors, screen-reader semantics intact).
- Standard card always renders tag pills, regardless of tag count —
  the colored left bar alone is too subtle, especially for visitors
  who don't yet know the palette or rely on assistive tech.
- Subscribe popover: RSS URL is now a copyable code box with a Copy
  button, matching the Slack /feed row. The copy handler is generalized
  via data-copy-target="prev" so adding future copy rows is trivial.

Depends-On: #11423