### PR TITLE
feat(tables): visual refresh of markdown tables

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -19,6 +19,7 @@ import { PagefindIndex } from './integrations/pagefind-index';
 import { autolinkConfig } from './plugins/rehype-autolink-config';
 import { rehypeOptimizeStatic } from './plugins/rehype-optimize-static';
 import { rehypeTasklistEnhancer } from './plugins/rehype-tasklist-enhancer';
+import { rehypeWrapTables } from './plugins/rehype-wrap-tables';
 import { remarkBuildkiteVersionPlugin } from './plugins/remark-buildkite-version';
 import { remarkEnterpriseVersionPlugin } from './plugins/remark-enterprise-version';
 import { remarkGraphvizPlugin } from './plugins/remark-graphviz';
@@ -140,6 +141,8 @@ export default defineConfig({
       [rehypeAutolinkHeadings, autolinkConfig],
       // Tweak GFM task list syntax
       rehypeTasklistEnhancer(),
+      // Wrap markdown tables in a scrollable container
+      rehypeWrapTables(),
       // Collapse static parts of the hast to html
 
       /** Issue with graphviz where inline styles get transformed: `font-size` => `fontsize` whch breaks rendered graphs SVG */

--- a/plugins/rehype-wrap-tables.ts
+++ b/plugins/rehype-wrap-tables.ts
@@ -1,0 +1,31 @@
+import type { Element, Root } from 'hast';
+import { h } from 'hastscript';
+import type { Plugin, Transformer } from 'unified';
+import { CONTINUE, SKIP, visit } from 'unist-util-visit';
+
+/**
+ * Wraps each `<table>` in `<div class="table-wrap">` so the docs default
+ * styling can apply a rounded border to the wrapper and the table itself
+ * can scroll horizontally on narrow viewports.
+ *
+ * Handles both:
+ * - hast `element` nodes — markdown tables and HTML `<table>` parsed as HTML
+ * - `mdxJsxFlowElement` nodes — literal `<table>` JSX in MDX files
+ */
+export function rehypeWrapTables(): Plugin<[], Root> {
+  const transformer: Transformer<Root> = (tree) => {
+    visit(tree, (node, index, parent) => {
+      if (!parent || typeof index !== 'number') return CONTINUE;
+      const isElementTable = node.type === 'element' && (node as Element).tagName === 'table';
+      const isMdxJsxTable =
+        node.type === 'mdxJsxFlowElement' && (node as { name?: string }).name === 'table';
+      if (!isElementTable && !isMdxJsxTable) return CONTINUE;
+      parent.children[index] = h('div', { className: ['table-wrap'] }, node);
+      return SKIP;
+    });
+  };
+
+  return function attacher() {
+    return transformer;
+  };
+}

--- a/src/components/Tables/PullRequestAttributes.tsx
+++ b/src/components/Tables/PullRequestAttributes.tsx
@@ -11,34 +11,36 @@ export default function PullRequestAttributes({ staticAttributes }: Props) {
   const attributes = staticAttributes ?? configSchema.$defs.PullRequestAttributes.properties;
 
   return (
-    <table>
-      <thead>
-        <tr>
-          <th>Attribute name</th>
-          <th>Value type</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        {Object.entries(attributes)
-          .sort(([keyA, _valueA], [keyB, _valueB]) => (keyA > keyB ? 1 : -1))
-          .map(([key, value]) => {
-            const valueType = getValueType(configSchema, value);
+    <div className="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Attribute name</th>
+            <th>Value type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(attributes)
+            .sort(([keyA, _valueA], [keyB, _valueB]) => (keyA > keyB ? 1 : -1))
+            .map(([key, value]) => {
+              const valueType = getValueType(configSchema, value);
 
-            return (
-              <tr key={key}>
-                <td style={{ whiteSpace: 'nowrap' }}>
-                  <code>{key}</code>
-                </td>
-                <td>{valueType}</td>
-                <td
-                  dangerouslySetInnerHTML={{ __html: renderMarkdown(value.description) }}
-                  style={{ width: '100%' }}
-                />
-              </tr>
-            );
-          })}
-      </tbody>
-    </table>
+              return (
+                <tr key={key}>
+                  <td style={{ whiteSpace: 'nowrap' }}>
+                    <code>{key}</code>
+                  </td>
+                  <td>{valueType}</td>
+                  <td
+                    dangerouslySetInnerHTML={{ __html: renderMarkdown(value.description) }}
+                    style={{ width: '100%' }}
+                  />
+                </tr>
+              );
+            })}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -271,40 +271,57 @@ pre > code {
   fill: white;
 }
 
-thead {
-  font-family: var(--font-body);
-  text-transform: uppercase;
-  font-size: small;
-  color: var(--theme-text-secondary);
-  font-weight: 100;
+.table-wrap {
+  border: 1px solid var(--theme-border);
+  border-radius: 8px;
+  background: var(--theme-bg-content);
+  overflow-x: auto;
 }
 
 table {
   width: 100%;
-  padding: var(--padding-block) 0;
   margin: 0;
-  border-collapse: separate;
-  line-height: 1.8;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 4px;
+  border-collapse: collapse;
+  line-height: 1.6;
+  font-size: 0.9375rem;
 }
 
-th {
-  font-weight: bold;
+thead {
+  background: var(--theme-bg-offset);
 }
 
-td,
-th {
-  padding: 12px;
+thead th {
+  padding: 0.625rem 1rem;
   text-align: start;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--theme-text-secondary);
+  border-bottom: 1px solid var(--theme-divider);
+}
+
+tbody td,
+tbody th {
+  padding: 0.75rem 1rem;
+  vertical-align: top;
+  border-bottom: 1px solid var(--theme-divider);
+}
+
+tbody th {
+  text-align: start;
+  font-weight: 600;
 }
 
 tbody tr:last-child td,
 tbody tr:last-child th {
   border-bottom: none;
+}
+
+tbody tr {
+  transition: background-color 0.12s;
+}
+
+tbody tr:hover {
+  background: var(--theme-bg-hover);
 }
 
 blockquote code {


### PR DESCRIPTION
Replace the default MDX table styling with Pass A-aligned visuals:

- Real --theme-border color (was unspecified, fell back to a
  browser default)
- thead gets a --theme-bg-offset background and sentence-case
  semibold headers, replacing the conflicting font-weight:100 +
  uppercase + th-bold mix
- border-collapse: collapse (was separate without border-spacing,
  which produced visible inter-cell gaps)
- border-radius lifted from 4px → 8px to match the rest of the
  site
- New subtle row hover (--theme-bg-hover) for interactivity

Each markdown table is now wrapped in a <div class="table-wrap">
via a new rehype plugin. The wrapper carries the rounded border
and provides overflow-x scrolling for wide tables on narrow
viewports.