### PR TITLE
docs(backport): document merge commit limitation

### DIFF
--- a/src/content/docs/commands/backport.mdx
+++ b/src/content/docs/commands/backport.mdx
@@ -3,6 +3,8 @@ title: Mergify Backport Command
 description: Copy a pull request to another branch after merge.
 ---
 
+import BackportLimitations from '../workflow/actions/_backport_limitations.mdx';
+
 The `backport` command is one of Mergify's most useful features, especially for
 projects that maintain multiple branches simultaneously. This command automates
 the process of creating a new pull request to apply changes from a merged pull
@@ -54,6 +56,8 @@ This command is also [available as an action](/workflow/actions/backport).
 
 - `<target-branch>`: The name of the branch to which the changes should be
   backported.
+
+<BackportLimitations />
 
 ## Example
 

--- a/src/content/docs/workflow/actions/_backport_limitations.mdx
+++ b/src/content/docs/workflow/actions/_backport_limitations.mdx
@@ -1,0 +1,14 @@
+## Limitations
+
+:::caution
+  Pull requests containing merge commits cannot be backported (except for
+  merges of the base branch).
+:::
+
+Mergify cannot backport a pull request that contains a merge commit, such as
+when you merge a teammate's branch into yours. Merges of the base branch into
+your pull request (for example, `Merge branch 'main'`) are an exception and
+don't block the backport.
+
+To avoid this, squash-merge or rebase your pull request before merging so its
+history stays linear.

--- a/src/content/docs/workflow/actions/backport.mdx
+++ b/src/content/docs/workflow/actions/backport.mdx
@@ -4,6 +4,7 @@ description: Copy a pull request to another branch once it is merged.
 ---
 
 import ActionOptionsTable from '../../../../components/Tables/ActionOptionsTable';
+import BackportLimitations from './_backport_limitations.mdx';
 
 The `backport` action enables you to automatically create a backport of a
 merged pull request. When the conditions you specify are met, Mergify will
@@ -43,6 +44,8 @@ On top of that, you can also use the following additional variables:
 
 - `{{ cherry_pick_error }}`: the cherry pick error message if any (only
     available in body).
+
+<BackportLimitations />
 
 ## Examples
 


### PR DESCRIPTION
Add a Limitations section to the backport action and command pages
explaining that pull requests containing merge commits cannot be
backported, with the exception of merges of the base branch.
Recommend squash-merge or rebase as a workaround.

Fixes MRGFY-7226

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>