### PR TITLE
docs(security): document products & integrations permissions

### DIFF
--- a/src/content/docs/security.mdx
+++ b/src/content/docs/security.mdx
@@ -391,6 +391,38 @@ relevant account or resource. Permissions are inherited from GitHub roles.
       <td>✓</td>
     </tr>
   </tbody>
+  <tbody>
+    <tr>
+      <th colSpan="7" scope="rowgroup">Products & Integrations</th>
+    </tr>
+    <tr>
+      <td>GitHub integration: Enable or disable Mergify products</td>
+      <td>✗</td>
+      <td>✗</td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <td>GitHub integration: Configure default products for new repositories</td>
+      <td>✗</td>
+      <td>✗</td>
+      <td>✗</td>
+      <td>✗</td>
+      <td>✗</td>
+      <td>✓</td>
+    </tr>
+    <tr>
+      <td>Third-party integrations: Configure Slack and Datadog notification integrations</td>
+      <td>✗</td>
+      <td>✗</td>
+      <td>✗</td>
+      <td>✗</td>
+      <td>✗</td>
+      <td>✓</td>
+    </tr>
+  </tbody>
 </table>
 
 :::note
@@ -403,8 +435,9 @@ relevant account or resource. Permissions are inherited from GitHub roles.
   - **CI Admin** — manage API keys (CI scope only), activate CI Insights,
     manage CI Insights Auto-Retry rules and self-hosted runners.
 
-  - **Integrations Admin** — enable or disable Mergify products
-    and configure the Slack and Datadog notification integrations.
+  - **Integrations Admin** — enable or disable Mergify products,
+    configure default products for new repositories, and configure third-party
+    integrations (Slack, Datadog, etc.).
 
   - **Delegation Admin** — grant or revoke any of the roles above.
 


### PR DESCRIPTION
Add a Products & Integrations rowgroup to the Features Permissions
table so the two permissions backing the Integrations Admin delegated
role are explicit: enabling Mergify products (Write+) and configuring
notification integrations (Owner-only).

Fixes MRGFY-7266