### PR TITLE
feat(changelog): render backtick code spans in entry titles

### DIFF
--- a/src/components/changelog/ChangelogCard.astro
+++ b/src/components/changelog/ChangelogCard.astro
@@ -1,6 +1,6 @@
 ---
 import type { CollectionEntry } from 'astro:content';
-import { formatDate, getProductAccent } from '~/util/changelog';
+import { formatDate, getProductAccent, renderInlineMarkdown } from '~/util/changelog';
 
 interface Props {
   entry: CollectionEntry<'changelog'>;
@@ -25,7 +25,7 @@ const monthDay = new Date(date).toLocaleDateString('en-US', {
 >
   <div class="card-body">
     <h3 class="card-title">
-      <a href={`/changelog/${entry.id}/`}>{title}</a>
+      <a href={`/changelog/${entry.id}/`} set:html={renderInlineMarkdown(title)} />
     </h3>
     {description && <p class="card-desc">{description}</p>}
   </div>

--- a/src/components/changelog/ChangelogMarquee.astro
+++ b/src/components/changelog/ChangelogMarquee.astro
@@ -1,6 +1,6 @@
 ---
 import type { CollectionEntry } from 'astro:content';
-import { formatDate, getProductAccent } from '~/util/changelog';
+import { formatDate, getProductAccent, renderInlineMarkdown } from '~/util/changelog';
 
 interface Props {
   entry: CollectionEntry<'changelog'>;
@@ -30,7 +30,7 @@ const monthDay = new Date(date).toLocaleDateString('en-US', {
         <div class="marquee-eyebrow"><span class="dot" />{primaryTag}</div>
       )}
       <h3 class="marquee-title">
-        <a href={`/changelog/${entry.id}/`}>{title}</a>
+        <a href={`/changelog/${entry.id}/`} set:html={renderInlineMarkdown(title)} />
       </h3>
       {description && <p class="marquee-desc">{description}</p>}
     </div>

--- a/src/pages/changelog/[slug].astro
+++ b/src/pages/changelog/[slug].astro
@@ -8,6 +8,7 @@ import {
   getPrevNextEntries,
   getProductAccent,
   getRelatedEntries,
+  renderInlineMarkdown,
 } from '../../util/changelog';
 
 export async function getStaticPaths() {
@@ -44,7 +45,7 @@ const related = getRelatedEntries(allEntries, entry.id, primaryTag, 4);
     {primaryTag && (
       <div class="detail-eyebrow"><span class="dot" />{primaryTag}</div>
     )}
-    <h1 class="detail-title">{title}</h1>
+    <h1 class="detail-title" set:html={renderInlineMarkdown(title)} />
     <time datetime={formatDate(date)} class="detail-date">{formatDateHuman(date)}</time>
     {description && <p class="detail-lede">{description}</p>}
 
@@ -61,13 +62,13 @@ const related = getRelatedEntries(allEntries, entry.id, primaryTag, 4);
         {previous ? (
           <a class="nav-link prev" href={`/changelog/${previous.id}/`}>
             <span class="nav-label">← Previous</span>
-            <span class="nav-title">{previous.data.title}</span>
+            <span class="nav-title" set:html={renderInlineMarkdown(previous.data.title)} />
           </a>
         ) : <span />}
         {next ? (
           <a class="nav-link next" href={`/changelog/${next.id}/`}>
             <span class="nav-label">Next →</span>
-            <span class="nav-title">{next.data.title}</span>
+            <span class="nav-title" set:html={renderInlineMarkdown(next.data.title)} />
           </a>
         ) : <span />}
       </nav>
@@ -79,7 +80,7 @@ const related = getRelatedEntries(allEntries, entry.id, primaryTag, 4);
         <div class="related-grid">
           {related.map((r) => (
             <a class="related-card" href={`/changelog/${r.id}/`}>
-              <span class="related-title">{r.data.title}</span>
+              <span class="related-title" set:html={renderInlineMarkdown(r.data.title)} />
               <span class="related-date">{formatDateHuman(r.data.date)}</span>
             </a>
           ))}

--- a/src/util/changelog.test.ts
+++ b/src/util/changelog.test.ts
@@ -1,6 +1,11 @@
 import type { CollectionEntry } from 'astro:content';
 import { describe, expect, test } from 'vitest';
-import { getPrevNextEntries, getProductAccent, getRelatedEntries } from './changelog';
+import {
+  getPrevNextEntries,
+  getProductAccent,
+  getRelatedEntries,
+  renderInlineMarkdown,
+} from './changelog';
 
 describe('getProductAccent', () => {
   test('maps Merge Queue to teal-700', () => {
@@ -174,5 +179,37 @@ describe('getRelatedEntries', () => {
   test('matches when the tag is in any position of the entry tags array', () => {
     const result = getRelatedEntries(entries, 'a', 'Workflow Automation', 4);
     expect(result.map((e) => e.id)).toEqual(['b']);
+  });
+});
+
+describe('renderInlineMarkdown', () => {
+  test('passes plain text through unchanged', () => {
+    expect(renderInlineMarkdown('Hello world')).toBe('Hello world');
+  });
+
+  test('converts backtick code spans to <code> tags', () => {
+    expect(renderInlineMarkdown('Configure `auto_merge_conditions`')).toBe(
+      'Configure <code>auto_merge_conditions</code>'
+    );
+  });
+
+  test('handles multiple code spans on one line', () => {
+    expect(renderInlineMarkdown('`foo` and `bar`')).toBe('<code>foo</code> and <code>bar</code>');
+  });
+
+  test('escapes HTML in surrounding text', () => {
+    expect(renderInlineMarkdown('Use <script> tag')).toBe('Use &lt;script&gt; tag');
+  });
+
+  test('escapes HTML inside code spans too', () => {
+    expect(renderInlineMarkdown('use `<div>` here')).toBe('use <code>&lt;div&gt;</code> here');
+  });
+
+  test('leaves an unpaired backtick literal', () => {
+    expect(renderInlineMarkdown('only `one open')).toBe('only `one open');
+  });
+
+  test('escapes ampersands and quotes', () => {
+    expect(renderInlineMarkdown('Tom & Jerry "win"')).toBe('Tom &amp; Jerry &quot;win&quot;');
   });
 });

--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -125,6 +125,22 @@ export function formatMonthYear(date: Date | string): string {
   });
 }
 
+/**
+ * Render a tiny subset of inline markdown for changelog titles: backtick code
+ * spans become <code>. HTML is escaped first, so the result is safe to render
+ * with set:html. We avoid a full markdown parser because titles only ever use
+ * code spans in practice.
+ */
+export function renderInlineMarkdown(text: string): string {
+  const escaped = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+  return escaped.replace(/`([^`]+)`/g, '<code>$1</code>');
+}
+
 export interface ProductAccent {
   bar: string;
   text: string;


### PR DESCRIPTION
Adds renderInlineMarkdown helper (with 7 tests) that escapes HTML and
converts backtick code spans to <code> tags. Applied everywhere a title
is rendered: card, marquee, detail page H1, prev/next nav, related
entries. Descriptions remain plain text per the design choice — titles
benefit most from code-span rendering since they frequently reference
config keys (commit_message_format, routing_conditions, etc.).

The helper deliberately avoids a full markdown parser because titles
only ever use code spans in practice.

Depends-On: #11424