### PR TITLE
docs(test-insights): Document `mergify tests quarantine` and `unquarantine`

### DIFF
--- a/src/content/docs/cli.mdx
+++ b/src/content/docs/cli.mdx
@@ -67,4 +67,4 @@ mergify --token your_token_here <command>
 | `mergify queue` | Monitor and control merge queue | [Monitoring](/merge-queue/monitoring) |
 | `mergify config` | Validate and simulate config | [Config](/configuration/file-format#validating-with-the-cli) |
 | `mergify ci` | Upload and analyze CI results | [CI Insights](/ci-insights) |
-| `mergify tests show` | Search test health by name | [Test Insights CLI](/test-insights/cli) |
+| `mergify tests` | Search test health and manage quarantine | [Test Insights CLI](/test-insights/cli) |

--- a/src/content/docs/test-insights/cli.mdx
+++ b/src/content/docs/test-insights/cli.mdx
@@ -36,6 +36,50 @@ tests, so callers can branch without parsing output:
 
 Exit code `2` is reserved for CLI argument errors.
 
+## `mergify tests quarantine`
+
+Add a test to [quarantine](/test-insights/quarantine) so its failures
+stop blocking merges and no longer mark the pipeline as failed. The
+test keeps running, and its results keep flowing into Test Insights.
+
+```bash
+mergify tests quarantine -r owner/repo \
+  --reason "flaky — tracked in MRGFY-1234" \
+  "tests/auth/test_login.py::test_login_timeout"
+```
+
+Pass the fully qualified test name and a `--reason` (both required). The
+quarantine applies to every branch by default; scope it to one branch or
+pattern with `--branch` (`-b`). The command prints a quarantine ID you
+can pass to `unquarantine`. Add `--json` for a machine-readable payload,
+and run `mergify tests quarantine --help` for the full list of flags.
+
+The command exits `0` on success and `6` on a Mergify API error, for
+example when the test is already quarantined.
+
+## `mergify tests unquarantine`
+
+Remove a test from quarantine, addressed either by its fully qualified
+name or by the quarantine ID that `quarantine` printed.
+
+```bash
+# By test name.
+mergify tests unquarantine -r owner/repo \
+  "tests/auth/test_login.py::test_login_timeout"
+
+# By quarantine ID.
+mergify tests unquarantine -r owner/repo \
+  12345678-1234-5678-1234-567812345678
+```
+
+A UUID-shaped argument is treated as the quarantine ID and removed
+directly; anything else is looked up by name. Add `--json` for a
+machine-readable payload, and run `mergify tests unquarantine --help`
+for the full list of flags.
+
+The command exits `0` on success and `6` on a Mergify API error, for
+example when the test is not quarantined.
+
 ## AI coding agent recipes
 
 The exit-code contract is designed to be chained from agents that ran

--- a/src/content/docs/test-insights/quarantine.mdx
+++ b/src/content/docs/test-insights/quarantine.mdx
@@ -4,7 +4,7 @@ description: Ignore problematic tests in your CI
 ---
 
 The Quarantine feature lets you isolate broken or flaky tests in your CI pipeline without removing them entirely.
-Once a test is quarantined via the Mergify dashboard, it will still run in your CI — but its failure
+Once a test is quarantined, it will still run in your CI, but its failure
 will be ignored for the purposes of blocking merges or marking a pipeline as failed.
 
 This helps you keep your CI green while maintaining full visibility into test reliability and ongoing issues.
@@ -26,3 +26,21 @@ To ensure the correct setup, refer to [the documentation for your test framework
 The [Mitigation page](https://dashboard.mergify.com/test-insights/mitigation) on the dashboard contains the list of
 tests that were retrieved from the CI Insights integration.
 From there, you can add or remove a test from quarantine.
+
+### From The Mergify CLI
+
+The [Mergify CLI](/test-insights/cli) can add and remove quarantines from the terminal,
+which is handy for scripting or for letting an AI coding agent quarantine a flaky test it just hit:
+
+```bash
+# Quarantine a test.
+mergify tests quarantine -r owner/repo \
+  --reason "flaky — tracked in MRGFY-1234" \
+  "tests/auth/test_login.py::test_login_timeout"
+
+# Remove it from quarantine.
+mergify tests unquarantine -r owner/repo \
+  "tests/auth/test_login.py::test_login_timeout"
+```
+
+See the [Test Insights CLI](/test-insights/cli) reference for all flags and exit codes.


### PR DESCRIPTION
Users can now manage a test's quarantine from the terminal, not only the
dashboard, so quarantining a flaky test can be scripted or driven by an
AI coding agent right after it hits the failure.

References: MRGFY-7434

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>