### PR TITLE
docs(merge-queue): reframe gha-mergify-ci as optional for file-pattern scopes

### DIFF
--- a/src/content/docs/merge-queue/migrate-partitions-to-scopes.mdx
+++ b/src/content/docs/merge-queue/migrate-partitions-to-scopes.mdx
@@ -26,22 +26,22 @@ compute**.
 
 ## Requirements
 
-### GitHub Actions
+With file-pattern scopes, Mergify evaluates the patterns itself: it matches each pull request's
+changed files against your `.mergify.yml` definitions and batches by scope. Nothing else is required
+for the merge queue.
 
-You need the [`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci)
-GitHub Action to detect scopes and report CI status. It handles:
+The [`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci) GitHub Action is optional and
+needed only when you want to:
 
-- Reading your scope definitions from `.mergify.yml`
-- Comparing the pull request diff against file patterns
-- Exposing scope outputs so downstream jobs can be conditionally skipped
-- Aggregating job results so required checks always report
+- Skip CI jobs whose scope a pull request doesn't touch, and aggregate results so required checks
+  always report.
 
-If you use a monorepo build tool, `gha-mergify-ci` also provides git refs for
-accurate affected-project detection:
+- Compute scopes with a monorepo build tool instead of file patterns. In this case, `gha-mergify-ci`
+  also provides git refs for accurate affected-project detection:
 
 | Build Tool | How scopes are detected |
 |---|---|
-| **File patterns** | `gha-mergify-ci` matches changed files against patterns in `.mergify.yml` |
+| **File patterns** | Mergify matches changed files against patterns in `.mergify.yml` |
 | **Nx** | `nx show projects --affected` using refs from `gha-mergify-ci` |
 | **Turborepo** | `turbo run build --dry=json --filter` using refs from `gha-mergify-ci` |
 | **Bazel** | `bazel query` for affected packages using refs from `gha-mergify-ci` |
@@ -134,10 +134,15 @@ Partition rules use **regex** conditions (`files~=^pattern/`), while scopes use
 | `files~=^apps/web/.*\.(js\|ts)$` | `apps/web/**/*.{js,ts}` |
 | `files~=^(config\|docker)/` | Two includes: `config/**/*` and `docker/**/*` |
 
-### 2. Update your GitHub Actions workflow
+### 2. (Optional) Wire scopes into your CI
 
-Add a job that detects and submits scopes on every pull request using
-[`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci):
+For the merge queue to batch by scope, you don't need to touch your CI: Mergify evaluates the file
+patterns from step 1 on its own. This step is only needed if you also want to **skip CI jobs** whose
+scope a pull request doesn't touch.
+
+Add a job that detects scopes on every pull request using
+[`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci), then condition your other jobs on
+its outputs:
 
 ```yaml
 name: Scopes
@@ -150,7 +155,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Detect and submit scopes
+      - name: Detect scopes
         uses: Mergifyio/gha-mergify-ci@v11
         with:
           action: scopes

--- a/src/content/docs/merge-queue/monorepo.mdx
+++ b/src/content/docs/merge-queue/monorepo.mdx
@@ -39,21 +39,26 @@ With scopes, Mergify can:
 1. **Define scopes** in `.mergify.yml` using either file patterns or data emitted by your build
    system. Start with the [Scopes reference](/merge-queue/scopes).
 
-2. **Collect scopes in CI** via [`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci) so
-   every workflow knows which services a pull request touches.
+2. **Batch by scope in Merge Queue** to group compatible pull requests and keep unrelated work
+   apart. With file patterns, Mergify evaluates them itself, so the queue batches by scope with no
+   extra setup.
 
-3. **Reuse scopes in Merge Queue** to batch compatible pull requests, keep unrelated work apart,
-   and gate expensive tests only when those scopes are present.
+3. **Optionally, collect scopes in CI** via
+   [`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci) when you compute scopes with a
+   build system (Nx, Bazel, Turborepo) or want to gate expensive tests on the scopes a pull request
+   touches.
 
 Need scope-aware CI without the merge queue? Explore [Monorepo CI](/monorepo-ci) for workflows that
 target GitHub Actions today.
 
 ### No monorepo tooling yet?
 
-Start with [Monorepo CI](/monorepo-ci) and its GitHub Actions guide. It ships a ready-made
-[`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci) workflow that detects scopes through file
-patterns, so you can adopt scope-aware batching without introducing Nx, Bazel, or Turborepo first. As
-your repository grows you can swap in more advanced tooling—your scopes stay the same.
+Just declare file-pattern scopes in `.mergify.yml`. Mergify evaluates them and the merge queue
+batches by scope with no workflow to add, so you get scope-aware batching without introducing Nx,
+Bazel, or Turborepo first. When you also want scope-aware CI, the
+[Monorepo CI](/monorepo-ci) GitHub Actions guide ships a ready-made
+[`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci) workflow. As your repository grows
+you can swap in more advanced tooling, and your scopes stay the same.
 
 ## Understanding Scopes
 

--- a/src/content/docs/merge-queue/scopes.mdx
+++ b/src/content/docs/merge-queue/scopes.mdx
@@ -83,11 +83,10 @@ changes in the batch because they touch the same areas of the codebase.
 
 Scopes can be attached to pull requests automatically or manually:
 
-- **File pattern detection:** Define scopes directly in your configuration so Mergify infers them
-  from changed paths once your CI uploads the results via
-  [`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci) or an equivalent integration.
-  See [file-pattern scopes](/merge-queue/scopes/file-patterns) for a
-  step-by-step setup.
+- **File pattern detection:** Define scopes directly in your configuration and Mergify evaluates
+  them itself, matching each pull request's changed files against your patterns. No CI job or GitHub
+  Action is required for the queue to batch by scope. See
+  [file-pattern scopes](/merge-queue/scopes/file-patterns) for a step-by-step setup.
 
 - **Manual upload:** Use the [`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci)
   GitHub Action, the [REST API](/api/pull-requests), or the `mergify scopes-send` CLI to push scopes

--- a/src/content/docs/merge-queue/scopes/file-patterns.mdx
+++ b/src/content/docs/merge-queue/scopes/file-patterns.mdx
@@ -46,9 +46,17 @@ Mergify will intelligently batch PRs with overlapping scopes together. For examp
 they share a common scope.
 :::
 
-## Setting Up CI with Scopes
+## How Mergify Evaluates File-Pattern Scopes
 
-To wire scopes into GitHub Actions, follow the
+Mergify evaluates file-pattern scopes itself. For each pull request, it matches the changed files
+against your `include` (and optional `exclude`) patterns and tags the pull request with the scopes
+it touches. This happens in the merge queue automatically, with no CI job or GitHub Action to set
+up: declare the patterns above and the queue batches by scope.
+
+## Conditioning CI Jobs on Scopes (Optional)
+
+The same scopes can also drive your CI, letting you skip jobs whose scope a pull request doesn't
+touch. This is optional and independent of merge queue batching. To wire it up, follow the
 [Monorepo CI GitHub Actions guide](/monorepo-ci/github-actions). It walks through:
 
 - Adding the [`gha-mergify-ci`](https://github.com/Mergifyio/gha-mergify-ci)
@@ -124,8 +132,8 @@ With this configuration:
 
 ### Scope Detection is PR-Specific
 
-The `gha-mergify-ci` action only analyzes files changed by the specific pull request, **not** files
-from other PRs in the merge queue batch. This ensures:
+Mergify evaluates the files changed by the specific pull request, **not** files from other PRs in
+the merge queue batch. This ensures:
 
 - Each PR's scopes reflect only its own changes
 - Batching decisions remain consistent even as the queue changes


### PR DESCRIPTION
File-pattern scopes declared in .mergify.yml are now evaluated directly by
the engine, so the merge queue can batch by scope with no GitHub Action or CI
upload. Reframe gha-mergify-ci as optional across the merge-queue docs: needed
only for external build-system scopes (Nx, Bazel, Turborepo) or for
conditioning CI jobs on scope outputs.

Fixes MRGFY-7399

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>