### PR TITLE
fix(sidebar): expand the active section on deep-link visits

### DIFF
--- a/src/components/HeadCommon.astro
+++ b/src/components/HeadCommon.astro
@@ -12,6 +12,12 @@ import '../styles/tokens.css';
 import '../styles/theme.css';
 import '../styles/typography.css';
 import '../styles/index.css';
+
+export interface Props {
+  activePageGroupIds?: string[];
+}
+
+const { activePageGroupIds = [] } = Astro.props as Props;
 ---
 
 <!-- Global Metadata -->
@@ -65,30 +71,37 @@ import '../styles/index.css';
 	});
 </script>
 
-<!-- Restore sidebar nav-group open/closed state from localStorage to avoid FOUC.
-     Generates CSS rules in <head> so groups render at the correct height from the
-     very first paint, before the body is parsed. Cleaned up by LeftSidebar. -->
-<script is:inline>
+<!-- Restore sidebar nav-group open/closed state to avoid FOUC. Merges localStorage
+     state with the current page's ancestor group IDs so deep-link visits paint with
+     the active section already expanded. Generates CSS in <head> before the body
+     parses; cleaned up by LeftSidebar. -->
+<script is:inline define:vars={{ activePageGroupIds }}>
 	{
+		const safe = /^[\w-]+$/;
+		const openIds = new Set();
 		const raw = localStorage.getItem('navState');
 		if (raw) {
 			try {
 				const state = JSON.parse(raw);
-				const safe = /^[\w-]+$/;
-				const css = Object.entries(state)
-					.filter(([id, open]) => open && safe.test(id))
-					.map(([id]) =>
-						`nav-group[data-uuid="${id}"]>.nav-details>.nav-group-content{grid-template-rows:1fr}` +
-						`nav-group[data-uuid="${id}"]>.nav-details>.nav-group-title .chevron{transform:rotate(90deg)}`
-					)
-					.join('');
-				if (css) {
-					const s = document.createElement('style');
-					s.id = 'nav-restore';
-					s.textContent = css;
-					document.head.appendChild(s);
+				for (const [id, open] of Object.entries(state)) {
+					if (open && safe.test(id)) openIds.add(id);
 				}
 			} catch { /* ignore corrupted localStorage */ }
+		}
+		for (const id of activePageGroupIds) {
+			if (safe.test(id)) openIds.add(id);
+		}
+		const css = Array.from(openIds)
+			.map((id) =>
+				`nav-group[data-uuid="${id}"]>.nav-details>.nav-group-content{grid-template-rows:1fr}` +
+				`nav-group[data-uuid="${id}"]>.nav-details>.nav-group-title .chevron{transform:rotate(90deg)}`
+			)
+			.join('');
+		if (css) {
+			const s = document.createElement('style');
+			s.id = 'nav-restore';
+			s.textContent = css;
+			document.head.appendChild(s);
 		}
 	}
 </script>

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -6,9 +6,10 @@ import SidebarContent from './SidebarContent.astro';
 
 export interface Props {
   currentPage: string;
+  activePageGroupIds?: string[];
 }
 
-const { currentPage } = Astro.props as Props;
+const { currentPage, activePageGroupIds = [] } = Astro.props as Props;
 const currentPageMatch = removeLeadingSlash(removeTrailingSlash(currentPage));
 const isEnterprisePage = currentPage === '/enterprise' || currentPage.startsWith('/enterprise/');
 ---
@@ -57,22 +58,26 @@ const isEnterprisePage = currentPage === '/enterprise' || currentPage.startsWith
 </nav>
 
 <!-- Restore nav state + sidebar scroll before first paint -->
-<script is:inline>
+<script is:inline define:vars={{ activePageGroupIds }}>
 	{
+		const openIds = new Set(activePageGroupIds);
 		const storedNavState = localStorage.getItem('navState');
 		if (storedNavState) {
 			try {
 				const navState = JSON.parse(storedNavState);
-				for (const el of document.querySelectorAll('nav-group[data-uuid]')) {
-					if (navState[el.dataset.uuid]) {
-						el.querySelector(':scope > .nav-details')?.classList.add('open');
-						const btn = el.querySelector(':scope > .nav-details > .nav-group-title');
-						if (btn) btn.setAttribute('aria-expanded', 'true');
-						const content = el.querySelector(':scope > .nav-details > .nav-group-content');
-						if (content) content.removeAttribute('inert');
-					}
+				for (const [id, open] of Object.entries(navState)) {
+					if (open) openIds.add(id);
 				}
 			} catch { /* ignore corrupted localStorage */ }
+		}
+		for (const el of document.querySelectorAll('nav-group[data-uuid]')) {
+			if (openIds.has(el.dataset.uuid)) {
+				el.querySelector(':scope > .nav-details')?.classList.add('open');
+				const btn = el.querySelector(':scope > .nav-details > .nav-group-title');
+				if (btn) btn.setAttribute('aria-expanded', 'true');
+				const content = el.querySelector(':scope > .nav-details > .nav-group-content');
+				if (content) content.removeAttribute('inert');
+			}
 		}
 		// Head-injected nav-restore style is no longer needed now that
 		// .open classes are set — remove it so it doesn't override clicks.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,6 +9,7 @@ import HeadSEO from '../components/HeadSEO.astro';
 import ImageZoom from '../components/ImageZoom.astro';
 import LeftSidebar from '../components/LeftSidebar/LeftSidebar.astro';
 import ScrollToTop from '../components/ScrollToTop.astro';
+import { getActivePageGroupIds } from '../util/activePageGroupIds';
 
 export interface Props {
   content: CollectionEntry<'docs'>['data'];
@@ -17,6 +18,7 @@ export interface Props {
 const { content } = Astro.props;
 const url = Astro.url;
 const currentPage = url.pathname;
+const activePageGroupIds = getActivePageGroupIds(currentPage);
 const formatTitle = (content: { title?: string }) => content.title;
 // Ensures the canonicalURL always has a trailing slash.
 const canonicalURL = new URL(Astro.url.pathname.replace(/([^/])$/, '$1/'), Astro.site);
@@ -24,7 +26,7 @@ const canonicalURL = new URL(Astro.url.pathname.replace(/([^/])$/, '$1/'), Astro
 
 <html dir={'ltr'} lang={'en'} class="initial">
 	<head>
-		<HeadCommon />
+		<HeadCommon activePageGroupIds={activePageGroupIds} />
 		<HeadSEO content={content} canonicalURL={canonicalURL} />
 		<title set:html={formatTitle(content)} />
 		<ClientRouter />
@@ -133,7 +135,7 @@ const canonicalURL = new URL(Astro.url.pathname.replace(/([^/])$/, '$1/'), Astro
 		<main class="layout">
 			<aside id="left-sidebar" class="sidebar" transition:animate="none">
 				<slot name="primary-sidebar">
-					<LeftSidebar currentPage={currentPage} />
+					<LeftSidebar currentPage={currentPage} activePageGroupIds={activePageGroupIds} />
 				</slot>
 			</aside>
 			<aside id="right-sidebar" class="sidebar" transition:animate={fade({ duration: '150ms' })}>

--- a/src/util/activePageGroupIds.test.ts
+++ b/src/util/activePageGroupIds.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest';
+import navItems from '../content/navItems';
+import { getActivePageGroupIds } from './activePageGroupIds';
+
+const findGroupId = (title: string, items = navItems): string | undefined => {
+  for (const item of items) {
+    if (item.title === title && item.id) return item.id;
+    if (item.children) {
+      const found = findGroupId(title, item.children);
+      if (found) return found;
+    }
+  }
+  return undefined;
+};
+
+describe('getActivePageGroupIds', () => {
+  test('returns empty for the homepage (no parent group)', () => {
+    expect(getActivePageGroupIds('/')).toEqual([]);
+  });
+
+  test('returns empty for an unknown path', () => {
+    expect(getActivePageGroupIds('/does-not-exist')).toEqual([]);
+  });
+
+  test('returns the parent group for a single-level page', () => {
+    const stacksId = findGroupId('Stacks');
+    expect(stacksId).toBeDefined();
+    expect(getActivePageGroupIds('/stacks/setup/')).toEqual([stacksId]);
+  });
+
+  test('handles paths without a trailing slash', () => {
+    const stacksId = findGroupId('Stacks');
+    expect(getActivePageGroupIds('/stacks/setup')).toEqual([stacksId]);
+  });
+
+  test('returns ancestors in outer-to-inner order for nested pages', () => {
+    const stacksId = findGroupId('Stacks');
+    const compareId = findGroupId('Compare Tools');
+    expect(stacksId).toBeDefined();
+    expect(compareId).toBeDefined();
+    expect(getActivePageGroupIds('/stacks/compare/gh-stack')).toEqual([stacksId, compareId]);
+  });
+
+  test('matches a leaf with the same path as its parent group (overview)', () => {
+    const stacksId = findGroupId('Stacks');
+    expect(getActivePageGroupIds('/stacks')).toEqual([stacksId]);
+  });
+
+  test('matches a group whose own path has no leaf child (top-level)', () => {
+    // Integrations group has path "/integrations" but its children are all
+    // distinct pages (/integrations/github, etc.) — no leaf for /integrations
+    // itself. The group should still be included in the open set.
+    const integrationsId = findGroupId('Integrations');
+    expect(integrationsId).toBeDefined();
+    expect(getActivePageGroupIds('/integrations')).toEqual([integrationsId]);
+  });
+
+  test('matches a nested group whose own path has no leaf child', () => {
+    // Workflow Automation > Actions group has path "/workflow/actions" with
+    // children like "/workflow/actions/assign", and no leaf for "/workflow/actions".
+    const workflowId = findGroupId('Workflow Automation');
+    const actionsId = findGroupId('Actions');
+    expect(workflowId).toBeDefined();
+    expect(actionsId).toBeDefined();
+    expect(getActivePageGroupIds('/workflow/actions')).toEqual([workflowId, actionsId]);
+  });
+
+  test('still prefers a deeper leaf match over the enclosing group', () => {
+    // Sanity check: on /workflow/actions/assign we want both ancestor groups,
+    // matched via the leaf — not the Actions group's own path.
+    const workflowId = findGroupId('Workflow Automation');
+    const actionsId = findGroupId('Actions');
+    expect(getActivePageGroupIds('/workflow/actions/assign')).toEqual([workflowId, actionsId]);
+  });
+});

--- a/src/util/activePageGroupIds.ts
+++ b/src/util/activePageGroupIds.ts
@@ -1,0 +1,39 @@
+import navItems, { type NavItem } from '../content/navItems';
+import { removeLeadingSlash, removeTrailingSlash } from '../util';
+
+/**
+ * Return the IDs of the navigation groups that are ancestors of the
+ * navItem matching `currentPath`. Used to expand the sidebar to the
+ * current page on initial load, even when localStorage has no entry.
+ */
+export function getActivePageGroupIds(currentPath: string): string[] {
+  const target = removeLeadingSlash(removeTrailingSlash(currentPath));
+
+  const matchesPath = (itemPath: string): boolean => {
+    const normalized = removeLeadingSlash(removeTrailingSlash(itemPath));
+    if (normalized === '') return target === '';
+    return target === normalized || target.endsWith(`/${normalized}`);
+  };
+
+  const findPath = (items: NavItem[], ancestorIds: string[]): string[] | null => {
+    for (const item of items) {
+      const nextAncestorIds = item.id ? [...ancestorIds, item.id] : ancestorIds;
+      if (!item.children && item.path && matchesPath(item.path)) {
+        return ancestorIds;
+      }
+      if (item.children) {
+        // Prefer a leaf match deeper in the tree (e.g. an explicit overview
+        // child) before falling back to the group's own path. This keeps the
+        // returned ancestor list as specific as possible.
+        const found = findPath(item.children, nextAncestorIds);
+        if (found) return found;
+        if (item.path && matchesPath(item.path)) {
+          return nextAncestorIds;
+        }
+      }
+    }
+    return null;
+  };
+
+  return findPath(navItems, []) ?? [];
+}


### PR DESCRIPTION
The left sidebar restored its open/closed state from localStorage only,
so a direct visit to a deep URL like /stacks/setup/ left the containing
group collapsed when the user had no prior nav state cached.

Compute the active page's ancestor nav-group UUIDs server-side and merge
them into the FOUC <head> CSS and the LeftSidebar inline restoration
script. The NavGroup custom element only adds .open (never removes), so
the inline script's class survives its later upgrade.