### PR TITLE
docs(security): update auto-retry rule permissions to repo WRITE

### DIFF
--- a/src/content/docs/security.mdx
+++ b/src/content/docs/security.mdx
@@ -88,7 +88,7 @@ Each user can hold any combination of the following roles:
       <th scope="row">CI Admin</th>
       <td>
         Configure CI Insights at the organization level — self-hosted runner
-        fleet and Auto-Retry rules — and manage CI-scoped application keys.
+        fleet — and manage CI-scoped application keys.
       </td>
     </tr>
     <tr>
@@ -321,9 +321,9 @@ relevant account or resource. Permissions are inherited from GitHub roles.
       <td>Manage CI Insights Auto-Retry rules</td>
       <td>✗</td>
       <td>✗</td>
-      <td>✗</td>
-      <td>✗</td>
-      <td>✗</td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>✓</td>
       <td>✓</td>
     </tr>
     <tr>
@@ -433,7 +433,7 @@ relevant account or resource. Permissions are inherited from GitHub roles.
   - **Billing Admin** — manage Mergify subscription.
 
   - **CI Admin** — manage API keys (CI scope only), activate CI Insights,
-    manage CI Insights Auto-Retry rules and self-hosted runners.
+    and manage CI Insights self-hosted runners.
 
   - **Integrations Admin** — enable or disable Mergify products,
     configure default products for new repositories, and configure third-party


### PR DESCRIPTION
Mergify's auto-retry rules moved from organization-scoped (gated on the
CI Admin delegation role) to per-repository (gated on repo WRITE on the
GitHub side). Reflect both changes:

* CI Admin role description: drop the Auto-Retry rules mention. The
  delegation role no longer gates them; per-repo Write/Maintain/Admin
  do. Self-hosted runner fleet config and CI-scoped application keys
  remain CI Admin's responsibility.
* Permissions table: the "Manage CI Insights Auto-Retry rules" row
  flips from "Owner only" to "Write / Maintain / Admin / Owner",
  matching the backend's MergifyRepoRole.WRITE gate.

Read and Triage stay denied. The existing "View CI Insights data" row
already covers the READ side (the list endpoint accepts any
collaborator).

Related to MRGFY-7345
Related to Mergifyio/monorepo#32337

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>