### PR TITLE
feat(api): add hover-reveal anchor links to endpoint headings

### DIFF
--- a/src/components/ApiReference/Endpoint.astro
+++ b/src/components/ApiReference/Endpoint.astro
@@ -15,6 +15,7 @@ interface Props {
 
 const { endpoint, rootSchema } = Astro.props;
 const { method, path, operation, slug } = endpoint;
+const title = operation.summary ?? `${method} ${path}`;
 
 const pathParams = (operation.parameters ?? []).filter((p) => p.in === 'path');
 const queryParams = (operation.parameters ?? []).filter((p) => p.in === 'query');
@@ -81,7 +82,12 @@ function getResponseExample(response: (typeof responses)[number][1]): string | n
 ---
 
 <div class="endpoint">
-  <h2 id={slug} class="endpoint-heading">{operation.summary}</h2>
+  <h2 id={slug} class="endpoint-heading">
+    {title}
+    <a class="endpoint-anchor" href={`#${slug}`} aria-label={`Link to ${title}`}>
+      #
+    </a>
+  </h2>
   <div class="endpoint-head">
     <div class="endpoint-method-path">
       <span class={`method-badge method-${method.toLowerCase()}`}

--- a/src/styles/api-reference.css
+++ b/src/styles/api-reference.css
@@ -101,7 +101,9 @@
   transition: border-color 0.15s;
 }
 
-.endpoint:target {
+/* The slug id lives on .endpoint-heading (the TOC observer reads heading ids),
+   so :target lands on the heading — highlight the enclosing card. */
+.endpoint:has(.endpoint-heading:target) {
   border-color: var(--theme-link);
   box-shadow: 0 0 0 1px var(--theme-link);
 }
@@ -113,6 +115,28 @@
   margin: 0 0 0.5rem !important;
   color: var(--theme-text);
   scroll-margin-top: calc(var(--theme-navbar-height) + 1rem);
+}
+
+.endpoint-anchor {
+  margin-left: 0.4rem;
+  color: var(--theme-text-muted);
+  text-decoration: none;
+  font-weight: 500;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease;
+}
+
+.endpoint-anchor:hover,
+.endpoint-anchor:focus {
+  color: var(--theme-link);
+}
+
+.endpoint:hover .endpoint-anchor,
+.endpoint:focus-within .endpoint-anchor,
+.endpoint-heading:target .endpoint-anchor {
+  opacity: 1;
 }
 
 .endpoint-head {


### PR DESCRIPTION
Each endpoint heading gets a `#` link to its own slug, revealed on card
hover/focus or when targeted, matching the config options table.

Fix the card :target highlight, which never fired: the slug id sits on
the heading, not the card, so :target matched the heading. Add
:has(.endpoint-heading:target) so deep links highlight the whole card.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>