### PR TITLE
fix(404): restore the navbar logo on the 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -17,6 +17,16 @@ import Header from '../components/Header/Header.astro';
 				display: none;
 			}
 
+			/* 404 has no left sidebar, so undo the docs layout's reservations:
+			   pull the navbar back flush with the viewport and keep the
+			   mobile logo visible at all widths so the brand is there. */
+			:global(header) {
+				left: 0 !important;
+			}
+			:global(.logo-mobile) {
+				display: flex !important;
+			}
+
 			.not-found {
 				display: flex;
 				flex-direction: column;


### PR DESCRIPTION
The 404 page renders `<Header />` without a `<LeftSidebar />`, but the
docs Header CSS assumes a sidebar exists at >=50em:

- `header { left: var(--theme-left-sidebar-width); }` shifts the navbar
  right, leaving a 17rem empty gap on the left of the 404 navbar
- `.logo-mobile { display: none; }` hides the in-header logo on the
  assumption that the sidebar's own logo takes over — but the sidebar
  isn't there, so the 404 page renders with no logo at all

Override both rules on the 404 page so the header sits flush with the
viewport edge and the mobile-style logo stays visible at all widths.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>