### PR TITLE
docs(nav): match Workflow Automation and Integrations icons with dashboard

### DIFF
--- a/src/content/navItems.tsx
+++ b/src/content/navItems.tsx
@@ -235,7 +235,7 @@ const navItems: NavItem[] = [
   },
   {
     title: 'Workflow Automation',
-    icon: 'lucide:settings',
+    icon: 'lucide:zap',
     path: '/workflow',
     children: [
       { title: 'Workflow Automation', path: '/workflow/', icon: 'lucide:bot' },
@@ -364,7 +364,7 @@ const navItems: NavItem[] = [
   },
   {
     title: 'Integrations',
-    icon: 'lucide:plug',
+    icon: 'lucide:blocks',
     path: '/integrations',
     children: [
       { title: 'GitHub', path: '/integrations/github', icon: 'simple-icons:github' },


### PR DESCRIPTION
Align the docs sidebar icons with the ones used in the Mergify
dashboard's main navigation so the same concepts read the same way
across products.

- Workflow Automation: lucide:settings → lucide:zap
- Integrations: lucide:plug → lucide:blocks

The dashboard will be updated separately to use the same icons.