### PR TITLE
fix(header): restore logo by scoping CSS to child component SVG

### DIFF
--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -163,7 +163,7 @@ const primaryLink = isEnterpriseSection
 		margin: -0.5em -0.25em;
 	}
 
-	.logo svg {
+	.logo :global(svg) {
 		height: 30px;
 		display: block;
 	}

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -116,7 +116,7 @@ const isEnterprisePage = currentPage === '/enterprise' || currentPage.startsWith
 			text-decoration: none;
 			color: inherit;
 		}
-		.sidebar-logo svg {
+		.sidebar-logo :global(svg) {
 			height: 28px;
 			width: auto;
 			display: block;


### PR DESCRIPTION
The footer-refresh refactor (#11660) moved the inline logo SVG into a new
Logo.astro component, but left the `.logo svg` and `.sidebar-logo svg`
size rules in their original parent components. Astro scopes those
selectors with a data-astro-cid attribute that only marks elements
declared in the same file, so the rules silently stopped matching the
SVG once it came from a child component, and the logo collapsed to 0x0.

Wrap the descendant selector in `:global(svg)` so the size rules reach
the child component's SVG. Verified at 1400px (sidebar logo) and 600px
(mobile header logo).