### PR TITLE
docs: fix code fence languages for non-yaml snippets

### DIFF
--- a/src/content/docs/configuration/data-types.mdx
+++ b/src/content/docs/configuration/data-types.mdx
@@ -114,7 +114,7 @@ timezone is specified, it defaults to UTC.
 Schedule can be only used with the equality operators `=` and `!=`.
 :::
 
-```yaml
+```text
 schedule = Mon-Fri
 schedule = 09:00-19:00
 schedule = 09:00-19:00[America/Vancouver]

--- a/src/content/docs/test-insights/test-frameworks/cypress.mdx
+++ b/src/content/docs/test-insights/test-frameworks/cypress.mdx
@@ -36,7 +36,7 @@ both have JUnit generated while keeping the standard output.
 
 2. Create a `reporter-config.json` at the top of your repository with this
    configuration:
-   ```yaml
+   ```json
    {
      "reporterEnabled": "spec, mocha-junit-reporter",
      "mochaJunitReporterReporterOptions": {


### PR DESCRIPTION
The cypress reporter-config.json snippet was tagged as yaml but contains
JSON, so Shiki rendered it as a plain pre with no syntax highlighting.

The schedule data-type example was also tagged as yaml but shows Mergify
condition-expression syntax, not yaml; switching to text matches the
sibling examples on the same page.