### PR TITLE
docs(backport): simplify Limitations and move before Examples

### DIFF
--- a/src/content/docs/commands/backport.mdx
+++ b/src/content/docs/commands/backport.mdx
@@ -68,3 +68,32 @@ command as follows:
 Upon executing this command, Mergify will attempt to automatically create a new
 pull request with the changes onto the `v2.0-stable` branch as soon as the
 original pull request is merged.
+
+## Limitations
+
+:::caution
+  Pull requests containing internal merge commits cannot be backported.
+:::
+
+The `backport` command replays each commit on the target branch with
+`git cherry-pick`, which refuses merge commits unless given a parent number.
+Any pull request whose history includes a non-base merge commit will fail
+with `is a merge but no -m option was given`.
+
+For example, the following history cannot be backported:
+
+```text
+* abc1234 (HEAD) Add feature
+*   def5678 Merge pull request #42 from teammate/helper
+|\
+| * 9abcdef Helper improvement
+|/
+* fedcba9 Earlier commit
+```
+
+Merges of the base branch into the pull request (for example,
+`Merge branch 'main'`) are ignored, so those are safe. Any other merge commit,
+such as merging a teammate's branch into yours, blocks the backport.
+
+To avoid this, squash-merge or rebase your pull request before merging so its
+history stays linear.

--- a/src/content/docs/commands/backport.mdx
+++ b/src/content/docs/commands/backport.mdx
@@ -55,6 +55,20 @@ This command is also [available as an action](/workflow/actions/backport).
 - `<target-branch>`: The name of the branch to which the changes should be
   backported.
 
+## Limitations
+
+:::caution
+  Pull requests containing merge commits cannot be backported.
+:::
+
+Mergify cannot backport a pull request that contains a merge commit, such as
+when you merge a teammate's branch into yours. Merges of the base branch into
+your pull request (for example, `Merge branch 'main'`) are an exception and
+don't block the backport.
+
+To avoid this, squash-merge or rebase your pull request before merging so its
+history stays linear.
+
 ## Example
 
 Suppose you have a pull request that was merged into `main`, but you also want
@@ -68,32 +82,3 @@ command as follows:
 Upon executing this command, Mergify will attempt to automatically create a new
 pull request with the changes onto the `v2.0-stable` branch as soon as the
 original pull request is merged.
-
-## Limitations
-
-:::caution
-  Pull requests containing internal merge commits cannot be backported.
-:::
-
-The `backport` command replays each commit on the target branch with
-`git cherry-pick`, which refuses merge commits unless given a parent number.
-Any pull request whose history includes a non-base merge commit will fail
-with `is a merge but no -m option was given`.
-
-For example, the following history cannot be backported:
-
-```text
-* abc1234 (HEAD) Add feature
-*   def5678 Merge pull request #42 from teammate/helper
-|\
-| * 9abcdef Helper improvement
-|/
-* fedcba9 Earlier commit
-```
-
-Merges of the base branch into the pull request (for example,
-`Merge branch 'main'`) are ignored, so those are safe. Any other merge commit,
-such as merging a teammate's branch into yours, blocks the backport.
-
-To avoid this, squash-merge or rebase your pull request before merging so its
-history stays linear.

--- a/src/content/docs/workflow/actions/backport.mdx
+++ b/src/content/docs/workflow/actions/backport.mdx
@@ -23,35 +23,6 @@ this behaviour using the `ignore_conflicts` option.
   you don't have the required permissions, the action will fail.
 :::
 
-## Limitations
-
-:::caution
-  Pull requests containing internal merge commits cannot be backported.
-:::
-
-Backporting replays each commit on the target branch with `git cherry-pick`,
-which refuses merge commits unless given a parent number. Any pull request
-whose history includes a non-base merge commit will fail with
-`is a merge but no -m option was given`.
-
-For example, the following history cannot be backported:
-
-```text
-* abc1234 (HEAD) Add feature
-*   def5678 Merge pull request #42 from teammate/helper
-|\
-| * 9abcdef Helper improvement
-|/
-* fedcba9 Earlier commit
-```
-
-Merges of the base branch into the pull request (for example,
-`Merge branch 'main'`) are ignored, so those are safe. Any other merge commit,
-such as merging a teammate's branch into yours, blocks the backport.
-
-To avoid this, squash-merge or rebase your pull request before merging so its
-history stays linear.
-
 ## Parameters
 
 The `backport` action takes a list of branches to which the changes from the
@@ -72,6 +43,20 @@ On top of that, you can also use the following additional variables:
 
 - `{{ cherry_pick_error }}`: the cherry pick error message if any (only
     available in body).
+
+## Limitations
+
+:::caution
+  Pull requests containing merge commits cannot be backported.
+:::
+
+Mergify cannot backport a pull request that contains a merge commit, such as
+when you merge a teammate's branch into yours. Merges of the base branch into
+your pull request (for example, `Merge branch 'main'`) are an exception and
+don't block the backport.
+
+To avoid this, squash-merge or rebase your pull request before merging so its
+history stays linear.
 
 ## Examples
 

--- a/src/content/docs/workflow/actions/backport.mdx
+++ b/src/content/docs/workflow/actions/backport.mdx
@@ -23,6 +23,35 @@ this behaviour using the `ignore_conflicts` option.
   you don't have the required permissions, the action will fail.
 :::
 
+## Limitations
+
+:::caution
+  Pull requests containing internal merge commits cannot be backported.
+:::
+
+Backporting replays each commit on the target branch with `git cherry-pick`,
+which refuses merge commits unless given a parent number. Any pull request
+whose history includes a non-base merge commit will fail with
+`is a merge but no -m option was given`.
+
+For example, the following history cannot be backported:
+
+```text
+* abc1234 (HEAD) Add feature
+*   def5678 Merge pull request #42 from teammate/helper
+|\
+| * 9abcdef Helper improvement
+|/
+* fedcba9 Earlier commit
+```
+
+Merges of the base branch into the pull request (for example,
+`Merge branch 'main'`) are ignored, so those are safe. Any other merge commit,
+such as merging a teammate's branch into yours, blocks the backport.
+
+To avoid this, squash-merge or rebase your pull request before merging so its
+history stays linear.
+
 ## Parameters
 
 The `backport` action takes a list of branches to which the changes from the


### PR DESCRIPTION
Drop the cherry-pick internals, raw git error, and ASCII git-log graph in
favour of a short user-facing description. Place the section right before
Examples on both the action and command pages so it sits between the
reference content and the worked examples.

Related to MRGFY-7226

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #11450