### PR TITLE
docs(billing): count commit contributors as active users

### DIFF
--- a/public/mergify-count-contributors.py
+++ b/public/mergify-count-contributors.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 # This script counts the number of contributors for repositories over the last 30 days.
 #
+# A contributor is a user who contributed commits to a pull request in the last
+# 30 days, either by opening it or by pushing commits to it. This matches how
+# Mergify counts active users for billing.
+#
 # See https://docs.mergify.com/billing/ for context.
 #
 # Keep in mind that this is not 100% accurate but gives a ballpark estimate.
@@ -98,67 +102,30 @@ def is_user_ignored(user):
 
 
 def get_users_from_pr(api_endpoint, repo_name, pr):
-    """Extract all active users from a PR: creator, reviewers, commenters, and label changers."""
+    """Extract the billable users from a PR: its author and the users who pushed commits to it."""
     users = set()
 
-    # Get PR creator
+    # The PR author (counted when the pull request is opened).
     user = pr["user"]
     if not is_user_ignored(user):
         users.add(user["login"])
 
-    # Get PR reviewers
+    # The users who pushed commits to the PR. Mergify bills the pusher on each
+    # push; the commit author and committer are the closest proxy available
+    # from the API.
     try:
-        reviews_response = _requests_get(
-            f"{api_endpoint}/repos/{repo_name}/pulls/{pr['number']}/reviews?per_page=100",
+        commits_response = _requests_get(
+            f"{api_endpoint}/repos/{repo_name}/pulls/{pr['number']}/commits?per_page=100",
             headers=HEADERS,
         )
-        reviews_response.raise_for_status()
+        commits_response.raise_for_status()
     except Exception:
-        print("W: Unable to retrieve PR reviews, ignoring, error below:")
+        print("W: Unable to retrieve PR commits, ignoring")
     else:
-        for reviewer in reviews_response.json():
-            if not is_user_ignored(reviewer["user"]):
-                users.add(reviewer["user"]["login"])
-
-    # Get PR comments authors
-    try:
-        comments_response = _requests_get(
-            f"{api_endpoint}/repos/{repo_name}/issues/{pr['number']}/comments?per_page=100",
-            headers=HEADERS,
-        )
-        comments_response.raise_for_status()
-    except Exception:
-        print("W: Unable to retrieve PR comments, ignoring")
-    else:
-        for comment in comments_response.json():
-            if not is_user_ignored(comment["user"]):
-                users.add(comment["user"]["login"])
-
-    try:
-        # Get users from the timeline
-        users |= get_users_from_timeline(api_endpoint, repo_name, pr["number"])
-    except Exception:
-        print("W: Unable to retrieve PR timeline, ignoring")
-
-    return users
-
-
-def get_users_from_timeline(api_endpoint, repo_name, pr_number):
-    """Extract users who added or removed labels from a PR timeline."""
-    users = set()
-
-    timeline_events = _requests_get(
-        f"{api_endpoint}/repos/{repo_name}/issues/{pr_number}/timeline",
-        params={"per_page": 100},
-        headers=HEADERS,
-    )
-    timeline_events.raise_for_status()
-
-    for event in timeline_events.json():
-        if event.get("event") in {"labeled", "unlabeled"}:
-            actor = event.get("actor")
-            if actor and not is_user_ignored(actor):
-                users.add(actor["login"])
+        for commit in commits_response.json():
+            for actor in (commit.get("author"), commit.get("committer")):
+                if actor and not is_user_ignored(actor):
+                    users.add(actor["login"])
 
     return users
 

--- a/src/content/docs/billing.mdx
+++ b/src/content/docs/billing.mdx
@@ -21,16 +21,17 @@ Mergify, we firmly believe in billing you only for what you actively use.
 This is why our billing system operates on the principle of contributors.
 Here's how it works:
 
-- A contributor is any individual who **engages in activities on a
-  repository**. This includes opening, closing, commenting, pushing or
-  reviewing a pull request.
+- A contributor is any user who **contributes commits to a pull request**,
+  either by opening it or by pushing new commits to it. Other activity, such
+  as reviewing, commenting on, closing, or reopening a pull request, does not
+  make someone a contributor.
 
-- Each user is counted **only once**, even if they're active across multiple
-  repositories.
+- Each user is counted **only once**, even if they contribute to pull requests
+  across multiple repositories.
 
-- The system uses a 30-day sliding window approach. This means a user is
-  regarded as a contributor for 30 days from their last activity. Post this
-  period, if no further activity is detected, they are no longer considered
+- The system uses a 30-day sliding window. A user is counted as a contributor
+  for 30 days after they open a pull request or push commits to one. After that
+  period, if they make no further contributions, they are no longer considered
   active for billing purposes.
 
 - Usage is prorated to the day: if a contributor is seen active during 48 days,


### PR DESCRIPTION
Mergify now counts a user as an active contributor only when they
contribute commits to a pull request: the author when the pull request
is opened, and the pusher on each subsequent push. Issue comments, pull
request reviews, review comments, reopens, edits, and closes no longer
count toward billing.

Update the billing definition and the 30-day sliding window wording to
match, and rework the estimation script to count the pull request author
plus the commit authors/committers (the closest API proxy for pushers)
instead of reviewers, commenters, and label changers.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>