### PR TITLE
docs(copy): document merge commit limitation

### DIFF
--- a/src/content/docs/commands/copy.mdx
+++ b/src/content/docs/commands/copy.mdx
@@ -3,6 +3,8 @@ title: Mergify Copy Command
 description: Copy a pull request to another branch.
 ---
 
+import CopyLimitations from '../workflow/actions/_copy_limitations.mdx';
+
 The `copy` command is a convenient tool in Mergify's suite, allowing users to
 replicate changes from a pull request to another branch within the same
 repository. This is particularly useful for teams working with multiple
@@ -50,6 +52,8 @@ The `copy` command is especially handy for:
 ## Parameters
 
 - `<target-branch>`: The destination branch within the same repository.
+
+<CopyLimitations />
 
 ## Example
 

--- a/src/content/docs/workflow/actions/_copy_limitations.mdx
+++ b/src/content/docs/workflow/actions/_copy_limitations.mdx
@@ -1,0 +1,14 @@
+## Limitations
+
+:::caution
+  Pull requests containing merge commits cannot be copied (except for
+  merges of the base branch).
+:::
+
+Mergify cannot copy a pull request that contains a merge commit, such as
+when you merge a teammate's branch into yours. Merges of the base branch into
+your pull request (for example, `Merge branch 'main'`) are an exception and
+don't block the copy.
+
+To avoid this, rebase your pull request or squash its commits so its history
+stays linear.

--- a/src/content/docs/workflow/actions/copy.mdx
+++ b/src/content/docs/workflow/actions/copy.mdx
@@ -4,6 +4,7 @@ description: Copy a pull request to another branch.
 ---
 
 import ActionOptionsTable from '../../../../components/Tables/ActionOptionsTable';
+import CopyLimitations from './_copy_limitations.mdx';
 
 The `copy` action enables you to automatically create a copy of a pull request.
 When the conditions you specify are met, Mergify will create a new pull request
@@ -45,6 +46,8 @@ On top of that, you can also use the following additional variables:
 
 - `{{ cherry_pick_error }}`: the cherry pick error message if any (only
     available in body).
+
+<CopyLimitations />
 
 ## Examples
 


### PR DESCRIPTION
The copy action and command share the same cherry-pick implementation as
backport, so they're subject to the same merge-commit limitation. Mirror
the backport Limitations partial for copy, imported from both the action
and command pages.

Related to MRGFY-7226

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>