### PR TITLE
docs(test-insights): explain Playwright multi-project test naming

### DIFF
--- a/src/content/docs/test-insights/test-frameworks/playwright.mdx
+++ b/src/content/docs/test-insights/test-frameworks/playwright.mdx
@@ -68,25 +68,16 @@ Every project's copy of a test therefore shares the same name, and Test Insights
 treats them as a single test — so a test that passes on `chromium` but fails on
 `webkit` looks flaky instead of consistently broken on one browser.
 
-To keep each project's tests separate, enable `includeProjectInTestName` on the
-JUnit reporter:
+To keep each project's tests separate, add `includeProjectInTestName` to the
+JUnit reporter options shown above:
 
 ```typescript
-// playwright.config.ts
-import { defineConfig } from '@playwright/test';
-
-export default defineConfig({
-  reporter: [
-    ['list'],
-    ['junit', { outputFile: 'junit.xml', includeProjectInTestName: true }]
-  ],
-  // ... other configuration
-});
+['junit', { outputFile: 'junit.xml', includeProjectInTestName: true }]
 ```
 
-This prefixes each test name with its project, for example `[chromium]
-login.spec.ts › logs in`, so Test Insights tracks flakiness and quarantine per
-project. The option requires Playwright 1.44 or later.
+This prefixes each test name with its project, for example
+`[chromium] login.spec.ts › logs in`, so Test Insights tracks flakiness and
+quarantine per project. The option requires Playwright 1.44 or later.
 
 ## Update Your CI Workflow
 

--- a/src/content/docs/test-insights/test-frameworks/playwright.mdx
+++ b/src/content/docs/test-insights/test-frameworks/playwright.mdx
@@ -57,6 +57,37 @@ To specify the output file location:
 npx playwright test --reporter=list --reporter=junit:junit.xml
 ```
 
+### Multi-Project (Cross-Browser) Runs
+
+If your `playwright.config.ts` defines multiple
+[projects](https://playwright.dev/docs/test-projects) — for example one per
+browser (`chromium`, `firefox`, `webkit`) — the same test runs once per project.
+By default, Playwright records the project name only in the `hostname` attribute
+of each `<testsuite>`, which Test Insights does not use to distinguish tests.
+Every project's copy of a test therefore shares the same name, and Test Insights
+treats them as a single test — so a test that passes on `chromium` but fails on
+`webkit` looks flaky instead of consistently broken on one browser.
+
+To keep each project's tests separate, enable `includeProjectInTestName` on the
+JUnit reporter:
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: [
+    ['list'],
+    ['junit', { outputFile: 'junit.xml', includeProjectInTestName: true }]
+  ],
+  // ... other configuration
+});
+```
+
+This prefixes each test name with its project, for example `[chromium]
+login.spec.ts › logs in`, so Test Insights tracks flakiness and quarantine per
+project. The option requires Playwright 1.44 or later.
+
 ## Update Your CI Workflow
 
 ### GitHub Actions


### PR DESCRIPTION
## What

Adds a **Multi-Project (Cross-Browser) Runs** subsection to the Playwright Test Insights guide.

## Why

Playwright projects (e.g. one per browser) run the same test once per project. By default Playwright writes the project name only to the `<testsuite>` `hostname` attribute, which Test Insights does not use to distinguish tests. Every project's copy of a test therefore collapses into a single identity — so a test that passes on `chromium` but fails on `webkit` shows up as flaky rather than consistently broken on one browser, and quarantine can't target a single project.

## How

Documents Playwright's own `includeProjectInTestName` JUnit reporter option (available since Playwright 1.44) as the fix. It prefixes each test name with `[project]`, keeping per-project results distinct in Test Insights — no changes needed in the Mergify CLI.

We deliberately chose documentation over a new CLI flag: since users already edit the reporter config to emit JUnit at all, enabling this one option at the source is the simplest path and keeps a single canonical test identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)