### PR TITLE
docs(backport): restore original placement of Limitations section

### DIFF
--- a/src/content/docs/commands/backport.mdx
+++ b/src/content/docs/commands/backport.mdx
@@ -55,20 +55,6 @@ This command is also [available as an action](/workflow/actions/backport).
 - `<target-branch>`: The name of the branch to which the changes should be
   backported.
 
-## Limitations
-
-:::caution
-  Pull requests containing merge commits cannot be backported.
-:::
-
-Mergify cannot backport a pull request that contains a merge commit, such as
-when you merge a teammate's branch into yours. Merges of the base branch into
-your pull request (for example, `Merge branch 'main'`) are an exception and
-don't block the backport.
-
-To avoid this, squash-merge or rebase your pull request before merging so its
-history stays linear.
-
 ## Example
 
 Suppose you have a pull request that was merged into `main`, but you also want
@@ -82,3 +68,17 @@ command as follows:
 Upon executing this command, Mergify will attempt to automatically create a new
 pull request with the changes onto the `v2.0-stable` branch as soon as the
 original pull request is merged.
+
+## Limitations
+
+:::caution
+  Pull requests containing merge commits cannot be backported.
+:::
+
+Mergify cannot backport a pull request that contains a merge commit, such as
+when you merge a teammate's branch into yours. Merges of the base branch into
+your pull request (for example, `Merge branch 'main'`) are an exception and
+don't block the backport.
+
+To avoid this, squash-merge or rebase your pull request before merging so its
+history stays linear.

--- a/src/content/docs/workflow/actions/backport.mdx
+++ b/src/content/docs/workflow/actions/backport.mdx
@@ -23,6 +23,20 @@ this behaviour using the `ignore_conflicts` option.
   you don't have the required permissions, the action will fail.
 :::
 
+## Limitations
+
+:::caution
+  Pull requests containing merge commits cannot be backported.
+:::
+
+Mergify cannot backport a pull request that contains a merge commit, such as
+when you merge a teammate's branch into yours. Merges of the base branch into
+your pull request (for example, `Merge branch 'main'`) are an exception and
+don't block the backport.
+
+To avoid this, squash-merge or rebase your pull request before merging so its
+history stays linear.
+
 ## Parameters
 
 The `backport` action takes a list of branches to which the changes from the
@@ -43,20 +57,6 @@ On top of that, you can also use the following additional variables:
 
 - `{{ cherry_pick_error }}`: the cherry pick error message if any (only
     available in body).
-
-## Limitations
-
-:::caution
-  Pull requests containing merge commits cannot be backported.
-:::
-
-Mergify cannot backport a pull request that contains a merge commit, such as
-when you merge a teammate's branch into yours. Merges of the base branch into
-your pull request (for example, `Merge branch 'main'`) are an exception and
-don't block the backport.
-
-To avoid this, squash-merge or rebase your pull request before merging so its
-history stays linear.
 
 ## Examples
 


### PR DESCRIPTION
Move the Limitations section back to where it lived in the initial commit:
between the intro caution and Parameters on the action page, and at the
end of the command page. Keep the simplified prose from the previous commit.

Related to MRGFY-7226

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #11451