### PR TITLE
docs: fix yaml anchor name in configuration/sharing.mdx

### DIFF
--- a/src/content/docs/configuration/sharing.mdx
+++ b/src/content/docs/configuration/sharing.mdx
@@ -45,10 +45,10 @@ shared:
 queue_rules:
   - name: hotfix
     queue_conditions:
-      - and: *my_ci
+      - and: *common_checks
   - name: default
     queue_conditions:
-      - and: *my_ci
+      - and: *common_checks
       - schedule = Mon-Fri 09:00-17:30[Europe/Paris]
 ```
 


### PR DESCRIPTION
The example in doc is not a valid YAML syntax.

Discovered while working on https://github.com/awesomeWM/awesome/pull/4104