### PR TITLE
docs(test-insights): Document `mergify tests quarantined`

### DIFF
--- a/src/content/docs/test-insights/cli.mdx
+++ b/src/content/docs/test-insights/cli.mdx
@@ -80,6 +80,26 @@ for the full list of flags.
 The command exits `0` on success and `6` on a Mergify API error, for
 example when the test is not quarantined.
 
+## `mergify tests quarantined`
+
+List every test currently in [quarantine](/test-insights/quarantine)
+for a repository. It's handy for reviewing what's being ignored, or for
+looking up a quarantine ID to pass to `unquarantine`.
+
+```bash
+mergify tests quarantined -r owner/repo
+```
+
+Each test is listed with its quarantine ID, the branch it's scoped to
+(`*` for all branches), the source (`manual` or `auto`), whether it
+has recovered, and the reason. Add `--json` for a machine-readable
+payload (`{"quarantined_tests": [...]}`, which also carries each
+quarantine's `created_at` timestamp), and run
+`mergify tests quarantined --help` for the full list of flags.
+
+The command always exits `0`, including when nothing is quarantined:
+an empty quarantine is a normal state, not an error.
+
 ## AI coding agent recipes
 
 The exit-code contract is designed to be chained from agents that ran

--- a/src/content/docs/test-insights/quarantine.mdx
+++ b/src/content/docs/test-insights/quarantine.mdx
@@ -29,7 +29,7 @@ From there, you can add or remove a test from quarantine.
 
 ### From The Mergify CLI
 
-The [Mergify CLI](/test-insights/cli) can add and remove quarantines from the terminal,
+The [Mergify CLI](/test-insights/cli) can manage quarantines from the terminal,
 which is handy for scripting or for letting an AI coding agent quarantine a flaky test it just hit:
 
 ```bash
@@ -41,6 +41,9 @@ mergify tests quarantine -r owner/repo \
 # Remove it from quarantine.
 mergify tests unquarantine -r owner/repo \
   "tests/auth/test_login.py::test_login_timeout"
+
+# List everything currently quarantined.
+mergify tests quarantined -r owner/repo
 ```
 
 See the [Test Insights CLI](/test-insights/cli) reference for all flags and exit codes.


### PR DESCRIPTION
Add a reference section for `tests quarantined`, which lists a
repository's CI Insights quarantine, and surface the command in the
quarantine page's CLI examples.

Depends-On: https://github.com/Mergifyio/mergify-cli/pull/1509

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>