### PR TITLE
feat(search): visual refresh of the Cmd+K modal

### DIFF
--- a/src/components/Search/Results.tsx
+++ b/src/components/Search/Results.tsx
@@ -1,5 +1,4 @@
 import { Icon } from '@iconify/react';
-import classNames from 'classnames';
 import { useEffect, useState } from 'react';
 import Preview, { prefetchSectionHtml } from './PageDetails';
 import type { SearchEntry } from './types';
@@ -25,6 +24,23 @@ function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+/** Map URL prefix to a known section key. Returns empty string for paths
+ * that don't match any product section; CSS then uses the default accent. */
+const SECTION_KEYS = [
+  'merge-queue',
+  'ci-insights',
+  'test-insights',
+  'merge-protections',
+  'stacks',
+  'workflow',
+] as const;
+
+function getSectionFromUrl(url: string): string {
+  const path = url.split('#')[0].replace(/^\/|\/$/g, '');
+  const first = path.split('/')[0];
+  return SECTION_KEYS.includes(first as (typeof SECTION_KEYS)[number]) ? first : '';
+}
+
 interface PageResultProps {
   entry: SearchEntry;
   query: string;
@@ -34,47 +50,22 @@ interface PageResultProps {
 }
 
 function PageResult({ entry, query, onHover, onNavigate, active }: PageResultProps) {
-  const breadcrumb = entry.breadcrumb;
-
+  const section = getSectionFromUrl(entry.url);
   return (
     <a
-      className={classNames({ 'page-result': true, active })}
-      style={{
-        justifyContent: 'space-between',
-        display: 'flex',
-        width: '100%',
-        overflow: 'hidden',
-        padding: '8px 16px',
-        cursor: 'pointer',
-      }}
+      className={`page-result${active ? ' active' : ''}`}
+      data-section={section || undefined}
       onMouseOver={onHover}
       onClick={onNavigate}
       href={entry.url}
       id={entry.id}
     >
-      <div
-        style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', gap: 4 }}
-      >
+      <div className="page-result-body">
         <div
           className="result-title"
           dangerouslySetInnerHTML={{ __html: highlightTerms(entry.title, query) }}
         />
-        {breadcrumb && (
-          <p
-            className="result-description"
-            style={{
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              width: '100%',
-              margin: 0,
-              fontSize: '0.875rem',
-              color: 'var(--theme-text-secondary)',
-            }}
-          >
-            {breadcrumb}
-          </p>
-        )}
+        {entry.breadcrumb && <p className="result-description">{entry.breadcrumb}</p>}
       </div>
       {active && <Icon icon="lucide:corner-down-left" />}
     </a>
@@ -150,36 +141,16 @@ export default function Results({ results, query, onNavigate }: ResultsProps) {
 
   if (results.length === 0) {
     return (
-      <div
-        style={{
-          padding: '32px 16px',
-          textAlign: 'center',
-          color: 'var(--theme-text-secondary)',
-          fontSize: '0.9375rem',
-        }}
-      >
-        No results found. Try different keywords.
+      <div className="search-state-no-results">
+        <p className="search-state-title">No results for &quot;{query}&quot;</p>
+        <p className="search-state-subtitle">Try simpler terms or check spelling.</p>
       </div>
     );
   }
 
   return (
-    <div
-      style={{
-        flex: 1,
-        overflow: 'hidden',
-        display: 'flex',
-      }}
-    >
-      <div
-        style={{
-          flex: 1,
-          alignItems: 'flex-start',
-          height: '100%',
-          overflow: 'auto',
-          position: 'relative',
-        }}
-      >
+    <div className="search-results-split">
+      <div className="search-results-list">
         {results.map((entry, i) => (
           <PageResult
             key={entry.id}
@@ -191,7 +162,7 @@ export default function Results({ results, query, onNavigate }: ResultsProps) {
           />
         ))}
       </div>
-      <hr />
+      <hr className="search-results-preview-divider" />
       {focusedEntry && <Preview entry={focusedEntry} />}
     </div>
   );

--- a/src/components/Search/Search.scss
+++ b/src/components/Search/Search.scss
@@ -5,48 +5,276 @@
 /* Modal content is portaled to document.body (outside #search-bar),
    so these styles must NOT be nested under #search-bar. */
 .modal-content {
+	/* ----- Modal frame ----- */
+	background: var(--theme-bg-content);
+	border: 1px solid var(--theme-border);
+	border-radius: 12px;
+	box-shadow: 0 12px 32px rgba(0, 0, 0, 0.10);
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+
+	/* ----- Input row ----- */
+	.search-input-row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.875rem 1rem;
+		border-bottom: 1px solid var(--theme-divider);
+	}
+	.search-input-row [data-icon] {
+		flex-shrink: 0;
+		color: var(--theme-text-muted);
+	}
+	.search-input {
+		flex: 1;
+		border: none;
+		outline: none;
+		background: transparent;
+		font-size: 1rem;
+		color: var(--theme-text);
+		border-radius: 4px;
+	}
+	/* Focus-visible affordance for keyboard users — the bare `outline: none`
+	   above clears the browser default; restore on keyboard focus only so
+	   mouse clicks don't show a ring. */
+	.search-input:focus-visible {
+		outline: 2px solid var(--theme-link);
+		outline-offset: 2px;
+	}
+	.search-input::placeholder {
+		color: var(--theme-text-muted);
+	}
+	.search-clear {
+		flex-shrink: 0;
+		background: none;
+		border: none;
+		padding: 0.25rem;
+		cursor: pointer;
+		color: var(--theme-text-muted);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 4px;
+	}
+	.search-clear:hover {
+		background: var(--theme-bg-offset);
+		color: var(--theme-text);
+	}
+
+	/* ----- Body (between input and footer) ----- */
+	.search-body {
+		flex: 1;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	/* ----- Section eyebrow (Recent / N results) ----- */
+	.search-eyebrow {
+		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--theme-text-muted);
+		padding: 0.75rem 1rem 0.5rem;
+	}
+
+	/* ----- Recent searches ----- */
+	.recent-list {
+		list-style: none;
+		margin: 0;
+		padding: 0 0 0.5rem;
+	}
+	.recent-item {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		width: 100%;
+		padding: 0.5rem 1rem;
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 0.9375rem;
+		color: var(--theme-text);
+		text-align: left;
+	}
+	.recent-item:hover {
+		background: var(--theme-bg-offset);
+	}
+	.recent-item [data-icon] {
+		color: var(--theme-text-muted);
+	}
+
+	/* ----- Empty state (no query, no recent) ----- */
+	.search-state-empty,
+	.search-state-no-results {
+		padding: 2.5rem 1.5rem;
+		text-align: center;
+		color: var(--theme-text-muted);
+	}
+	.search-state-title {
+		font-size: 1rem;
+		font-weight: 500;
+		color: var(--theme-text);
+		margin: 0 0 0.25rem;
+	}
+	.search-state-subtitle {
+		font-size: 0.875rem;
+		margin: 0;
+	}
+
+	/* ----- Loading skeleton ----- */
+	.search-skeleton {
+		padding: 0.5rem 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.search-skeleton-row {
+		height: 2.5rem;
+		border-radius: 6px;
+		background: var(--theme-bg-offset);
+		animation: search-skeleton-pulse 1.4s ease-in-out infinite;
+	}
+	@keyframes search-skeleton-pulse {
+		0%, 100% { opacity: 1; }
+		50% { opacity: 0.55; }
+	}
+
+	/* ----- Results container ----- */
+	.search-results-split {
+		flex: 1;
+		display: flex;
+		min-height: 0;
+		overflow: hidden;
+	}
+	.search-results-list {
+		flex: 1;
+		overflow: auto;
+		min-width: 0;
+	}
+	.search-results-preview-divider {
+		border: none;
+		border-left: 1px solid var(--theme-divider);
+		margin: 0;
+	}
+
+	/* ----- Result row ----- */
+	.page-result {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.625rem 1rem;
+		text-decoration: none;
+		color: var(--theme-text);
+		border-left: 3px solid transparent;
+		cursor: pointer;
+		overflow: hidden;
+	}
+	.page-result.active,
+	.page-result:hover {
+		background: var(--theme-bg-offset);
+		border-left-color: var(--theme-link);
+	}
+	.page-result[data-section="merge-queue"].active,
+	.page-result[data-section="merge-queue"]:hover {
+		border-left-color: var(--color-teal-700);
+	}
+	.page-result[data-section="ci-insights"].active,
+	.page-result[data-section="ci-insights"]:hover {
+		border-left-color: var(--color-purple-700);
+	}
+	.page-result[data-section="test-insights"].active,
+	.page-result[data-section="test-insights"]:hover {
+		border-left-color: var(--color-orange-700);
+	}
+	.page-result[data-section="merge-protections"].active,
+	.page-result[data-section="merge-protections"]:hover {
+		border-left-color: var(--color-blue-700);
+	}
+	.page-result[data-section="stacks"].active,
+	.page-result[data-section="stacks"]:hover {
+		border-left-color: var(--color-coral-700);
+	}
+	.page-result[data-section="workflow"].active,
+	.page-result[data-section="workflow"]:hover {
+		border-left-color: var(--color-rose-700);
+	}
+	.page-result-body {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+	}
+	.result-title {
+		font-size: 0.9375rem;
+		font-weight: 500;
+		color: var(--theme-text);
+	}
+	.result-description {
+		font-size: 0.8125rem;
+		color: var(--theme-text-muted);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	/* ----- Highlight ----- */
 	mark {
 		color: var(--theme-link);
 		background: transparent;
 		font-weight: 500;
 	}
 
-	a {
-		text-decoration: none;
-		color: var(--theme-text);
-	}
-
-	.page-result {
-		&.active {
-			background: var(--theme-bg-offset);
-		}
-	}
-
-	.result-title {
-		font-size: var(--theme-text-lg);
-	}
-
-	.result-description {
+	/* ----- Footer kbd hints ----- */
+	.search-footer {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 1.25rem;
+		padding: 0.5rem 1rem;
+		background: var(--theme-bg-offset);
+		border-top: 1px solid var(--theme-divider);
+		font-size: 0.75rem;
 		color: var(--theme-text-muted);
-		font-weight: 300;
-		text-decoration: none !important;
+	}
+	.search-footer-hint {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+	}
+	.search-footer-kbd {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 1.25rem;
+		height: 1.25rem;
+		padding: 0 0.25rem;
+		border: 1px solid var(--theme-border);
+		border-radius: 4px;
+		background: var(--theme-bg-content);
+		font-family: var(--font-mono);
+		font-size: 0.7rem;
+		line-height: 1;
+		color: var(--theme-text-secondary);
 	}
 
-	.table-of-content {
-		a {
-			color: var(--theme-text-muted);
-			transition: color 0.115s;
-
-			&:hover {
-				color: var(--theme-text);
-			}
-		}
+	/* ----- Preview pane (right side, existing component) ----- */
+	.table-of-content a {
+		color: var(--theme-text-muted);
+		transition: color 0.115s;
+	}
+	.table-of-content a:hover {
+		color: var(--theme-text);
 	}
 }
 
+/* Dark mode tweak — the active state should be slightly stronger
+   so it reads clearly against the dark bg. */
 .theme-dark .modal-content .page-result.active {
 	background: var(--theme-bg-hover) !important;
 }
-
-/* Dark mode mark color comes from --theme-link's dark-mode remap;
-   no separate override needed. */

--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -58,40 +58,59 @@ function RecentSearches({ onSelect }: { onSelect: (q: string) => void }) {
   if (recent.length === 0) return null;
 
   return (
-    <div style={{ padding: '8px 0' }}>
-      <div
-        style={{
-          padding: '4px 16px',
-          fontSize: '0.75rem',
-          color: 'var(--theme-text-secondary)',
-          textTransform: 'uppercase',
-          letterSpacing: '0.05em',
-        }}
-      >
-        Recent searches
-      </div>
-      {recent.map((q) => (
-        <button
-          key={q}
-          onClick={() => onSelect(q)}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            width: '100%',
-            padding: '8px 16px',
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-            fontSize: '0.9375rem',
-            color: 'var(--theme-text)',
-            textAlign: 'left',
-          }}
-        >
-          <Icon icon="lucide:history" width="16" height="16" />
-          {q}
-        </button>
-      ))}
+    <div>
+      <div className="search-eyebrow">Recent searches</div>
+      <ul className="recent-list">
+        {recent.map((q) => (
+          <li key={q}>
+            <button type="button" className="recent-item" onClick={() => onSelect(q)}>
+              <Icon icon="lucide:history" width="16" height="16" />
+              {q}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="search-state-empty">
+      <p className="search-state-title">Search the docs</p>
+      <p className="search-state-subtitle">
+        Try a config key, a feature name, or &quot;merge queue&quot;.
+      </p>
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="search-skeleton" aria-hidden="true">
+      <div className="search-skeleton-row" />
+      <div className="search-skeleton-row" />
+      <div className="search-skeleton-row" />
+    </div>
+  );
+}
+
+function KbdHints() {
+  return (
+    <div className="search-footer">
+      <span className="search-footer-hint">
+        <kbd className="search-footer-kbd">↑</kbd>
+        <kbd className="search-footer-kbd">↓</kbd>
+        navigate
+      </span>
+      <span className="search-footer-hint">
+        <kbd className="search-footer-kbd">↵</kbd>
+        open
+      </span>
+      <span className="search-footer-hint">
+        <kbd className="search-footer-kbd">esc</kbd>
+        close
+      </span>
     </div>
   );
 }
@@ -114,16 +133,17 @@ function preloadPagefind() {
 
 function usePagefindSearch(query: string, open: boolean) {
   const [results, setResults] = useState<SearchEntry[]>();
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!open || !query || query.length < 2) {
       setResults(undefined);
+      setLoading(false);
       return;
     }
 
-    // Clear stale results immediately so the old list doesn't linger
-    // while the new search is in flight.
     setResults(undefined);
+    setLoading(true);
 
     let cancelled = false;
 
@@ -135,7 +155,6 @@ function usePagefindSearch(query: string, open: boolean) {
       const loaded = await Promise.all(response.results.slice(0, 30).map((r) => r.data()));
       if (cancelled) return;
 
-      // Deduplicate: keep only the best match per page
       const seen = new Set<string>();
       const entries: SearchEntry[] = [];
       for (const page of loaded) {
@@ -154,16 +173,21 @@ function usePagefindSearch(query: string, open: boolean) {
       }
 
       setResults(entries);
+      setLoading(false);
     };
 
     search();
 
+    // React runs this cleanup before the next effect body fires, so any
+    // in-flight search sees cancelled=true and won't call setLoading(false)
+    // after the new query's setLoading(true) has already fired. Order is
+    // load-bearing — don't reorder the cleanup and the body's setLoading.
     return () => {
       cancelled = true;
     };
   }, [query, open]);
 
-  return results;
+  return { results, loading };
 }
 
 export default function SearchBar() {
@@ -172,7 +196,7 @@ export default function SearchBar() {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
 
-  const searchResults = usePagefindSearch(search, open);
+  const { results: searchResults, loading } = usePagefindSearch(search, open);
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(e.target.value);
@@ -212,8 +236,6 @@ export default function SearchBar() {
     button?.addEventListener('mouseenter', preloadPagefind, { once: true });
     window.addEventListener('keydown', openModalKeydown);
 
-    // Also preload during page idle so the first search is instant
-    // even if the user never hovered the button (e.g. keyboard-only users).
     const idleHandle =
       typeof requestIdleCallback !== 'undefined'
         ? requestIdleCallback(() => preloadPagefind())
@@ -237,7 +259,6 @@ export default function SearchBar() {
     }
   }, [open]);
 
-  // Escape: clear query first; if already empty, close the modal.
   useEffect(() => {
     if (!open) return;
     const handleEscape = (e: KeyboardEvent) => {
@@ -253,46 +274,60 @@ export default function SearchBar() {
     return () => window.removeEventListener('keydown', handleEscape, { capture: true });
   }, [open, search]);
 
+  // Track hasRecent in state so we don't hit localStorage on every render.
+  // Refresh whenever the modal opens — that's the only time it can change
+  // (a successful search calls saveRecentSearch while the modal is open).
+  const [hasRecent, setHasRecent] = useState(false);
+  useEffect(() => {
+    if (open) setHasRecent(loadRecentSearches().length > 0);
+  }, [open]);
+  const showRecent = !search && hasRecent;
+  const showEmpty = !search && !hasRecent;
+
   return (
     <div id="search-bar">
       <Modal open={open} onClose={handleClose}>
-        <div
-          style={{ display: 'flex', alignItems: 'center', gap: 12, paddingLeft: 16, paddingTop: 8 }}
-        >
-          <Icon icon="lucide:search" width="24" height="24" />
+        <div className="search-input-row">
+          <Icon icon="lucide:search" width="20" height="20" />
           <input
             autoFocus
             name="search"
             ref={inputRef}
             value={search}
             onChange={handleSearchChange}
-            style={{
-              border: 'none',
-              height: 46,
-              fontSize: 'large',
-              outline: 'none',
-              flex: 1,
-              background: 'transparent',
-            }}
-            placeholder="Search Mergify Docs"
+            className="search-input"
+            placeholder="Search docs…"
           />
+          {search && (
+            <button
+              type="button"
+              className="search-clear"
+              onClick={() => setSearch('')}
+              aria-label="Clear search"
+            >
+              <Icon icon="lucide:x" width="16" height="16" />
+            </button>
+          )}
         </div>
-        <hr style={{ margin: '8px 0' }} />
-        {!search && <RecentSearches onSelect={setSearch} />}
-        {searchResults && searchResults.length > 0 && (
-          <div
-            style={{
-              padding: '2px 16px 6px',
-              fontSize: '0.75rem',
-              color: 'var(--theme-text-secondary)',
-            }}
-          >
-            {searchResults.length} result{searchResults.length !== 1 ? 's' : ''}
-          </div>
-        )}
-        {searchResults && (
-          <Results results={searchResults} query={search} onNavigate={handleNavigate} />
-        )}
+
+        <div className="search-body">
+          {showRecent && <RecentSearches onSelect={setSearch} />}
+          {showEmpty && <EmptyState />}
+          {loading && <LoadingSkeleton />}
+          {searchResults && searchResults.length > 0 && (
+            <>
+              <div className="search-eyebrow">
+                {searchResults.length} result{searchResults.length !== 1 ? 's' : ''}
+              </div>
+              <Results results={searchResults} query={search} onNavigate={handleNavigate} />
+            </>
+          )}
+          {searchResults && searchResults.length === 0 && (
+            <Results results={searchResults} query={search} onNavigate={handleNavigate} />
+          )}
+        </div>
+
+        <KbdHints />
       </Modal>
     </div>
   );


### PR DESCRIPTION
The search modal worked functionally but its styling was inline-heavy
and pre-dated the docs design system. Refactor the modal styling to use
semantic tokens, add UI for empty / loading / no-results states, and
add a small keyboard-hint footer.

- Modal frame uses --theme-bg-content + --theme-border + 12px radius
  + 0 12px 32px rgba(0,0,0,0.10) shadow, matching the homepage hero
  screenshot frame established earlier.
- Search input row: lucide:search icon on the left, an × clear button
  on the right when there's text, --theme-divider underline.
- Empty state (no query, no recent history): centered "Search the
  docs" with a subtitle hint.
- Loading state: 3 skeleton placeholder rows with subtle opacity-pulse
  animation. Brief on fast networks; matters on slow ones.
- Result rows: title + breadcrumb, hover/active background and a 3px
  left border in the page's product accent color (teal for merge
  queue, purple for ci insights, etc.). Fallback to --theme-link for
  pages outside the named product sections.
- No-results state: centered "No results for «query»" message.
- Footer kbd-hint bar pinned to the bottom of the modal: ↑↓ navigate,
  ↵ open, esc close.

No functional changes: Pagefind indexing, recent-searches localStorage,
hover-prefetch preview pane, and keyboard navigation all preserved.
SearchBar.tsx and Results.tsx no longer carry inline style props;
PageDetails.tsx still has some inline styles and is out of scope here.