### PR TITLE
docs(merge-queue): hide branch_protection_injection_mode `none` from rulesets page

### DIFF
--- a/src/content/docs/merge-queue/github-rulesets.mdx
+++ b/src/content/docs/merge-queue/github-rulesets.mdx
@@ -36,11 +36,6 @@ option on your queue rules:
 - **`merge`** -- rules are injected as merge conditions, checked after the
   queue has tested the pull request.
 
-- **`none`** -- no injection at all. This mode requires a
-  [`merge_bot_account`](/configuration/file-format/#queue-rules) with at
-  least maintain permission. Use this only if you manage all conditions
-  explicitly in your Mergify configuration.
-
 ### Bypass Actors and Injection
 
 If you are using GitHub rulesets (not classic branch protections), you can


### PR DESCRIPTION
Stop advertising the `none` injection mode in the GitHub Rulesets
Compatibility page, ahead of its deprecation (MRGFY-7121). The schema
still accepts the value, so existing configs keep working — this is a
docs-only change to reduce new adoption.

For the equivalent skip-injection behavior, the next section already
documents adding Mergify as a bypass actor with `exempt` bypass mode.

Refs MRGFY-7253.