### PR TITLE
fix(changelog): marquee hero opens entry, not zoom modal

### DIFF
--- a/src/components/changelog/ChangelogMarquee.astro
+++ b/src/components/changelog/ChangelogMarquee.astro
@@ -23,7 +23,11 @@ const monthDay = new Date(date).toLocaleDateString('en-US', {
   data-title={title.toLowerCase()}
   style={`--card-accent: ${accent.bar}; --card-accent-text: ${accent.text};`}
 >
-  {image && <img src={image.src} alt={image.alt} class="marquee-hero" loading="lazy" />}
+  {image && (
+    <a href={`/changelog/${entry.id}/`} class="marquee-hero-link" aria-hidden="true" tabindex="-1">
+      <img src={image.src} alt={image.alt} class="marquee-hero no-zoom" loading="lazy" />
+    </a>
+  )}
   <div class="marquee-body">
     <div class="marquee-content">
       {primaryTag && (
@@ -52,11 +56,16 @@ const monthDay = new Date(date).toLocaleDateString('en-US', {
     box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
     transform: translateY(-1px);
   }
+  .marquee-hero-link {
+    display: block;
+    line-height: 0;
+  }
   .marquee-hero {
     width: 100%;
     height: 220px;
     object-fit: cover;
     display: block;
+    cursor: pointer;
   }
   .marquee-body {
     padding: 24px 26px 24px 28px;


### PR DESCRIPTION
The global ImageZoom handler intercepts any <img> inside an <article>
unless it has class="no-zoom", which was triggering the lightbox when
users clicked the marquee card hero. The stretched-link from the title
only covers the body (it inherits .marquee-body as its positioned
ancestor), so the hero area was never part of the link.

Re-wrap the hero image in an aria-hidden anchor pointing at the entry
and mark the image .no-zoom so the global handler skips it. The title
remains the only screen-reader-visible link to the entry.

Depends-On: #11425