### PR TITLE
docs: use lucide:zap for Workflow Automation icon everywhere

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -109,7 +109,7 @@ import mergeQueueHero from './images/merge-queue-hero.jpg';
       <Docset title="Stacks" path="/stacks" icon="mergify:stacks">
         Stacked PR workflow for incremental changes.
       </Docset>
-      <Docset title="Workflow Automation" path="/workflow" icon="lucide:bot">
+      <Docset title="Workflow Automation" path="/workflow" icon="lucide:zap">
         Rule engine and actions to automate PR workflows.
       </Docset>
     </DocsetGrid>

--- a/src/content/navItems.tsx
+++ b/src/content/navItems.tsx
@@ -242,7 +242,7 @@ const navItems: NavItem[] = [
     icon: 'lucide:zap',
     path: '/workflow',
     children: [
-      { title: 'Workflow Automation', path: '/workflow/', icon: 'lucide:bot' },
+      { title: 'Workflow Automation', path: '/workflow/', icon: 'lucide:zap' },
       { title: 'Rule Syntax', path: '/workflow/rule-syntax', icon: 'lucide:badge-question-mark' },
       {
         title: 'Actions',


### PR DESCRIPTION
The Workflow Automation section header in the left sidebar uses
`lucide:zap`, but the home page Docset card and the child overview link
in the sidebar still used `lucide:bot`. Align both to `lucide:zap` so
the icon is consistent wherever Workflow Automation is referenced.