### PR TITLE
feat(changelog): add schema field, helpers, and editorial card components

### DIFF
--- a/src/components/changelog/ChangelogCard.astro
+++ b/src/components/changelog/ChangelogCard.astro
@@ -1,0 +1,157 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { formatDate, getProductAccent, renderInlineMarkdown } from '~/util/changelog';
+
+interface Props {
+  entry: CollectionEntry<'changelog'>;
+}
+
+const { entry } = Astro.props;
+const { title, description, date, tags } = entry.data;
+const primaryTag = tags[0];
+const accent = getProductAccent(primaryTag);
+
+const monthDay = new Date(date).toLocaleDateString('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+---
+
+<article
+  class="card"
+  data-tags={tags.join(',')}
+  data-title={title.toLowerCase()}
+  style={`--card-accent: ${accent.bar}; --card-accent-text: ${accent.text};`}
+>
+  <div class="card-body">
+    <h3 class="card-title">
+      <a href={`/changelog/${entry.id}/`} set:html={renderInlineMarkdown(title)} />
+    </h3>
+    {description && <p class="card-desc">{description}</p>}
+  </div>
+  <div class="card-aside">
+    <time datetime={formatDate(date)} class="card-date">{monthDay}</time>
+    {tags.length > 0 && (
+      <div class="pills-stack">
+        {tags.map((t) => <span class="card-pill">{t}</span>)}
+      </div>
+    )}
+  </div>
+</article>
+
+<style>
+  .card {
+    background: var(--theme-bg-content);
+    border: 1px solid var(--theme-border);
+    border-radius: 12px;
+    padding: 18px 22px 18px 24px;
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 22px;
+    align-items: start;
+    transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+  }
+  .card:hover {
+    border-color: var(--theme-text-muted);
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.04);
+    transform: translateY(-1px);
+  }
+  .card::before {
+    content: '';
+    position: absolute;
+    top: 16px;
+    bottom: 16px;
+    left: 0;
+    width: 3px;
+    background: var(--card-accent);
+    border-radius: 0 3px 3px 0;
+  }
+  .card-body {
+    min-width: 0;
+  }
+  .card-title {
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0 0 4px;
+    line-height: 1.3;
+    color: var(--theme-text);
+  }
+  .card-title a {
+    color: inherit;
+    text-decoration: none;
+  }
+  .card-title a:hover {
+    color: var(--card-accent-text);
+  }
+  /* Stretched-link: title <a> covers the whole card, so the entire card is clickable. */
+  .card-title a::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+  }
+  .card-desc {
+    font-size: 0.8125rem;
+    color: var(--theme-text-secondary);
+    margin: 0;
+    line-height: 1.6;
+  }
+  .card-desc :global(code),
+  .card-title :global(code) {
+    background: var(--theme-bg-offset);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 0.92em;
+    font-family: var(--font-mono);
+  }
+
+  .card-aside {
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-end;
+    padding-top: 3px;
+  }
+  .card-date {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--theme-text-muted);
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+  }
+  .pills-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-end;
+  }
+  .card-pill {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.65rem;
+    padding: 3px 10px;
+    border-radius: 99px;
+    background: var(--theme-bg-offset);
+    color: var(--theme-text-secondary);
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  @media (max-width: 36rem) {
+    .card {
+      grid-template-columns: 1fr;
+      gap: 8px;
+    }
+    .card-aside {
+      flex-direction: row;
+      align-items: center;
+      justify-content: flex-start;
+    }
+    .pills-stack {
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+</style>

--- a/src/components/changelog/ChangelogMarquee.astro
+++ b/src/components/changelog/ChangelogMarquee.astro
@@ -1,0 +1,165 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { formatDate, getProductAccent, renderInlineMarkdown } from '~/util/changelog';
+
+interface Props {
+  entry: CollectionEntry<'changelog'>;
+}
+
+const { entry } = Astro.props;
+const { title, description, date, tags, image } = entry.data;
+const primaryTag = tags[0];
+const accent = getProductAccent(primaryTag);
+
+const monthDay = new Date(date).toLocaleDateString('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+---
+
+<article
+  class="marquee"
+  data-tags={tags.join(',')}
+  data-title={title.toLowerCase()}
+  style={`--card-accent: ${accent.bar}; --card-accent-text: ${accent.text};`}
+>
+  {image && (
+    <a href={`/changelog/${entry.id}/`} class="marquee-hero-link" aria-hidden="true" tabindex="-1">
+      <img src={image.src} alt={image.alt} class="marquee-hero no-zoom" loading="lazy" />
+    </a>
+  )}
+  <div class="marquee-body">
+    <div class="marquee-content">
+      {primaryTag && (
+        <div class="marquee-eyebrow"><span class="dot" />{primaryTag}</div>
+      )}
+      <h3 class="marquee-title">
+        <a href={`/changelog/${entry.id}/`} set:html={renderInlineMarkdown(title)} />
+      </h3>
+      {description && <p class="marquee-desc">{description}</p>}
+    </div>
+    <time datetime={formatDate(date)} class="marquee-date">{monthDay}</time>
+  </div>
+</article>
+
+<style>
+  .marquee {
+    background: var(--theme-bg-content);
+    border: 1px solid var(--theme-border);
+    border-radius: 14px;
+    overflow: hidden;
+    position: relative;
+    transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+  }
+  .marquee:hover {
+    border-color: var(--theme-text-muted);
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
+    transform: translateY(-1px);
+  }
+  .marquee-hero-link {
+    display: block;
+    line-height: 0;
+  }
+  .marquee-hero {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
+    display: block;
+    cursor: pointer;
+  }
+  .marquee-body {
+    padding: 24px 26px 24px 28px;
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 22px;
+    align-items: start;
+  }
+  .marquee-body::before {
+    content: '';
+    position: absolute;
+    top: 22px;
+    bottom: 22px;
+    left: 0;
+    width: 3px;
+    background: var(--card-accent);
+    border-radius: 0 3px 3px 0;
+  }
+  .marquee-content {
+    min-width: 0;
+  }
+  .marquee-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--card-accent-text);
+    margin-bottom: 8px;
+  }
+  .marquee-eyebrow .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 99px;
+    background: var(--card-accent);
+  }
+  .marquee-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 6px;
+    line-height: 1.22;
+    color: var(--theme-text);
+    letter-spacing: -0.015em;
+  }
+  .marquee-title a {
+    color: inherit;
+    text-decoration: none;
+  }
+  .marquee-title a:hover {
+    color: var(--card-accent-text);
+  }
+  /* Stretched-link: title <a> covers the whole marquee, hero included. */
+  .marquee-title a::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+  }
+  .marquee-desc {
+    font-size: 0.9375rem;
+    color: var(--theme-text-secondary);
+    margin: 0;
+    line-height: 1.6;
+  }
+  .marquee-desc :global(code),
+  .marquee-title :global(code) {
+    background: var(--theme-bg-offset);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 0.92em;
+    font-family: var(--font-mono);
+  }
+  .marquee-date {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--theme-text-muted);
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+    padding-top: 3px;
+  }
+
+  @media (max-width: 36rem) {
+    .marquee-hero {
+      height: 160px;
+    }
+    .marquee-body {
+      grid-template-columns: 1fr;
+      gap: 8px;
+    }
+    .marquee-title {
+      font-size: 1.25rem;
+    }
+  }
+</style>

--- a/src/components/changelog/ChangelogSubscribePopover.astro
+++ b/src/components/changelog/ChangelogSubscribePopover.astro
@@ -1,0 +1,205 @@
+---
+import { Icon } from 'astro-icon/components';
+
+const slackCommand = `/feed subscribe ${import.meta.env.SITE}/changelog/rss.xml`;
+---
+
+<div class="subscribe-wrap">
+  <button
+    type="button"
+    class="subscribe-btn"
+    aria-haspopup="dialog"
+    aria-expanded="false"
+    data-subscribe-toggle
+  >
+    <Icon name="heroicons:rss" class="btn-icon" />
+    Subscribe
+    <span class="caret" aria-hidden="true">▾</span>
+  </button>
+  <div class="popover" role="dialog" aria-label="Subscribe options" hidden data-subscribe-popover>
+    <h6 class="pop-h">RSS</h6>
+    <p class="pop-desc">Paste this URL into your feed reader.</p>
+    <div class="pop-cmd">
+      <Icon name="heroicons:rss" class="pop-icon" />
+      <code data-copy-source>{import.meta.env.SITE}/changelog/rss.xml</code>
+      <button type="button" class="pop-copy" data-copy-target="prev">Copy</button>
+    </div>
+    <div class="pop-divider"></div>
+    <h6 class="pop-h">Slack</h6>
+    <p class="pop-desc">Run this in any Slack channel to subscribe.</p>
+    <div class="pop-cmd">
+      <code data-copy-source>{slackCommand}</code>
+      <button type="button" class="pop-copy" data-copy-target="prev">Copy</button>
+    </div>
+  </div>
+</div>
+
+<script is:inline>
+  function initSubscribePopover() {
+    const toggle = document.querySelector('[data-subscribe-toggle]');
+    const popover = document.querySelector('[data-subscribe-popover]');
+    if (!toggle || !popover) return;
+
+    function setOpen(open) {
+      popover.hidden = !open;
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+
+    toggle.addEventListener('click', function (e) {
+      e.stopPropagation();
+      setOpen(popover.hidden);
+    });
+
+    document.addEventListener('click', function (e) {
+      if (popover.hidden) return;
+      if (popover.contains(e.target) || toggle.contains(e.target)) return;
+      setOpen(false);
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && !popover.hidden) {
+        setOpen(false);
+        toggle.focus();
+      }
+    });
+
+    popover.querySelectorAll('[data-copy-target="prev"]').forEach(function (btn) {
+      const source = btn.previousElementSibling;
+      if (!source) return;
+      btn.addEventListener('click', function () {
+        const text = (source.textContent || '').trim();
+        if (!navigator.clipboard || !navigator.clipboard.writeText) return;
+        navigator.clipboard.writeText(text).then(function () {
+          const original = btn.textContent;
+          btn.textContent = 'Copied!';
+          btn.classList.add('copied');
+          setTimeout(function () {
+            btn.textContent = original;
+            btn.classList.remove('copied');
+          }, 2000);
+        });
+      });
+    });
+  }
+
+  initSubscribePopover();
+  if (!window.__changelogSubscribeInit__) {
+    window.__changelogSubscribeInit__ = true;
+    document.addEventListener('astro:after-swap', initSubscribePopover);
+  }
+</script>
+
+<style>
+  .subscribe-wrap {
+    position: relative;
+  }
+  .subscribe-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--theme-text-secondary);
+    background: var(--theme-bg-content);
+    border: 1px solid var(--theme-border);
+    padding: 7px 14px;
+    border-radius: 9px;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .subscribe-btn:hover {
+    border-color: var(--theme-text-muted);
+    color: var(--theme-text);
+  }
+  .btn-icon {
+    width: 14px;
+    height: 14px;
+  }
+  .caret {
+    font-size: 0.7rem;
+    color: var(--theme-text-muted);
+  }
+
+  .popover {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    background: var(--theme-bg-content);
+    border: 1px solid var(--theme-border);
+    border-radius: 12px;
+    width: 360px;
+    padding: 16px;
+    z-index: 10;
+    box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+  }
+  @media (max-width: 28rem) {
+    .popover {
+      position: fixed;
+      top: auto;
+      bottom: 16px;
+      left: 16px;
+      right: 16px;
+      width: auto;
+    }
+  }
+
+  .pop-h {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--theme-text-muted);
+    margin: 0 0 8px;
+    font-weight: 700;
+  }
+  .pop-desc {
+    font-size: 0.75rem;
+    color: var(--theme-text-secondary);
+    margin: 0 0 10px;
+    line-height: 1.5;
+  }
+  .pop-icon {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+  }
+  .pop-divider {
+    height: 1px;
+    background: var(--theme-border);
+    margin: 14px -16px;
+  }
+  .pop-cmd {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px 8px 12px;
+    border: 1px solid var(--theme-border);
+    border-radius: 8px;
+    background: var(--theme-bg-offset);
+  }
+  .pop-cmd code {
+    flex: 1;
+    font-size: 0.7rem;
+    background: transparent;
+    padding: 0;
+    color: var(--theme-text);
+    font-family: var(--font-mono);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .pop-copy {
+    background: var(--theme-text);
+    color: var(--theme-bg-content);
+    border: none;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    padding: 5px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .pop-copy.copied {
+    background: var(--color-teal-700);
+    color: #fff;
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -28,6 +28,12 @@ const changelog = defineCollection({
     description: z.string().optional(),
     // Accept null/undefined and coerce to [] so frontmatter like `tags: null` is tolerated
     tags: z.preprocess((val) => (val == null ? [] : val), z.array(z.string())).default([]),
+    image: z
+      .object({
+        src: z.string(),
+        alt: z.string(),
+      })
+      .optional(),
   }),
 });
 

--- a/src/util/changelog.test.ts
+++ b/src/util/changelog.test.ts
@@ -1,0 +1,215 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, test } from 'vitest';
+import {
+  getPrevNextEntries,
+  getProductAccent,
+  getRelatedEntries,
+  renderInlineMarkdown,
+} from './changelog';
+
+describe('getProductAccent', () => {
+  test('maps Merge Queue to teal-700', () => {
+    expect(getProductAccent('Merge Queue')).toEqual({
+      bar: 'var(--color-teal-700)',
+      text: 'var(--color-teal-700)',
+    });
+  });
+
+  test('maps Workflow Automation to rose-700', () => {
+    expect(getProductAccent('Workflow Automation')).toEqual({
+      bar: 'var(--color-rose-700)',
+      text: 'var(--color-rose-700)',
+    });
+  });
+
+  test('maps CI Insights to purple-700', () => {
+    expect(getProductAccent('CI Insights')).toEqual({
+      bar: 'var(--color-purple-700)',
+      text: 'var(--color-purple-700)',
+    });
+  });
+
+  test('maps Test Insights to orange-700', () => {
+    expect(getProductAccent('Test Insights')).toEqual({
+      bar: 'var(--color-orange-700)',
+      text: 'var(--color-orange-700)',
+    });
+  });
+
+  test('maps Merge Protections to blue-700', () => {
+    expect(getProductAccent('Merge Protections')).toEqual({
+      bar: 'var(--color-blue-700)',
+      text: 'var(--color-blue-700)',
+    });
+  });
+
+  test('maps Stacks to coral-700', () => {
+    expect(getProductAccent('Stacks')).toEqual({
+      bar: 'var(--color-coral-700)',
+      text: 'var(--color-coral-700)',
+    });
+  });
+
+  test('falls back to neutral for Deprecations (no explicit mapping)', () => {
+    expect(getProductAccent('Deprecations')).toEqual({
+      bar: 'var(--theme-text-muted)',
+      text: 'var(--theme-text-secondary)',
+    });
+  });
+
+  test('maps Enterprise to dark neutral', () => {
+    expect(getProductAccent('Enterprise')).toEqual({
+      bar: 'var(--theme-text)',
+      text: 'var(--theme-text)',
+    });
+  });
+
+  test('falls back to neutral for unknown tag', () => {
+    expect(getProductAccent('Some New Product')).toEqual({
+      bar: 'var(--theme-text-muted)',
+      text: 'var(--theme-text-secondary)',
+    });
+  });
+
+  test('handles undefined as fallback', () => {
+    expect(getProductAccent(undefined)).toEqual({
+      bar: 'var(--theme-text-muted)',
+      text: 'var(--theme-text-secondary)',
+    });
+  });
+});
+
+function fakeEntry(id: string, dateISO: string): CollectionEntry<'changelog'> {
+  return {
+    id,
+    collection: 'changelog',
+    data: {
+      title: id,
+      date: new Date(dateISO),
+      description: '',
+      tags: [],
+    },
+    // Other CollectionEntry fields are not used by the helper
+  } as unknown as CollectionEntry<'changelog'>;
+}
+
+describe('getPrevNextEntries', () => {
+  const entries = [
+    fakeEntry('a', '2026-05-06'),
+    fakeEntry('b', '2026-05-05'),
+    fakeEntry('c', '2026-05-04'),
+    fakeEntry('d', '2026-05-03'),
+  ];
+
+  test('returns previous (older) and next (newer) for a middle entry', () => {
+    const result = getPrevNextEntries(entries, 'b');
+    expect(result.previous?.id).toBe('c');
+    expect(result.next?.id).toBe('a');
+  });
+
+  test('returns null for previous when entry is the oldest', () => {
+    const result = getPrevNextEntries(entries, 'd');
+    expect(result.previous).toBeNull();
+    expect(result.next?.id).toBe('c');
+  });
+
+  test('returns null for next when entry is the newest', () => {
+    const result = getPrevNextEntries(entries, 'a');
+    expect(result.previous?.id).toBe('b');
+    expect(result.next).toBeNull();
+  });
+
+  test('returns both null when entry id is not found', () => {
+    const result = getPrevNextEntries(entries, 'missing');
+    expect(result.previous).toBeNull();
+    expect(result.next).toBeNull();
+  });
+
+  test('works on an unsorted input array (sorts internally)', () => {
+    const shuffled = [entries[2], entries[0], entries[3], entries[1]];
+    const result = getPrevNextEntries(shuffled, 'b');
+    expect(result.previous?.id).toBe('c');
+    expect(result.next?.id).toBe('a');
+  });
+});
+
+describe('getRelatedEntries', () => {
+  function tagged(id: string, dateISO: string, tags: string[]): CollectionEntry<'changelog'> {
+    return {
+      id,
+      collection: 'changelog',
+      data: {
+        title: id,
+        date: new Date(dateISO),
+        description: '',
+        tags,
+      },
+    } as unknown as CollectionEntry<'changelog'>;
+  }
+
+  const entries = [
+    tagged('a', '2026-05-06', ['Merge Queue']),
+    tagged('b', '2026-05-05', ['Merge Queue', 'Workflow Automation']),
+    tagged('c', '2026-05-04', ['CI Insights']),
+    tagged('d', '2026-05-03', ['Merge Queue']),
+    tagged('e', '2026-05-02', ['Merge Queue']),
+    tagged('f', '2026-05-01', ['Merge Queue']),
+  ];
+
+  test('returns most-recent entries sharing the primary tag, excluding current', () => {
+    const result = getRelatedEntries(entries, 'a', 'Merge Queue', 4);
+    expect(result.map((e) => e.id)).toEqual(['b', 'd', 'e', 'f']);
+  });
+
+  test('respects the limit', () => {
+    const result = getRelatedEntries(entries, 'a', 'Merge Queue', 2);
+    expect(result.map((e) => e.id)).toEqual(['b', 'd']);
+  });
+
+  test('returns empty array when no other entry shares the tag', () => {
+    const result = getRelatedEntries(entries, 'c', 'CI Insights', 4);
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty array when primary tag is undefined', () => {
+    const result = getRelatedEntries(entries, 'a', undefined, 4);
+    expect(result).toEqual([]);
+  });
+
+  test('matches when the tag is in any position of the entry tags array', () => {
+    const result = getRelatedEntries(entries, 'a', 'Workflow Automation', 4);
+    expect(result.map((e) => e.id)).toEqual(['b']);
+  });
+});
+
+describe('renderInlineMarkdown', () => {
+  test('passes plain text through unchanged', () => {
+    expect(renderInlineMarkdown('Hello world')).toBe('Hello world');
+  });
+
+  test('converts backtick code spans to <code> tags', () => {
+    expect(renderInlineMarkdown('Configure `auto_merge_conditions`')).toBe(
+      'Configure <code>auto_merge_conditions</code>'
+    );
+  });
+
+  test('handles multiple code spans on one line', () => {
+    expect(renderInlineMarkdown('`foo` and `bar`')).toBe('<code>foo</code> and <code>bar</code>');
+  });
+
+  test('escapes HTML in surrounding text', () => {
+    expect(renderInlineMarkdown('Use <script> tag')).toBe('Use &lt;script&gt; tag');
+  });
+
+  test('escapes HTML inside code spans too', () => {
+    expect(renderInlineMarkdown('use `<div>` here')).toBe('use <code>&lt;div&gt;</code> here');
+  });
+
+  test('leaves an unpaired backtick literal', () => {
+    expect(renderInlineMarkdown('only `one open')).toBe('only `one open');
+  });
+
+  test('escapes ampersands and quotes', () => {
+    expect(renderInlineMarkdown('Tom & Jerry "win"')).toBe('Tom &amp; Jerry &quot;win&quot;');
+  });
+});

--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -124,3 +124,88 @@ export function formatMonthYear(date: Date | string): string {
     month: 'long',
   });
 }
+
+/**
+ * Render a tiny subset of inline markdown for changelog titles: backtick code
+ * spans become <code>. HTML is escaped first, so the result is safe to render
+ * with set:html. We avoid a full markdown parser because titles only ever use
+ * code spans in practice.
+ */
+export function renderInlineMarkdown(text: string): string {
+  const escaped = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+  return escaped.replace(/`([^`]+)`/g, '<code>$1</code>');
+}
+
+export interface ProductAccent {
+  bar: string;
+  text: string;
+}
+
+const PRODUCT_ACCENTS: Record<string, ProductAccent> = {
+  'Merge Queue': { bar: 'var(--color-teal-700)', text: 'var(--color-teal-700)' },
+  'Workflow Automation': { bar: 'var(--color-rose-700)', text: 'var(--color-rose-700)' },
+  'CI Insights': { bar: 'var(--color-purple-700)', text: 'var(--color-purple-700)' },
+  'Test Insights': { bar: 'var(--color-orange-700)', text: 'var(--color-orange-700)' },
+  'Merge Protections': { bar: 'var(--color-blue-700)', text: 'var(--color-blue-700)' },
+  Stacks: { bar: 'var(--color-coral-700)', text: 'var(--color-coral-700)' },
+  Enterprise: { bar: 'var(--theme-text)', text: 'var(--theme-text)' },
+};
+
+const NEUTRAL_ACCENT: ProductAccent = {
+  bar: 'var(--theme-text-muted)',
+  text: 'var(--theme-text-secondary)',
+};
+
+/**
+ * Map a changelog tag to its left-bar accent color and detail-page eyebrow color.
+ * Unknown tags (and Deprecations) fall back to a neutral gray.
+ */
+export function getProductAccent(tag: string | undefined): ProductAccent {
+  if (!tag) return NEUTRAL_ACCENT;
+  return PRODUCT_ACCENTS[tag] ?? NEUTRAL_ACCENT;
+}
+
+export interface PrevNext {
+  previous: CollectionEntry<'changelog'> | null;
+  next: CollectionEntry<'changelog'> | null;
+}
+
+/**
+ * Given a sorted-or-unsorted list of changelog entries and a current entry id,
+ * return the chronologically previous (older) and next (newer) entries.
+ */
+export function getPrevNextEntries(
+  entries: CollectionEntry<'changelog'>[],
+  currentId: string
+): PrevNext {
+  const sorted = sortChangelog(entries);
+  const idx = sorted.findIndex((e) => e.id === currentId);
+  if (idx === -1) return { previous: null, next: null };
+  return {
+    // sorted is newest-first, so previous (older) is at idx + 1
+    previous: sorted[idx + 1] ?? null,
+    next: sorted[idx - 1] ?? null,
+  };
+}
+
+/**
+ * Return up to `limit` most-recent entries that share the given tag,
+ * excluding the entry with `currentId`. Returns [] when tag is undefined
+ * or no other entry matches.
+ */
+export function getRelatedEntries(
+  entries: CollectionEntry<'changelog'>[],
+  currentId: string,
+  tag: string | undefined,
+  limit: number
+): CollectionEntry<'changelog'>[] {
+  if (!tag) return [];
+  return sortChangelog(entries)
+    .filter((e) => e.id !== currentId && (e.data.tags || []).includes(tag))
+    .slice(0, limit);
+}


### PR DESCRIPTION
Foundation for the changelog redesign — added in isolation so it can be
reviewed independently of the page rewrites that consume it.

Schema (src/content.config.ts): optional image: { src, alt } field.
Existing entries are unaffected; future entries that ship with a
screenshot can opt into the marquee card variant.

Helpers (src/util/changelog.ts): four pure functions, 27 tests in
src/util/changelog.test.ts.
- getProductAccent — maps a tag to its left-bar / eyebrow accent color
  pair. Unknown tags and Deprecations fall back to a neutral gray.
- getPrevNextEntries — chronological prev/next for the detail page.
- getRelatedEntries — N most-recent entries sharing a tag, excluding
  the current entry. Used for the 'More in [product]' footer.
- renderInlineMarkdown — escapes HTML and converts backtick code spans
  to <code> tags. Used everywhere a title is rendered, since titles
  frequently reference config keys.

Components (src/components/changelog/):
- ChangelogCard — typography-only card with a 3px product-color left
  bar, date pulled to the right, tag pills always visible. Stretched-
  link from the title makes the whole card clickable.
- ChangelogMarquee — hero-bearing variant for entries that declare an
  image. Same accent system, larger title, eyebrow above. Hero is
  marked .no-zoom so it navigates to the entry instead of opening the
  global lightbox.
- ChangelogSubscribePopover — Subscribe ▾ button with a popover that
  contains both the RSS feed URL and the Slack /feed subscribe command,
  each in a copyable code box with a Copy button.

All component CSS uses semantic --theme-* tokens; the per-product
--color-* primitives flow through getProductAccent and are the
documented changelog exception per DESIGN.md.