### PR TITLE
feat(changelog): editorial redesign of /changelog index and entry pages

### DIFF
--- a/src/components/changelog/ChangelogCard.astro
+++ b/src/components/changelog/ChangelogCard.astro
@@ -1,0 +1,157 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { formatDate, getProductAccent, renderInlineMarkdown } from '~/util/changelog';
+
+interface Props {
+  entry: CollectionEntry<'changelog'>;
+}
+
+const { entry } = Astro.props;
+const { title, description, date, tags } = entry.data;
+const primaryTag = tags[0];
+const accent = getProductAccent(primaryTag);
+
+const monthDay = new Date(date).toLocaleDateString('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+---
+
+<article
+  class="card"
+  data-tags={tags.join(',')}
+  data-title={title.toLowerCase()}
+  style={`--card-accent: ${accent.bar}; --card-accent-text: ${accent.text};`}
+>
+  <div class="card-body">
+    <h3 class="card-title">
+      <a href={`/changelog/${entry.id}/`} set:html={renderInlineMarkdown(title)} />
+    </h3>
+    {description && <p class="card-desc">{description}</p>}
+  </div>
+  <div class="card-aside">
+    <time datetime={formatDate(date)} class="card-date">{monthDay}</time>
+    {tags.length > 0 && (
+      <div class="pills-stack">
+        {tags.map((t) => <span class="card-pill">{t}</span>)}
+      </div>
+    )}
+  </div>
+</article>
+
+<style>
+  .card {
+    background: var(--theme-bg-content);
+    border: 1px solid var(--theme-border);
+    border-radius: 12px;
+    padding: 18px 22px 18px 24px;
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 22px;
+    align-items: start;
+    transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+  }
+  .card:hover {
+    border-color: var(--theme-text-muted);
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.04);
+    transform: translateY(-1px);
+  }
+  .card::before {
+    content: '';
+    position: absolute;
+    top: 16px;
+    bottom: 16px;
+    left: 0;
+    width: 3px;
+    background: var(--card-accent);
+    border-radius: 0 3px 3px 0;
+  }
+  .card-body {
+    min-width: 0;
+  }
+  .card-title {
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0 0 4px;
+    line-height: 1.3;
+    color: var(--theme-text);
+  }
+  .card-title a {
+    color: inherit;
+    text-decoration: none;
+  }
+  .card-title a:hover {
+    color: var(--card-accent-text);
+  }
+  /* Stretched-link: title <a> covers the whole card, so the entire card is clickable. */
+  .card-title a::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+  }
+  .card-desc {
+    font-size: 0.8125rem;
+    color: var(--theme-text-secondary);
+    margin: 0;
+    line-height: 1.6;
+  }
+  .card-desc :global(code),
+  .card-title :global(code) {
+    background: var(--theme-bg-offset);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 0.92em;
+    font-family: var(--font-mono);
+  }
+
+  .card-aside {
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-end;
+    padding-top: 3px;
+  }
+  .card-date {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--theme-text-muted);
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+  }
+  .pills-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-end;
+  }
+  .card-pill {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.65rem;
+    padding: 3px 10px;
+    border-radius: 99px;
+    background: var(--theme-bg-offset);
+    color: var(--theme-text-secondary);
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  @media (max-width: 36rem) {
+    .card {
+      grid-template-columns: 1fr;
+      gap: 8px;
+    }
+    .card-aside {
+      flex-direction: row;
+      align-items: center;
+      justify-content: flex-start;
+    }
+    .pills-stack {
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+</style>

--- a/src/components/changelog/ChangelogMarquee.astro
+++ b/src/components/changelog/ChangelogMarquee.astro
@@ -1,0 +1,160 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { formatDate, getProductAccent, renderInlineMarkdown } from '~/util/changelog';
+
+interface Props {
+  entry: CollectionEntry<'changelog'>;
+}
+
+const { entry } = Astro.props;
+const { title, description, date, tags, image } = entry.data;
+const primaryTag = tags[0];
+const accent = getProductAccent(primaryTag);
+
+const monthDay = new Date(date).toLocaleDateString('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+---
+
+<article
+  class="marquee"
+  data-tags={tags.join(',')}
+  data-title={title.toLowerCase()}
+  style={`--card-accent: ${accent.bar}; --card-accent-text: ${accent.text};`}
+>
+  {image && <img src={image.src} alt={image.alt} class="marquee-hero no-zoom" loading="lazy" />}
+  <div class="marquee-body">
+    <div class="marquee-content">
+      {primaryTag && (
+        <div class="marquee-eyebrow"><span class="dot" />{primaryTag}</div>
+      )}
+      <h3 class="marquee-title">
+        <a href={`/changelog/${entry.id}/`} set:html={renderInlineMarkdown(title)} />
+      </h3>
+      {description && <p class="marquee-desc">{description}</p>}
+    </div>
+    <time datetime={formatDate(date)} class="marquee-date">{monthDay}</time>
+  </div>
+</article>
+
+<style>
+  .marquee {
+    background: var(--theme-bg-content);
+    border: 1px solid var(--theme-border);
+    border-radius: 14px;
+    overflow: hidden;
+    position: relative;
+    transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+  }
+  .marquee:hover {
+    border-color: var(--theme-text-muted);
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
+    transform: translateY(-1px);
+  }
+  /* Left-bar accent runs the full card so the title's stretched-link can
+     reach the hero too — see .marquee-title a::after below. */
+  .marquee::before {
+    content: '';
+    position: absolute;
+    top: 14px;
+    bottom: 14px;
+    left: 0;
+    width: 3px;
+    background: var(--card-accent);
+    border-radius: 0 3px 3px 0;
+    z-index: 2;
+  }
+  .marquee-hero {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
+    display: block;
+    cursor: pointer;
+  }
+  .marquee-body {
+    padding: 24px 26px 24px 28px;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 22px;
+    align-items: start;
+  }
+  .marquee-content {
+    min-width: 0;
+  }
+  .marquee-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--card-accent-text);
+    margin-bottom: 8px;
+  }
+  .marquee-eyebrow .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 99px;
+    background: var(--card-accent);
+  }
+  .marquee-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 6px;
+    line-height: 1.22;
+    color: var(--theme-text);
+    letter-spacing: -0.015em;
+  }
+  .marquee-title a {
+    color: inherit;
+    text-decoration: none;
+  }
+  .marquee-title a:hover {
+    color: var(--card-accent-text);
+  }
+  /* Stretched-link: title <a> covers the whole marquee (hero included),
+     since .marquee-body no longer has its own positioned context. */
+  .marquee-title a::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+  }
+  .marquee-desc {
+    font-size: 0.9375rem;
+    color: var(--theme-text-secondary);
+    margin: 0;
+    line-height: 1.6;
+  }
+  .marquee-desc :global(code),
+  .marquee-title :global(code) {
+    background: var(--theme-bg-offset);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 0.92em;
+    font-family: var(--font-mono);
+  }
+  .marquee-date {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--theme-text-muted);
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+    padding-top: 3px;
+  }
+
+  @media (max-width: 36rem) {
+    .marquee-hero {
+      height: 160px;
+    }
+    .marquee-body {
+      grid-template-columns: 1fr;
+      gap: 8px;
+    }
+    .marquee-title {
+      font-size: 1.25rem;
+    }
+  }
+</style>

--- a/src/components/changelog/ChangelogSubscribePopover.astro
+++ b/src/components/changelog/ChangelogSubscribePopover.astro
@@ -1,0 +1,220 @@
+---
+import { Icon } from 'astro-icon/components';
+
+const slackCommand = `/feed subscribe ${import.meta.env.SITE}/changelog/rss.xml`;
+---
+
+<div class="subscribe-wrap">
+  <button
+    type="button"
+    class="subscribe-btn"
+    aria-haspopup="dialog"
+    aria-expanded="false"
+    data-subscribe-toggle
+  >
+    <Icon name="lucide:rss" class="btn-icon" />
+    Subscribe
+    <span class="caret" aria-hidden="true">▾</span>
+  </button>
+  <div class="popover" role="dialog" aria-label="Subscribe options" hidden data-subscribe-popover>
+    <h6 class="pop-h">RSS</h6>
+    <p class="pop-desc">Paste this URL into your feed reader.</p>
+    <div class="pop-cmd">
+      <Icon name="lucide:rss" class="pop-icon" />
+      <code data-copy-source>{import.meta.env.SITE}/changelog/rss.xml</code>
+      <button type="button" class="pop-copy" data-copy-target="prev">Copy</button>
+    </div>
+    <div class="pop-divider"></div>
+    <h6 class="pop-h">Slack</h6>
+    <p class="pop-desc">Run this in any Slack channel to subscribe.</p>
+    <div class="pop-cmd">
+      <code data-copy-source>{slackCommand}</code>
+      <button type="button" class="pop-copy" data-copy-target="prev">Copy</button>
+    </div>
+  </div>
+</div>
+
+<script is:inline>
+  // Abort the previous wiring on each (re-)init so document-level listeners
+  // don't accumulate across Astro view-transition swaps.
+  let subscribePopoverAbort;
+
+  function initSubscribePopover() {
+    if (subscribePopoverAbort) subscribePopoverAbort.abort();
+    subscribePopoverAbort = new AbortController();
+    const signal = subscribePopoverAbort.signal;
+
+    const toggle = document.querySelector('[data-subscribe-toggle]');
+    const popover = document.querySelector('[data-subscribe-popover]');
+    if (!toggle || !popover) return;
+
+    function setOpen(open) {
+      popover.hidden = !open;
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+
+    toggle.addEventListener('click', function (e) {
+      e.stopPropagation();
+      setOpen(popover.hidden);
+    }, { signal });
+
+    document.addEventListener('click', function (e) {
+      if (popover.hidden) return;
+      if (popover.contains(e.target) || toggle.contains(e.target)) return;
+      setOpen(false);
+    }, { signal });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && !popover.hidden) {
+        setOpen(false);
+        toggle.focus();
+      }
+    }, { signal });
+
+    popover.querySelectorAll('[data-copy-target="prev"]').forEach(function (btn) {
+      const source = btn.previousElementSibling;
+      if (!source) return;
+      btn.addEventListener('click', function () {
+        const text = (source.textContent || '').trim();
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+          btn.textContent = 'Copy failed';
+          setTimeout(function () { btn.textContent = 'Copy'; }, 2000);
+          return;
+        }
+        navigator.clipboard.writeText(text).then(function () {
+          const original = btn.textContent;
+          btn.textContent = 'Copied!';
+          btn.classList.add('copied');
+          setTimeout(function () {
+            btn.textContent = original;
+            btn.classList.remove('copied');
+          }, 2000);
+        }).catch(function () {
+          btn.textContent = 'Copy failed';
+          setTimeout(function () { btn.textContent = 'Copy'; }, 2000);
+        });
+      }, { signal });
+    });
+  }
+
+  initSubscribePopover();
+  if (!window.__changelogSubscribeInit__) {
+    window.__changelogSubscribeInit__ = true;
+    document.addEventListener('astro:after-swap', initSubscribePopover);
+  }
+</script>
+
+<style>
+  .subscribe-wrap {
+    position: relative;
+  }
+  .subscribe-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--theme-text-secondary);
+    background: var(--theme-bg-content);
+    border: 1px solid var(--theme-border);
+    padding: 7px 14px;
+    border-radius: 9px;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .subscribe-btn:hover {
+    border-color: var(--theme-text-muted);
+    color: var(--theme-text);
+  }
+  .btn-icon {
+    width: 14px;
+    height: 14px;
+  }
+  .caret {
+    font-size: 0.7rem;
+    color: var(--theme-text-muted);
+  }
+
+  .popover {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    background: var(--theme-bg-content);
+    border: 1px solid var(--theme-border);
+    border-radius: 12px;
+    width: 360px;
+    padding: 16px;
+    z-index: 10;
+    box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+  }
+  @media (max-width: 28rem) {
+    .popover {
+      position: fixed;
+      top: auto;
+      bottom: 16px;
+      left: 16px;
+      right: 16px;
+      width: auto;
+    }
+  }
+
+  .pop-h {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--theme-text-muted);
+    margin: 0 0 8px;
+    font-weight: 700;
+  }
+  .pop-desc {
+    font-size: 0.75rem;
+    color: var(--theme-text-secondary);
+    margin: 0 0 10px;
+    line-height: 1.5;
+  }
+  .pop-icon {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+  }
+  .pop-divider {
+    height: 1px;
+    background: var(--theme-border);
+    margin: 14px -16px;
+  }
+  .pop-cmd {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px 8px 12px;
+    border: 1px solid var(--theme-border);
+    border-radius: 8px;
+    background: var(--theme-bg-offset);
+  }
+  .pop-cmd code {
+    flex: 1;
+    font-size: 0.7rem;
+    background: transparent;
+    padding: 0;
+    color: var(--theme-text);
+    font-family: var(--font-mono);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .pop-copy {
+    background: var(--theme-text);
+    color: var(--theme-bg-content);
+    border: none;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    padding: 5px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .pop-copy.copied {
+    background: var(--color-teal-700);
+    color: #fff;
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -28,6 +28,12 @@ const changelog = defineCollection({
     description: z.string().optional(),
     // Accept null/undefined and coerce to [] so frontmatter like `tags: null` is tolerated
     tags: z.preprocess((val) => (val == null ? [] : val), z.array(z.string())).default([]),
+    image: z
+      .object({
+        src: z.string(),
+        alt: z.string(),
+      })
+      .optional(),
   }),
 });
 

--- a/src/pages/changelog/[slug].astro
+++ b/src/pages/changelog/[slug].astro
@@ -2,333 +2,343 @@
 import type { CollectionEntry } from 'astro:content';
 import { getCollection, render } from 'astro:content';
 import MainLayout from '../../layouts/MainLayout.astro';
-import { formatDate, formatDateHuman } from '../../util/changelog';
+import {
+  formatDate,
+  formatDateHuman,
+  getProductAccent,
+  renderInlineMarkdown,
+  sortChangelog,
+} from '../../util/changelog';
 
 export async function getStaticPaths() {
-  const entries = await getCollection('changelog');
-  return entries.map((entry) => ({
-    params: { slug: entry.id },
-    props: { entry },
-  }));
+  // Sort + index once at build time; per-entry lookups stay O(1) for prev/next
+  // and O(N) for related, instead of duplicating the full collection into
+  // every page's props. Astro evaluates getStaticPaths in an isolated context,
+  // so any helpers it depends on must be imported (not declared at module
+  // scope outside this function).
+  const RELATED_LIMIT = 4;
+  const sorted = sortChangelog(await getCollection('changelog'));
+  return sorted.map((entry, idx) => {
+    const previous = sorted[idx + 1] ?? null; // older
+    const next = sorted[idx - 1] ?? null; // newer
+    const primaryTag = entry.data.tags[0];
+    const related = primaryTag
+      ? sorted
+          .filter((e) => e.id !== entry.id && (e.data.tags || []).includes(primaryTag))
+          .slice(0, RELATED_LIMIT)
+      : [];
+    return {
+      params: { slug: entry.id },
+      props: { entry, previous, next, related },
+    };
+  });
 }
 
 interface Props {
   entry: CollectionEntry<'changelog'>;
+  previous: CollectionEntry<'changelog'> | null;
+  next: CollectionEntry<'changelog'> | null;
+  related: CollectionEntry<'changelog'>[];
 }
 
-const { entry } = Astro.props;
+const { entry, previous, next, related } = Astro.props;
 const { Content } = await render(entry);
-const { title, description, date, tags } = entry.data;
+const { title, description, date, tags, image } = entry.data;
+const primaryTag = tags[0];
+const accent = getProductAccent(primaryTag);
 ---
 
-<MainLayout content={{ title, description: description || '', suppressTitle: false }} breadcrumbTitle={title}>
-  <article class="changelog-entry">
-    <header class="entry-header">
-      <div class="header-meta">
-        <time datetime={formatDate(date)} class="date">{formatDateHuman(date)}</time>
-      </div>
-      {tags && tags.length > 0 && (
-        <ul class="tag-list" role="list" aria-label="Categories">
-          {tags.map(tag => (
-            <li><span class="tag">{tag}</span></li>
-          ))}
-        </ul>
-      )}
-    </header>
+<MainLayout
+  content={{ title, description: description || '', suppressTitle: true }}
+  breadcrumbTitle={title}
+>
+  <article
+    class="changelog-detail"
+    style={`--card-accent: ${accent.bar}; --card-accent-text: ${accent.text};`}
+  >
+    {primaryTag && (
+      <div class="detail-eyebrow"><span class="dot" />{primaryTag}</div>
+    )}
+    <h1 class="detail-title" set:html={renderInlineMarkdown(title)} />
+    <time datetime={formatDate(date)} class="detail-date">{formatDateHuman(date)}</time>
+    {description && <p class="detail-lede">{description}</p>}
 
-    <div class="entry-content">
+    {image && (
+      <img src={image.src} alt={image.alt} class="detail-hero" loading="eager" />
+    )}
+
+    <div class="detail-body">
       <Content />
     </div>
 
-    <footer class="entry-footer">
-      <a href="/changelog/" class="back-button">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M19 12H5M12 19l-7-7 7-7"/>
-        </svg>
-        Back to Changelog
-      </a>
-    </footer>
+    {(previous || next) && (
+      <nav class="detail-nav" aria-label="Adjacent entries">
+        {previous ? (
+          <a class="nav-link prev" href={`/changelog/${previous.id}/`}>
+            <span class="nav-label">← Previous</span>
+            <span class="nav-title" set:html={renderInlineMarkdown(previous.data.title)} />
+          </a>
+        ) : <span />}
+        {next ? (
+          <a class="nav-link next" href={`/changelog/${next.id}/`}>
+            <span class="nav-label">Next →</span>
+            <span class="nav-title" set:html={renderInlineMarkdown(next.data.title)} />
+          </a>
+        ) : <span />}
+      </nav>
+    )}
+
+    {related.length >= 2 && (
+      <section class="detail-related" aria-labelledby="related-h">
+        <h2 id="related-h" class="related-heading">More in {primaryTag}</h2>
+        <div class="related-grid">
+          {related.map((r) => (
+            <a class="related-card" href={`/changelog/${r.id}/`}>
+              <span class="related-title" set:html={renderInlineMarkdown(r.data.title)} />
+              <span class="related-date">{formatDateHuman(r.data.date)}</span>
+            </a>
+          ))}
+        </div>
+      </section>
+    )}
   </article>
-</MainLayout>
 
-<style>
-  .changelog-entry {
-    max-width: 75ch;
-  }
-
-  /* Header section */
-  .entry-header {
-    margin-bottom: 3rem;
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 2rem;
-    align-items: center;
-  }
-
-  .header-meta {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    align-items: flex-start;
-  }
-
-  .date {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--theme-text-secondary);
-    letter-spacing: 0.01em;
-    background: var(--theme-bg-offset);
-    padding: 0.5rem 1rem;
-    border-radius: 6px;
-    border: 1px solid var(--theme-border);
-    display: inline-block;
-  }
-
-  .theme-dark .date {
-    background: var(--theme-bg-offset);
-    color: var(--theme-text-secondary);
-    border-color: var(--theme-border);
-  }
-
-  .tag-list {
-    list-style: none;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    padding: 0;
-    margin: 0;
-    align-items: flex-end;
-    justify-content: flex-end;
-  }
-
-  @media (max-width: 50em) {
-    .entry-header {
-      grid-template-columns: 1fr;
+  <style>
+    .changelog-detail {
+      max-width: 45rem;
+      margin: 0 auto;
     }
 
-    .tag-list {
-      align-items: flex-start;
-      justify-content: flex-start;
+    .detail-eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--card-accent-text);
+      margin-bottom: 10px;
     }
-  }
-
-  .tag {
-    background: var(--theme-bg-offset);
-    color: var(--theme-text-secondary);
-    font-size: 0.75rem;
-    font-weight: 600;
-    padding: 0.4rem 0.75rem;
-    border-radius: 6px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    border: 1px solid var(--theme-border);
-  }
-
-  .theme-dark .tag {
-    background: var(--theme-bg-offset);
-    color: var(--theme-text-secondary);
-    border-color: var(--theme-border);
-  }
-
-  .entry-title {
-    font-size: 2.25rem;
-    font-weight: 700;
-    line-height: 1.2;
-    margin: 0 0 1rem;
-    color: var(--theme-text);
-    letter-spacing: -0.02em;
-  }
-
-  @media (max-width: 50em) {
-    .entry-title {
-      font-size: 1.75rem;
+    .detail-eyebrow .dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 99px;
+      background: var(--card-accent);
     }
-  }
 
-  .lead {
-    font-size: 1.25rem;
-    line-height: 1.6;
-    color: var(--theme-text-secondary);
-    margin: 0;
-    font-weight: 400;
-  }
+    .detail-title {
+      font-size: 2.25rem;
+      line-height: 1.16;
+      font-weight: 700;
+      margin: 0;
+      letter-spacing: -0.02em;
+      color: var(--theme-text);
+    }
+    .detail-title :global(code) {
+      background: var(--theme-bg-offset);
+      padding: 1px 8px;
+      border-radius: 4px;
+      font-size: 0.92em;
+      font-family: var(--font-mono);
+    }
+    @media (max-width: 36rem) {
+      .detail-title {
+        font-size: 1.75rem;
+      }
+    }
+    /* Disable global heading auto-numbering */
+    .changelog-detail .detail-title {
+      counter-increment: none !important;
+    }
+    .changelog-detail .detail-title::before {
+      content: none !important;
+    }
 
-  @media (max-width: 50em) {
-    .lead {
+    .detail-date {
+      font-size: 0.8125rem;
+      color: var(--theme-text-muted);
+      margin-top: 14px;
+      display: block;
+    }
+
+    .detail-lede {
       font-size: 1.125rem;
+      color: var(--theme-text-secondary);
+      line-height: 1.55;
+      margin: 22px 0 0;
     }
-  }
 
-  /* Content section */
-  .entry-content {
-    font-size: 1.0625rem;
-    line-height: 1.75;
-    color: var(--theme-text);
-  }
+    .detail-hero {
+      display: block;
+      width: 100%;
+      max-height: 400px;
+      object-fit: cover;
+      border-radius: 14px;
+      margin-top: 28px;
+    }
 
-  .entry-content :global(h2) {
-    margin-top: 2.5rem;
-    margin-bottom: 1rem;
-    font-size: 1.75rem;
-    font-weight: 600;
-    line-height: 1.3;
-    letter-spacing: -0.01em;
-  }
+    .detail-body {
+      font-size: 1rem;
+      line-height: 1.75;
+      color: var(--theme-text);
+      margin-top: 32px;
+    }
+    .detail-body :global(h2) {
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+      font-size: 1.5rem;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+    .detail-body :global(h3) {
+      margin-top: 2rem;
+      margin-bottom: 0.875rem;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .detail-body :global(p) {
+      margin-bottom: 1.25rem;
+    }
+    .detail-body :global(ul),
+    .detail-body :global(ol) {
+      margin-bottom: 1.25rem;
+      padding-left: 1.75rem;
+    }
+    .detail-body :global(li) {
+      margin-bottom: 0.5rem;
+    }
+    .detail-body :global(code) {
+      background: var(--theme-bg-offset);
+      color: var(--theme-text);
+      padding: 0.2em 0.4em;
+      border-radius: 4px;
+      font-size: 0.9em;
+      font-family: var(--font-mono);
+    }
+    .detail-body :global(pre) {
+      margin: 1.5rem 0;
+      padding: 1.25rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      background: var(--theme-bg-offset);
+      border: 1px solid var(--theme-border);
+    }
+    .detail-body :global(pre code) {
+      background: none;
+      padding: 0;
+      color: inherit;
+    }
+    .detail-body :global(a) {
+      color: var(--theme-accent);
+      text-decoration: underline;
+    }
+    .detail-body :global(img) {
+      max-width: 100%;
+      height: auto;
+      border-radius: 8px;
+      margin: 2rem 0;
+    }
 
-  .entry-content :global(h3) {
-    margin-top: 2rem;
-    margin-bottom: 0.875rem;
-    font-size: 1.375rem;
-    font-weight: 600;
-    line-height: 1.4;
-  }
+    .detail-nav {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 14px;
+      margin-top: 40px;
+      border-top: 1px solid var(--theme-border);
+      padding-top: 22px;
+    }
+    .nav-link {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+      border: 1px solid var(--theme-border);
+      border-radius: 12px;
+      padding: 14px 18px;
+      text-decoration: none;
+      color: var(--theme-text);
+      transition: border-color 0.15s, transform 0.15s;
+    }
+    .nav-link:hover {
+      border-color: var(--theme-text-muted);
+      transform: translateY(-1px);
+    }
+    .nav-link.next {
+      text-align: right;
+    }
+    .nav-label {
+      font-size: 0.6875rem;
+      color: var(--theme-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 600;
+    }
+    .nav-title {
+      font-size: 0.875rem;
+      font-weight: 600;
+      line-height: 1.35;
+    }
+    @media (max-width: 36rem) {
+      .detail-nav {
+        grid-template-columns: 1fr;
+      }
+      .nav-link.next {
+        text-align: left;
+      }
+    }
 
-  .entry-content :global(p) {
-    margin-bottom: 1.25rem;
-  }
-
-  .entry-content :global(ul),
-  .entry-content :global(ol) {
-    margin-bottom: 1.25rem;
-    padding-left: 1.75rem;
-  }
-
-  .entry-content :global(li) {
-    margin-bottom: 0.5rem;
-  }
-
-  .entry-content :global(li > p) {
-    margin-bottom: 0.5rem;
-  }
-
-  .entry-content :global(img) {
-    max-width: 100%;
-    height: auto;
-    border-radius: 8px;
-    margin: 2rem 0;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  }
-
-  .theme-dark .entry-content :global(img) {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  }
-
-  .entry-content :global(code) {
-    background: var(--theme-code-inline-bg);
-    color: var(--theme-code-inline-text);
-    padding: 0.2em 0.4em;
-    border-radius: 4px;
-    font-size: 0.9em;
-    font-family: var(--font-mono);
-  }
-
-  .entry-content :global(pre) {
-    margin: 1.5rem 0;
-    padding: 1.25rem;
-    border-radius: 8px;
-    overflow-x: auto;
-    background: var(--theme-code-bg);
-    border: 1px solid var(--theme-border-color);
-  }
-
-  .entry-content :global(pre code) {
-    background: none;
-    padding: 0;
-    color: inherit;
-    font-size: 0.875rem;
-  }
-
-  .entry-content :global(blockquote) {
-    margin: 1.5rem 0;
-    padding: 1rem 1.25rem;
-    border-left: 4px solid var(--theme-border);
-    background: var(--theme-bg-offset);
-    color: var(--theme-text-secondary);
-    font-style: italic;
-  }
-
-  .theme-dark .entry-content :global(blockquote) {
-    border-left-color: var(--theme-border);
-    background: var(--theme-bg-offset);
-  }
-
-  .entry-content :global(a) {
-    color: var(--theme-text);
-    text-decoration: underline;
-    text-decoration-color: var(--theme-border);
-    text-underline-offset: 2px;
-    transition: text-decoration-color 0.2s;
-  }
-
-  .entry-content :global(a:hover) {
-    text-decoration-color: var(--theme-text-muted);
-  }
-
-  .entry-content :global(hr) {
-    margin: 2.5rem 0;
-    border: none;
-    border-top: 1px solid var(--theme-border-color);
-  }
-
-  /* Spacing adjustments */
-  .entry-content > :global(*:first-child) {
-    margin-top: 0;
-  }
-
-  .entry-content > :global(*:last-child) {
-    margin-bottom: 0;
-  }
-
-  /* Footer */
-  .entry-footer {
-    margin-top: 4rem;
-  }
-
-  .back-button {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    text-decoration: none;
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--theme-text-secondary);
-    background: var(--theme-bg-offset);
-    padding: 0.5rem 1rem;
-    border-radius: 6px;
-    border: 1px solid var(--theme-border);
-    transition: all 0.2s ease;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-  }
-
-  .back-button:hover {
-    background: var(--theme-accent);
-    color: var(--theme-bg-content);
-    border-color: var(--theme-accent);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    transform: translateY(-1px);
-  }
-
-  .back-button:active {
-    transform: translateY(0);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-  }
-
-  .back-button svg {
-    width: 16px;
-    height: 16px;
-    flex-shrink: 0;
-  }
-
-  .theme-dark .back-button {
-    background: var(--theme-bg-offset);
-    color: var(--theme-text-secondary);
-    border-color: var(--theme-border);
-  }
-
-  .theme-dark .back-button:hover {
-    background: var(--theme-accent);
-    color: var(--theme-bg-content);
-    border-color: var(--theme-accent);
-  }
-</style>
+    .detail-related {
+      margin-top: 40px;
+      border-top: 1px solid var(--theme-border);
+      padding-top: 22px;
+    }
+    .related-heading {
+      font-size: 0.6875rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--theme-text-muted);
+      font-weight: 700;
+      margin: 0 0 14px;
+    }
+    /* Disable global heading auto-numbering on related-heading */
+    .changelog-detail .related-heading {
+      counter-increment: none !important;
+    }
+    .changelog-detail .related-heading::before {
+      content: none !important;
+    }
+    .related-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+    }
+    @media (max-width: 36rem) {
+      .related-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+    .related-card {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      border: 1px solid var(--theme-border);
+      border-radius: 10px;
+      padding: 12px 14px;
+      text-decoration: none;
+      color: var(--theme-text);
+      transition: border-color 0.15s;
+    }
+    .related-card:hover {
+      border-color: var(--theme-text-muted);
+    }
+    .related-title {
+      font-size: 0.84375rem;
+      font-weight: 600;
+      line-height: 1.35;
+    }
+    .related-date {
+      font-size: 0.6875rem;
+      color: var(--theme-text-muted);
+    }
+  </style>
+</MainLayout>

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -1,6 +1,9 @@
 ---
 import { getCollection } from 'astro:content';
 import { Icon } from 'astro-icon/components';
+import ChangelogCard from '../../components/changelog/ChangelogCard.astro';
+import ChangelogMarquee from '../../components/changelog/ChangelogMarquee.astro';
+import ChangelogSubscribePopover from '../../components/changelog/ChangelogSubscribePopover.astro';
 import enterpriseReleases from '../../data/enterprise-releases.json';
 import MainLayout from '../../layouts/MainLayout.astro';
 import type { TimelineEntry } from '../../util/changelog';
@@ -8,32 +11,21 @@ import { formatDate, groupTimelineByYearMonth, sortChangelog } from '../../util/
 
 const ENTERPRISE_TAG = 'Enterprise';
 const entries = sortChangelog(await getCollection('changelog'));
-// Derive tag info (entries may have no tags)
-const allTags = Array.from(new Set(entries.flatMap((e) => e.data.tags || []))).sort();
-const tagsWithEnterprise = Array.from(new Set([...allTags, ENTERPRISE_TAG]));
-type EnterpriseRelease = {
-  version: string;
-  releasedAt: string;
-};
+const productTags = Array.from(new Set(entries.flatMap((e) => e.data.tags || []))).sort();
+const allTags = [...productTags, ENTERPRISE_TAG];
 
+type EnterpriseRelease = { version: string; releasedAt: string };
 const releaseMarkers: TimelineEntry[] = (enterpriseReleases as EnterpriseRelease[]).map(
-  (release) => ({
-    kind: 'release',
-    date: release.releasedAt,
-    version: release.version,
-  })
+  (release) => ({ kind: 'release', date: release.releasedAt, version: release.version })
 );
-
 const changelogTimeline: TimelineEntry[] = entries.map((entry) => ({
   kind: 'changelog',
   date: entry.data.date,
   entry,
 }));
-
 const timelineEntries: TimelineEntry[] = [...changelogTimeline, ...releaseMarkers].sort(
   (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
 );
-
 const groupedTimeline = groupTimelineByYearMonth(timelineEntries);
 const years = Object.keys(groupedTimeline).sort((a, b) => b.localeCompare(a));
 
@@ -41,545 +33,328 @@ const title = 'Changelog';
 const description = 'Latest product updates from Mergify.';
 ---
 
-<MainLayout content={{ title, description, suppressTitle: false }} showMarkdownActions={false}>
-    <div class="changelog-header">
-      <div class="search-wrap">
-        <label for="search" class="sr-only">Search changelog</label>
-        <input id="search" type="search" placeholder="Search changes..." aria-label="Search changelog" />
+<MainLayout content={{ title, description, suppressTitle: true }} showMarkdownActions={false}>
+  <div class="changelog-page">
+    <header class="cl-header">
+      <h1 class="cl-title">Changelog</h1>
+      <div class="cl-actions">
+        <label class="cl-search" for="changelog-search">
+          <Icon name="lucide:search" class="search-icon" />
+          <input
+            id="changelog-search"
+            type="search"
+            placeholder="Search updates…"
+            aria-label="Search changelog"
+          />
+          <kbd class="cl-kbd">⌘K</kbd>
+        </label>
+        <ChangelogSubscribePopover />
       </div>
-      <a href="/changelog/rss.xml" class="rss-button" aria-label="Subscribe to RSS feed">
-        <Icon name="lucide:rss" />
-        Subscribe via RSS
-      </a>
-    </div>
+    </header>
 
-    <div class="slack-subscribe">
-      <div class="slack-content">
-        <Icon name="simple-icons:slack" class="slack-icon" />
-        <span class="slack-text">Stay updated on Slack! Subscribe to get changelog updates in your workspace:</span>
-      </div>
-      <div class="slack-command">
-        <code id="slack-command-text">{`/feed subscribe ${import.meta.env.SITE}/changelog/rss.xml`}</code>
-        <button id="copy-slack-command" class="copy-btn" aria-label="Copy Slack command">
-          <span class="copy-icon">📋</span>
-          <span class="copy-text">Copy</span>
-        </button>
-      </div>
-    </div>
-
-    <div class="tag-pills tag-pills-row" id="tag-pills" aria-label="Tag filter">
-      <button data-tag="" class="pill active" aria-pressed="true">All</button>
-      {tagsWithEnterprise.map(tag => (
-        <button data-tag={tag} class="pill" aria-pressed="false">{tag}</button>
+    <nav class="cl-tabs" id="cl-tabs" aria-label="Filter by product">
+      <button data-tag="" class="cl-tab is-active" aria-pressed="true">All</button>
+      {allTags.map((tag) => (
+        <button data-tag={tag} class="cl-tab" aria-pressed="false">{tag}</button>
       ))}
-    </div>
-  {years.map(year => {
-    const months = Object.keys(groupedTimeline[year]).sort((a, b) => {
-      // Sort months in reverse chronological order
-      const dateA = new Date(`${a} 1, ${year}`);
-      const dateB = new Date(`${b} 1, ${year}`);
-      return dateB.getTime() - dateA.getTime();
-    });
+    </nav>
 
-    return (
-      <section class="year" data-year={year}>
-        <h2 class="no-counter year-heading">{year}</h2>
-        {months.map(month => (
-          <div class="month-group">
-            <h3 class="month-heading">{month}</h3>
-            <ul class="entry-list" role="list">
-              {groupedTimeline[year][month].map(item => (
-                item.kind === 'release' ? (
-                  <li
-                    class="entry entry-release"
-                    data-kind="release"
-                    data-tags={ENTERPRISE_TAG}
-                    data-title={`enterprise ${item.version}`}
-                  >
-                    <div class="row">
-                      <div class="col date-tags">
-                        <time datetime={formatDate(item.date)} class="date">
-                          {formatDate(item.date)}
-                        </time>
-                        <span class="tag tag-enterprise" data-tag={ENTERPRISE_TAG}>{ENTERPRISE_TAG}</span>
-                      </div>
-                      <div class="col content-col">
-                        <div class="release-title">
-                          <Icon name="lucide:factory" class="release-icon" aria-hidden="true" />
-                          <span class="sr-only">Enterprise release</span>
-                          <span>{ENTERPRISE_TAG} {item.version}</span>
-                        </div>
-                        <p class="summary release-summary">
-                          Enterprise bundle shipping for self-hosted customers.
-                        </p>
-                      </div>
-                    </div>
-                  </li>
-                ) : (
-                  <li
-                    class="entry"
-                    data-kind="changelog"
-                    data-tags={(item.entry.data.tags || []).join(',')}
-                    data-title={item.entry.data.title.toLowerCase()}
-                  >
-                    <div class="row">
-                      <div class="col date-tags">
-                        <time datetime={formatDate(item.entry.data.date)} class="date">
-                          {formatDate(item.entry.data.date)}
-                        </time>
-                        {item.entry.data.tags.length ? (
-                          <ul class="tag-list" aria-label="Tags">
-                            {item.entry.data.tags.map(t => (
-                              <li>
-                                <span class="tag" data-tag={t}>
-                                  {t}
-                                </span>
-                              </li>
-                            ))}
-                          </ul>
-                        ) : null}
-                      </div>
-                      <div class="col content-col">
-                        <h3 class="title">
-                          <a href={`/changelog/${item.entry.id}/`}>{item.entry.data.title}</a>
-                        </h3>
-                        {item.entry.data.description && <p class="summary">{item.entry.data.description}</p>}
-                      </div>
-                      <div class="col more-col">
-                        <a
-                          class="read-more"
-                          href={`/changelog/${item.entry.id}/`}
-                          aria-label={`Read full entry: ${item.entry.data.title}`}
-                        >
-                          <span class="read-text">Read</span>
-                          <span class="read-icon" aria-hidden="true">
-                            →
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                  </li>
-                )
-              ))}
-            </ul>
-          </div>
-        ))}
-      </section>
-    );
-  })}
-  <p id="no-results" hidden>No matching entries.</p>
+    {years.map((year) => {
+      const months = Object.keys(groupedTimeline[year]).sort((a, b) => {
+        const da = new Date(`${a} 1, ${year}`);
+        const db = new Date(`${b} 1, ${year}`);
+        return db.getTime() - da.getTime();
+      });
+      return (
+        <section class="cl-year" data-year={year}>
+          <h2 class="cl-year-heading" id={`year-${year}`}>{year}</h2>
+          {months.map((month) => (
+            <div class="cl-month-group">
+              <h3 class="cl-month-heading">{month}</h3>
+              <div class="cl-feed">
+                {groupedTimeline[year][month].map((item) => (
+                  item.kind === 'release' ? (
+                    <article
+                      class="cl-release"
+                      data-tags={ENTERPRISE_TAG}
+                      data-title={`enterprise ${item.version}`}
+                    >
+                      <Icon name="lucide:server" class="release-icon" aria-hidden="true" />
+                      <span class="release-text">
+                        <strong>Enterprise {item.version}</strong>
+                        <span class="release-sub">released for self-hosted</span>
+                      </span>
+                      <time datetime={formatDate(item.date)} class="release-date">
+                        {new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                      </time>
+                    </article>
+                  ) : (
+                    item.entry.data.image
+                      ? <ChangelogMarquee entry={item.entry} />
+                      : <ChangelogCard entry={item.entry} />
+                  )
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      );
+    })}
+
+    <p id="cl-no-results" class="cl-no-results" hidden>No matching entries.</p>
+  </div>
+
   <script is:inline>
-    function initChangelog() {
-      var search = document.getElementById('search');
-      var pillBar = document.getElementById('tag-pills');
-      var entryRows = Array.from(document.querySelectorAll('.entry'));
-      var noResults = document.getElementById('no-results');
-      if (!search || !noResults || !pillBar) return;
+    function initChangelogIndex() {
+      var search = document.getElementById('changelog-search');
+      var tabBar = document.getElementById('cl-tabs');
+      var entryEls = Array.from(document.querySelectorAll('.cl-feed > [data-tags]'));
+      var noResults = document.getElementById('cl-no-results');
+      if (!search || !tabBar || !noResults) return;
       var activeTag = '';
 
       function applyFilter() {
         var q = (search.value || '').trim().toLowerCase();
-        var visibleCount = 0;
-        entryRows.forEach(function(el) {
-          var tags = (el.getAttribute('data-tags')||'').split(',').filter(Boolean);
-          var title = el.getAttribute('data-title') || '';
-          var matchesTag = !activeTag || tags.includes(activeTag);
-          var matchesSearch = !q || title.includes(q);
+        var visible = 0;
+        entryEls.forEach(function (el) {
+          var tags = (el.getAttribute('data-tags') || '').split(',').filter(Boolean);
+          var ttl = el.getAttribute('data-title') || '';
+          var matchesTag = !activeTag || tags.indexOf(activeTag) !== -1;
+          var matchesSearch = !q || ttl.indexOf(q) !== -1;
           var show = matchesTag && matchesSearch;
           el.style.display = show ? '' : 'none';
-          if (show) visibleCount++;
+          if (show) visible++;
         });
-        noResults.hidden = visibleCount !== 0;
-        var monthGroups = Array.from(document.querySelectorAll('.month-group'));
-        monthGroups.forEach(function(group) {
-          var entriesInGroup = Array.from(group.querySelectorAll('.entry'));
-          var anyVisible = entriesInGroup.some(function(e) { return e.style.display !== 'none'; });
-          if (activeTag) {
-            group.style.display = anyVisible ? '' : 'none';
-          } else {
-            group.style.display = '';
-          }
+        noResults.hidden = visible !== 0;
+
+        Array.from(document.querySelectorAll('.cl-month-group')).forEach(function (g) {
+          var any = Array.from(g.querySelectorAll('[data-tags]')).some(function (e) {
+            return e.style.display !== 'none';
+          });
+          g.style.display = activeTag || q ? (any ? '' : 'none') : '';
         });
-        var yearSections = Array.from(document.querySelectorAll('section.year'));
-        yearSections.forEach(function(year) {
-          var months = Array.from(year.querySelectorAll('.month-group'));
-          var anyMonthVisible = months.some(function(m) { return m.style.display !== 'none'; });
-          if (activeTag) {
-            year.style.display = anyMonthVisible ? '' : 'none';
-          } else {
-            year.style.display = '';
-          }
+        Array.from(document.querySelectorAll('.cl-year')).forEach(function (y) {
+          var any = Array.from(y.querySelectorAll('.cl-month-group')).some(function (g) {
+            return g.style.display !== 'none';
+          });
+          y.style.display = activeTag || q ? (any ? '' : 'none') : '';
         });
       }
 
-      pillBar.addEventListener('click', function(e) {
-        if (!e.target) return;
-        var btn = e.target.closest('button[data-tag]');
+      tabBar.addEventListener('click', function (e) {
+        var btn = e.target && e.target.closest('button[data-tag]');
         if (!btn) return;
         activeTag = btn.dataset.tag || '';
-        pillBar.querySelectorAll('button[data-tag]').forEach(function(b) {
-          var on = (b === btn);
-          b.classList.toggle('active', on);
+        tabBar.querySelectorAll('button[data-tag]').forEach(function (b) {
+          var on = b === btn;
+          b.classList.toggle('is-active', on);
           b.setAttribute('aria-pressed', on ? 'true' : 'false');
         });
         applyFilter();
       });
-
       search.addEventListener('input', applyFilter);
+    }
 
-      // Copy Slack command functionality
-      var copyBtn = document.getElementById('copy-slack-command');
-      var commandText = document.getElementById('slack-command-text');
+    initChangelogIndex();
+    if (!window.__changelogIndexInit__) {
+      window.__changelogIndexInit__ = true;
+      document.addEventListener('astro:after-swap', initChangelogIndex);
+    }
+  </script>
 
-      if (copyBtn && commandText) {
-        copyBtn.addEventListener('click', function() {
-          var text = commandText.textContent || '';
-          if (!navigator.clipboard || !navigator.clipboard.writeText) return;
-          navigator.clipboard.writeText(text).then(function() {
-            var copyTextSpan = copyBtn.querySelector('.copy-text');
-            if (copyTextSpan) {
-              var originalText = copyTextSpan.textContent;
-              copyTextSpan.textContent = 'Copied!';
-              copyBtn.classList.add('copied');
-              setTimeout(function() {
-                copyTextSpan.textContent = originalText;
-                copyBtn.classList.remove('copied');
-              }, 2000);
-            }
-          }).catch(function(err) {
-            console.error('Failed to copy:', err);
-          });
-        });
+  <style>
+    .changelog-page {
+      max-width: 56rem;
+      margin: 0 auto;
+    }
+
+    /* Header */
+    .cl-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 8px;
+    }
+    .cl-title {
+      font-size: 2.25rem;
+      font-weight: 700;
+      margin: 0;
+      letter-spacing: -0.025em;
+      color: var(--theme-text);
+    }
+    .cl-actions {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+    }
+    .cl-search {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--theme-bg-content);
+      border: 1px solid var(--theme-border);
+      border-radius: 9px;
+      padding: 6px 12px;
+      transition: border-color 0.15s;
+    }
+    .cl-search:focus-within {
+      border-color: var(--theme-text-muted);
+    }
+    .search-icon {
+      width: 14px;
+      height: 14px;
+      color: var(--theme-text-muted);
+    }
+    .cl-search input {
+      border: none;
+      background: transparent;
+      font: inherit;
+      font-size: 0.8125rem;
+      color: var(--theme-text);
+      outline: none;
+      width: 200px;
+    }
+    .cl-search input::placeholder {
+      color: var(--theme-text-muted);
+    }
+    .cl-kbd {
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      background: var(--theme-bg-offset);
+      color: var(--theme-text-secondary);
+      border: 1px solid var(--theme-border);
+      padding: 1px 6px;
+      border-radius: 4px;
+    }
+    @media (max-width: 36rem) {
+      .cl-header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      .cl-actions {
+        width: 100%;
+        justify-content: space-between;
+      }
+      .cl-search input {
+        width: 100%;
+        min-width: 0;
+      }
+      .cl-kbd {
+        display: none;
       }
     }
 
-    initChangelog();
-    if (!window.__changelogSwapInitialized__) {
-      window.__changelogSwapInitialized__ = true;
-      document.addEventListener('astro:after-swap', initChangelog);
-    }
-  </script>
-  <style>
-    .cl-header { margin-bottom: 2rem; }
-    .changelog-header {
+    /* Tabs */
+    .cl-tabs {
       display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-      margin-bottom: 1rem;
+      gap: 28px;
+      border-bottom: 1px solid var(--theme-border);
+      margin-top: 24px;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
     }
-    .search-wrap {
-      flex: 1;
-      max-width: 400px;
-    }
-    .lead {
+    .cl-tab {
+      font-size: 0.8125rem;
+      padding: 14px 0;
       color: var(--theme-text-secondary);
-      margin: 0;
-      font-size: 1rem;
+      font-weight: 500;
+      position: relative;
+      cursor: pointer;
+      white-space: nowrap;
+      background: none;
+      border: none;
+      transition: color 0.15s;
     }
-    #search { width: 100%; padding: .6rem .75rem; border: 1px solid var(--theme-border-color); border-radius: .6rem; font: inherit; background: var(--theme-bg); }
-    #search:focus { outline: 2px solid var(--theme-accent); outline-offset: 2px; }
-    .rss-button {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      text-decoration: none;
-      font-size: 0.875rem;
+    .cl-tab:hover {
+      color: var(--theme-text);
+    }
+    .cl-tab.is-active {
+      color: var(--theme-text);
       font-weight: 600;
-      color: var(--theme-text-secondary);
+    }
+    .cl-tab.is-active::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: -1px;
+      height: 2px;
+      background: var(--theme-text);
+    }
+
+    /* Year / month headings — disable global numbering */
+    .changelog-page .cl-year > .cl-year-heading {
+      counter-increment: none !important;
+    }
+    .changelog-page .cl-year > .cl-year-heading::before {
+      content: none !important;
+    }
+    .cl-year {
+      margin-bottom: 0;
+    }
+    .cl-year-heading {
+      font-size: 0.8125rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      color: var(--theme-text);
+      margin: 44px 0 6px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid var(--theme-border);
+    }
+    .cl-month-heading {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      color: var(--theme-text-muted);
+      margin: 28px 0 14px;
+    }
+
+    /* Feed */
+    .cl-feed {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    /* Enterprise release marker */
+    .cl-release {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 16px;
+      border: 1px dashed var(--theme-border);
+      border-radius: 999px;
       background: var(--theme-bg-offset);
-      padding: 0.5rem 1rem;
-      border-radius: 6px;
-      border: 1px solid var(--theme-border);
-      transition: all 0.2s ease;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-    }
-    .rss-button:hover {
-      background: var(--theme-accent);
-      color: var(--theme-bg-content);
-      border-color: var(--theme-accent);
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      transform: translateY(-1px);
-    }
-    .rss-button:active {
-      transform: translateY(0);
-    }
-    .rss-button svg {
-      width: 18px;
-      height: 18px;
-      flex-shrink: 0;
-    }
-    .theme-dark .rss-button {
-      background: var(--theme-bg-offset);
       color: var(--theme-text-secondary);
-      border-color: var(--theme-border);
+      font-size: 0.8125rem;
     }
-    .theme-dark .rss-button:hover {
-      background: var(--theme-accent);
-      color: var(--theme-bg-content);
-      border-color: var(--theme-accent);
+    .release-icon {
+      width: 16px;
+      height: 16px;
+      color: var(--theme-text);
+    }
+    .release-text strong {
+      color: var(--theme-text);
+      font-weight: 700;
+      margin-right: 6px;
+    }
+    .release-sub {
+      color: var(--theme-text-muted);
+    }
+    .release-date {
+      margin-left: auto;
+      font-weight: 600;
+      color: var(--theme-text-muted);
+      font-size: 0.7rem;
     }
 
-  .slack-subscribe {
-    background: var(--theme-bg-offset);
-    border: 1px solid var(--theme-border-color);
-    border-radius: 6px;
-    padding: 1rem 1.25rem;
-    margin: 1.5rem 0;
-  }
-
-  .slack-content {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 0.75rem;
-  }
-
-  .slack-icon {
-    width: 1.5rem;
-    height: 1.5rem;
-    flex-shrink: 0;
-    color: var(--theme-text);
-  }
-
-  .slack-text {
-    font-size: 0.9rem;
-    color: var(--theme-text);
-    font-weight: 500;
-  }
-
-  .slack-command {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    background: var(--theme-code-inline-bg);
-    border: 1px solid var(--theme-border-color);
-    border-radius: 6px;
-    padding: 0.5rem 0.75rem;
-  }
-
-  .slack-command code {
-    flex: 1;
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    color: var(--theme-code-inline-text);
-    background: transparent;
-    padding: 0;
-    border: none;
-    word-break: break-all;
-  }
-
-  .copy-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    background: var(--theme-accent);
-    color: var(--theme-bg-content);
-    border: none;
-    padding: 0.4rem 0.75rem;
-    border-radius: 4px;
-    font-size: 0.8rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-
-  .copy-btn:hover {
-    background: var(--theme-accent-secondary);
-  }
-
-  .copy-btn.copied {
-    background: var(--color-teal-700);
-  }
-
-  .copy-icon {
-    font-size: 0.9rem;
-  }
-
-  .tag-pills { display: flex; flex-wrap: wrap; gap: .65rem; }
-  .tag-pills-row { margin-top: 1rem; }
-  .pill { border: 1px solid var(--theme-border-color); background: var(--theme-bg-offset); color: var(--theme-text-secondary); padding: .5rem .95rem; border-radius: 999px; font-size: .85rem; font-weight: 600; cursor: pointer; line-height: 1; transition: background .15s, color .15s, border-color .15s, transform .15s; box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
-    .pill:hover { background: var(--theme-bg-hover); }
-  .pill.active { background: var(--theme-accent); color: var(--theme-bg-content); border-color: var(--theme-accent); box-shadow: 0 2px 4px rgba(0,0,0,0.12); }
-  .pill:active { transform: translateY(1px); }
-
-  /* Product-specific pill colors */
-  .pill[data-tag="Workflow Automation"] {
-    background: color-mix(in srgb, var(--color-rose-400) 25%, transparent);
-    color: var(--color-rose-700);
-    border-color: var(--color-rose-700);
-  }
-
-  .pill[data-tag="Workflow Automation"]:hover {
-    background: var(--color-rose-700);
-    color: var(--color-white);
-  }
-
-  .pill[data-tag="Workflow Automation"].active {
-    background: var(--color-rose-700);
-    color: var(--color-white);
-    border-color: var(--color-rose-700);
-  }
-
-  .pill[data-tag="Merge Queue"] {
-    background: color-mix(in srgb, var(--color-teal-400) 25%, transparent);
-    color: var(--color-teal-700);
-    border-color: var(--color-teal-700);
-  }
-
-  .pill[data-tag="Merge Queue"]:hover {
-    background: var(--color-teal-700);
-    color: var(--color-white);
-  }
-
-  .pill[data-tag="Merge Queue"].active {
-    background: var(--color-teal-700);
-    color: var(--color-white);
-    border-color: var(--color-teal-700);
-  }
-
-  .pill[data-tag="CI Insights"] {
-    background: color-mix(in srgb, var(--color-purple-400) 25%, transparent);
-    color: var(--color-purple-700);
-    border-color: var(--color-purple-700);
-  }
-
-  .pill[data-tag="CI Insights"]:hover {
-    background: var(--color-purple-700);
-    color: var(--color-white);
-  }
-
-  .pill[data-tag="CI Insights"].active {
-    background: var(--color-purple-700);
-    color: var(--color-white);
-    border-color: var(--color-purple-700);
-  }
-
-  .pill[data-tag="Merge Protections"] {
-    background: color-mix(in srgb, var(--color-blue-400) 25%, transparent);
-    color: var(--color-blue-700);
-    border-color: var(--color-blue-700);
-  }
-
-  .pill[data-tag="Merge Protections"]:hover {
-    background: var(--color-blue-700);
-    color: var(--color-white);
-  }
-
-  .pill[data-tag="Merge Protections"].active {
-    background: var(--color-blue-700);
-    color: var(--color-white);
-    border-color: var(--color-blue-700);
-  }
-  /* Deprecations — semantic warning, mapped to orange palette per the
-     same convention used for "caution" elsewhere in the system. */
-  .pill[data-tag="Deprecations"] {
-    background: color-mix(in srgb, var(--color-orange-400) 25%, transparent);
-    color: var(--color-orange-700);
-    border-color: var(--color-orange-700);
-  }
-  .pill[data-tag="Deprecations"]:hover {
-    background: var(--color-orange-700);
-    color: var(--color-white);
-  }
-  .pill[data-tag="Deprecations"].active {
-    background: var(--color-orange-700);
-    color: var(--color-white);
-    border-color: var(--color-orange-700);
-  }
-  .pill[data-tag="Enterprise"] {
-    background: var(--color-dark);
-    color: var(--color-white);
-    border-color: var(--color-dark);
-  }
-  .pill[data-tag="Enterprise"]:hover,
-  .pill[data-tag="Enterprise"].active {
-    background: var(--color-dark);
-    color: var(--color-white);
-    border-color: var(--color-dark);
-  }
-  /* Disable global automatic numbering for year headings (global rule targets .content h2) */
-  .content section.year > h2.no-counter { counter-increment: none !important; }
-  .content section.year > h2.no-counter::before { content: none !important; }
-  .year { margin-bottom: 3rem; }
-  .year-heading { font-size: 1.75rem; margin-bottom: 1.5rem; }
-  .month-group { margin-bottom: 2rem; position: relative; }
-  .month-heading {
-    font-size: 1.125rem;
-    font-weight: 600;
-    color: var(--theme-text-secondary);
-    margin: 0 0 1rem 0;
-    padding-left: 1.25rem;
-    position: relative;
-  }
-  .entry-list { list-style: none; padding: 0; margin: 0; border-left: 2px solid var(--theme-border-color); }
-  .entry { position: relative; margin: 0; padding: 1.25rem 0 1.25rem 1.25rem; border-bottom: 1px solid var(--theme-border-color); }
-  .entry:last-child { border-bottom: 0; }
-  .entry::before { content: ''; position: absolute; left: -6px; top: 1.4rem; width: 10px; height: 10px; background: var(--theme-text-muted); border-radius: 50%; box-shadow: 0 0 0 2px var(--theme-bg); }
-  .entry-release::before { background: var(--color-teal-700); box-shadow: 0 0 0 2px var(--theme-bg), 0 0 0 6px color-mix(in srgb, var(--color-teal-400) 25%, transparent); }
-  .entry-release + .entry { border-top: 1px solid var(--theme-border-color); }
-  .entry-release .release-title { display: inline-flex; align-items: center; gap: .4rem; font-weight: 600; font-size: 1rem; }
-  .entry-release .release-icon { width: 1rem; height: 1rem; color: var(--color-teal-700); }
-  .entry-release .release-summary { margin: .35rem 0 0; font-size: .85rem; color: var(--theme-text-secondary); }
-  .tag-enterprise {
-    background: var(--color-dark);
-    color: var(--color-white);
-    border: 1px solid var(--color-dark);
-  }
-  .row { display: grid; gap: .9rem; align-items: flex-start; grid-template-columns: 1fr; }
-  @media (min-width: 50em) { .row { grid-template-columns: 10rem 1fr auto; } }
-  .date-tags { display: flex; flex-direction: column; gap: .5rem; align-items: flex-start; }
-  .date { font-size: .65rem; font-weight: 600; letter-spacing: .5px; text-transform: uppercase; color: var(--theme-text-muted); background: var(--theme-bg-offset); padding: 3px 8px; border-radius: 6px; width: fit-content; }
-  .tag-list { list-style: none; display: flex; flex-direction: column; gap: .4rem; padding: 0; margin: 0; }
-  .tag-list li { margin: 0; padding: 0; display: block; line-height: 1; }
-  .tag { background: var(--theme-bg-offset); color: var(--theme-text); font-size: .6rem; padding: 4px 10px; border-radius: 999px; text-transform: uppercase; letter-spacing: .5px; font-weight: 600; display: inline-block; line-height: 1; overflow-wrap: anywhere; border: 1px solid var(--theme-border-color); }
-
-  /* Product-specific label colors */
-  .tag[data-tag="Workflow Automation"] {
-    background: color-mix(in srgb, var(--color-rose-400) 25%, transparent);
-    color: var(--color-rose-700);
-    border: 1px solid var(--color-rose-700);
-  }
-
-  .tag[data-tag="Merge Queue"] {
-    background: color-mix(in srgb, var(--color-teal-400) 25%, transparent);
-    color: var(--color-teal-700);
-    border: 1px solid var(--color-teal-700);
-  }
-
-  .tag[data-tag="CI Insights"] {
-    background: color-mix(in srgb, var(--color-purple-400) 25%, transparent);
-    color: var(--color-purple-700);
-    border: 1px solid var(--color-purple-700);
-  }
-
-  .tag[data-tag="Merge Protections"] {
-    background: color-mix(in srgb, var(--color-blue-400) 25%, transparent);
-    color: var(--color-blue-700);
-    border: 1px solid var(--color-blue-700);
-  }
-  .tag[data-tag="Deprecations"] {
-    background: color-mix(in srgb, var(--color-orange-400) 25%, transparent);
-    color: var(--color-orange-700);
-    border: 1px solid var(--color-orange-700);
-  }
-  .tag[data-tag="Enterprise"] {
-    background: var(--color-dark);
-    color: var(--color-white);
-    border-color: var(--color-dark);
-  }
-  .title { font-size: 1.05rem; margin: 0 0 .4rem; line-height: 1.3; }
-  .title a { text-decoration: none; color: var(--theme-text); }
-  .title a:hover { text-decoration: underline; color: var(--theme-text-secondary); }
-  .summary { font-size: .85rem; margin: .1rem 0 0; color: var(--theme-text-secondary); line-height: 1.5; }
-  .more-col { align-self: center; justify-self: start; }
-  .read-more { display: inline-flex; align-items: center; gap: .35rem; font-size: .8rem; text-decoration: none; font-weight: 700; padding: .4rem .7rem; border-radius: .6rem; background: var(--theme-bg-offset); color: var(--theme-text); transition: background .15s, color .15s, transform .15s; box-shadow: 0 1px 2px rgba(0,0,0,.05); }
-  .read-more .read-icon { transition: transform .15s ease; }
-  .read-more:hover { background: var(--theme-accent); color: var(--theme-bg-content); }
-  .read-more:hover .read-icon { transform: translateX(2px); }
-  @media (min-width: 50em) { .more-col { justify-self: end; } }
-    #no-results { text-align: center; font-size: .875rem; margin: 3rem 0; }
+    .cl-no-results {
+      text-align: center;
+      font-size: 0.8125rem;
+      color: var(--theme-text-secondary);
+      margin: 3rem 0;
+    }
   </style>
 </MainLayout>

--- a/src/util/changelog.test.ts
+++ b/src/util/changelog.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'vitest';
+import { getProductAccent, renderInlineMarkdown } from './changelog';
+
+describe('getProductAccent', () => {
+  test('maps Merge Queue to teal-700', () => {
+    expect(getProductAccent('Merge Queue')).toEqual({
+      bar: 'var(--color-teal-700)',
+      text: 'var(--color-teal-700)',
+    });
+  });
+
+  test('maps Workflow Automation to rose-700', () => {
+    expect(getProductAccent('Workflow Automation')).toEqual({
+      bar: 'var(--color-rose-700)',
+      text: 'var(--color-rose-700)',
+    });
+  });
+
+  test('maps CI Insights to purple-700', () => {
+    expect(getProductAccent('CI Insights')).toEqual({
+      bar: 'var(--color-purple-700)',
+      text: 'var(--color-purple-700)',
+    });
+  });
+
+  test('maps Test Insights to orange-700', () => {
+    expect(getProductAccent('Test Insights')).toEqual({
+      bar: 'var(--color-orange-700)',
+      text: 'var(--color-orange-700)',
+    });
+  });
+
+  test('maps Merge Protections to blue-700', () => {
+    expect(getProductAccent('Merge Protections')).toEqual({
+      bar: 'var(--color-blue-700)',
+      text: 'var(--color-blue-700)',
+    });
+  });
+
+  test('maps Stacks to coral-700', () => {
+    expect(getProductAccent('Stacks')).toEqual({
+      bar: 'var(--color-coral-700)',
+      text: 'var(--color-coral-700)',
+    });
+  });
+
+  test('falls back to neutral for Deprecations (no explicit mapping)', () => {
+    expect(getProductAccent('Deprecations')).toEqual({
+      bar: 'var(--theme-text-muted)',
+      text: 'var(--theme-text-secondary)',
+    });
+  });
+
+  test('maps Enterprise to dark neutral', () => {
+    expect(getProductAccent('Enterprise')).toEqual({
+      bar: 'var(--theme-text)',
+      text: 'var(--theme-text)',
+    });
+  });
+
+  test('falls back to neutral for unknown tag', () => {
+    expect(getProductAccent('Some New Product')).toEqual({
+      bar: 'var(--theme-text-muted)',
+      text: 'var(--theme-text-secondary)',
+    });
+  });
+
+  test('handles undefined as fallback', () => {
+    expect(getProductAccent(undefined)).toEqual({
+      bar: 'var(--theme-text-muted)',
+      text: 'var(--theme-text-secondary)',
+    });
+  });
+});
+
+describe('renderInlineMarkdown', () => {
+  test('passes plain text through unchanged', () => {
+    expect(renderInlineMarkdown('Hello world')).toBe('Hello world');
+  });
+
+  test('converts backtick code spans to <code> tags', () => {
+    expect(renderInlineMarkdown('Configure `auto_merge_conditions`')).toBe(
+      'Configure <code>auto_merge_conditions</code>'
+    );
+  });
+
+  test('handles multiple code spans on one line', () => {
+    expect(renderInlineMarkdown('`foo` and `bar`')).toBe('<code>foo</code> and <code>bar</code>');
+  });
+
+  test('escapes HTML in surrounding text', () => {
+    expect(renderInlineMarkdown('Use <script> tag')).toBe('Use &lt;script&gt; tag');
+  });
+
+  test('escapes HTML inside code spans too', () => {
+    expect(renderInlineMarkdown('use `<div>` here')).toBe('use <code>&lt;div&gt;</code> here');
+  });
+
+  test('leaves an unpaired backtick literal', () => {
+    expect(renderInlineMarkdown('only `one open')).toBe('only `one open');
+  });
+
+  test('escapes ampersands and quotes', () => {
+    expect(renderInlineMarkdown('Tom & Jerry "win"')).toBe('Tom &amp; Jerry &quot;win&quot;');
+  });
+});

--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -1,4 +1,5 @@
 import type { CollectionEntry } from 'astro:content';
+import { escape } from './html-entities';
 
 type DateCarrier = {
   date: Date | string;
@@ -123,4 +124,44 @@ export function formatMonthYear(date: Date | string): string {
     year: 'numeric',
     month: 'long',
   });
+}
+
+/**
+ * Render a tiny subset of inline markdown for changelog titles: backtick code
+ * spans become <code>. The shared `escape` helper handles HTML entity escaping
+ * (kept consistent with the rest of the codebase), then code-span pairs are
+ * substituted with real <code> tags. We avoid a full markdown parser because
+ * titles only ever use code spans in practice.
+ */
+export function renderInlineMarkdown(text: string): string {
+  return escape(text).replace(/`([^`]+)`/g, '<code>$1</code>');
+}
+
+export interface ProductAccent {
+  bar: string;
+  text: string;
+}
+
+const PRODUCT_ACCENTS: Record<string, ProductAccent> = {
+  'Merge Queue': { bar: 'var(--color-teal-700)', text: 'var(--color-teal-700)' },
+  'Workflow Automation': { bar: 'var(--color-rose-700)', text: 'var(--color-rose-700)' },
+  'CI Insights': { bar: 'var(--color-purple-700)', text: 'var(--color-purple-700)' },
+  'Test Insights': { bar: 'var(--color-orange-700)', text: 'var(--color-orange-700)' },
+  'Merge Protections': { bar: 'var(--color-blue-700)', text: 'var(--color-blue-700)' },
+  Stacks: { bar: 'var(--color-coral-700)', text: 'var(--color-coral-700)' },
+  Enterprise: { bar: 'var(--theme-text)', text: 'var(--theme-text)' },
+};
+
+const NEUTRAL_ACCENT: ProductAccent = {
+  bar: 'var(--theme-text-muted)',
+  text: 'var(--theme-text-secondary)',
+};
+
+/**
+ * Map a changelog tag to its left-bar accent color and detail-page eyebrow color.
+ * Unknown tags (and Deprecations) fall back to a neutral gray.
+ */
+export function getProductAccent(tag: string | undefined): ProductAccent {
+  if (!tag) return NEUTRAL_ACCENT;
+  return PRODUCT_ACCENTS[tag] ?? NEUTRAL_ACCENT;
 }


### PR DESCRIPTION
Rebuilds the changelog index and entry detail pages around an editorial
card layout: typography-only standard cards with a 3px product-color
left bar, a marquee variant for entries that ship with a hero image,
and a much calmer header.

Schema (src/content.config.ts): adds an optional image: { src, alt }
field. Existing entries are unaffected; future entries that ship with
a screenshot can opt into the marquee card variant.

Helpers (src/util/changelog.ts) — four pure functions, 27 tests:
- getProductAccent — maps a tag to its left-bar / eyebrow accent color
  pair. Unknown tags and Deprecations fall back to neutral.
- getPrevNextEntries — chronological prev/next for the detail page.
- getRelatedEntries — N most-recent entries sharing a tag, excluding
  the current entry. Used for 'More in [product]'.
- renderInlineMarkdown — escapes via the shared html-entities helper,
  then converts backtick code spans to <code>. Used everywhere a title
  is rendered, since titles frequently reference config keys.

Components (src/components/changelog/):
- ChangelogCard — typography-only card, 3px product-color left bar,
  date pulled to the right, tag pills always visible. Stretched-link
  from the title makes the whole card clickable.
- ChangelogMarquee — hero variant for entries with an image. Same
  accent system; the left-bar is set on the outer .marquee so the
  title's stretched-link covers the entire card (hero included), which
  also keeps the image's alt text in the accessibility tree.
- ChangelogSubscribePopover — Subscribe ▾ button with a popover that
  contains both the RSS feed URL and the Slack /feed subscribe command,
  each in a copyable code box with a Copy button. Document-level
  listeners are wired through an AbortController so they don't
  accumulate across Astro view-transition swaps; clipboard.writeText
  has a .catch fallback that surfaces a 'Copy failed' state.

Pages:
- index.astro — editorial header (title + ⌘K-cued search +
  Subscribe ▾), underlined tabs filter (replaces colored pill row),
  year + month grouping kept. Standard cards by default; entries with
  an image render as ChangelogMarquee. Enterprise release markers
  preserved as compact dashed-pill badges.
- [slug].astro — product eyebrow, large H1, lede from frontmatter
  description, optional hero image, body, prev/next nav, and
  'More in [product]' related-entries footer.

Icons migrated from heroicons / fa-solid to lucide to match the
project's icon-set unification (PR #11406).