### PR TITLE
docs(test-insights): explain Playwright multi-project test naming

### DIFF
--- a/src/content/docs/test-insights/test-frameworks/playwright.mdx
+++ b/src/content/docs/test-insights/test-frameworks/playwright.mdx
@@ -57,6 +57,28 @@ To specify the output file location:
 npx playwright test --reporter=list --reporter=junit:junit.xml
 ```
 
+### Multi-Project (Cross-Browser) Runs
+
+If your `playwright.config.ts` defines multiple
+[projects](https://playwright.dev/docs/test-projects), such as one per browser
+(`chromium`, `firefox`, `webkit`), the same test runs once per project.
+By default, Playwright records the project name only in the `hostname` attribute
+of each `<testsuite>`, which Test Insights does not use to distinguish tests.
+Every project's copy of a test therefore shares the same name, and Test Insights
+treats them as a single test. A test that passes on `chromium` but fails on
+`webkit` then looks flaky instead of consistently broken on one browser.
+
+To keep each project's tests separate, add `includeProjectInTestName` to the
+JUnit reporter options shown above:
+
+```typescript
+['junit', { outputFile: 'junit.xml', includeProjectInTestName: true }]
+```
+
+This prefixes each test name with its project, for example
+`[chromium] login.spec.ts › logs in`, so Test Insights tracks flakiness and
+quarantine per project. The option requires Playwright 1.44 or later.
+
 ## Update Your CI Workflow
 
 ### GitHub Actions


### PR DESCRIPTION
Playwright projects (e.g. one per browser) run the same test once per
project, but by default the project name is written only to the
<testsuite> hostname attribute, which Test Insights does not use to
distinguish tests. That collapses every project's copy of a test into a
single identity, distorting flaky detection and quarantine.

Document Playwright's own includeProjectInTestName reporter option as the
fix: it prefixes each test name with [project], keeping per-project
results distinct in Test Insights.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>