### PR TITLE
ci(dependabot): group react and react-dom updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
     allow:
       - dependency-name: "*"
         dependency-type: "all"
+    groups:
+      # Astro requires react and react-dom to be the exact same version,
+      # so they must be bumped together in a single PR.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@astrojs/react"
     commit-message:
       prefix: chore
       prefix-development: chore


### PR DESCRIPTION
Astro requires react and react-dom to share the exact same version.
Dependabot opened them as separate PRs, so a lone react-dom bump (#11412)
failed the build with a version mismatch. Grouping the react packages
keeps them lock-stepped in a single PR.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>