### PR TITLE
docs(merge-queue): remove partition rules note from merge-batch strategy

### DIFF
--- a/src/content/docs/merge-queue/merge-strategies.mdx
+++ b/src/content/docs/merge-queue/merge-strategies.mdx
@@ -297,8 +297,6 @@ were included in the batch (e.g., "Merge queue: merged #42, #43, #44").
 - **Requires `batch_size > 1`** — this method is designed for batch merging and
   cannot be used with single PRs
 
-- **Not compatible with [partition rules](/merge-queue/parallel-scopes)**
-
 - **Use case:** teams that use batch merging and want a single merge commit per
   batch on the base branch, triggering only one deployment per batch
 


### PR DESCRIPTION
Partitions are being deprecated in favor of scopes. The merge-batch
strategy is compatible with scopes (only partition_rules trigger the
engine's incompatibility check), so the note no longer applies and is
removed rather than re-pointed at scopes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>