### PR TITLE
ci: skip external links in broken link check

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "biome format --write .",
     "format:check": "biome format src integrations plugins scripts",
     "check": "astro check && eslint . && biome check .",
-    "check:links": "linkinator dist/ --recurse --retry-errors --retry-errors-count 3 --timeout 30000 --concurrency 25 --verbosity error --skip 'github.com/.*/edit/' --skip 'https://docs.mergify.com' --skip 'https://slack.mergify.com'"
+    "check:links": "linkinator dist/ --recurse --concurrency 25 --verbosity error --skip 'https?://'"
   },
   "devDependencies": {
     "@actions/core": "^3.0.1",


### PR DESCRIPTION
External link checks cause flaky CI failures unrelated to PR changes.
Only check internal links which are deterministic and catch real issues.