### PR TITLE
fix(mobile): stack page toolbar and keep TOC dropdown on-screen

### DIFF
--- a/src/components/CopyForLLMButton.astro
+++ b/src/components/CopyForLLMButton.astro
@@ -70,13 +70,6 @@ const markdownPath = getMarkdownPath(Astro.url.pathname);
 		line-height: 1;
 	}
 
-	@media (max-width: var(--docs-toolbar-mobile-breakpoint)) {
-		:global(.docs-toolbar-button) {
-			width: 100%;
-			justify-content: center;
-		}
-	}
-
 	:global(.theme-dark .docs-toolbar-button) {
 		border-color: rgba(255, 255, 255, 0.2);
 		background: rgba(255, 255, 255, 0.05);

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -129,7 +129,13 @@ const suppressTitle = content.suppressTitle;
 		}
 	}
 
-	@media (max-width: var(--docs-toolbar-mobile-breakpoint)) {
+	/* Stack the breadcrumb above the action buttons once they no longer fit
+	   side by side. The threshold accounts for the left sidebar (~17rem) that
+	   eats into the content width from 50em up, so the breadcrumb keeps
+	   getting squeezed until ~72em. Below it: breadcrumb on its own row,
+	   actions left-aligned underneath. (Custom properties can't be used in
+	   media query conditions, hence the literal breakpoint.) */
+	@media (max-width: 72em) {
 		:global(.page-heading-bar) {
 			grid-template-columns: 1fr;
 		}

--- a/src/components/RightSidebar/TableOfContents.css
+++ b/src/components/RightSidebar/TableOfContents.css
@@ -38,7 +38,10 @@
 .toc-mobile-panel {
   position: absolute;
   top: calc(100% + 0.5rem);
-  inset-inline-end: 0;
+  /* Anchor to the trigger's leading edge so the panel opens into the viewport.
+     The trigger sits at the left of the (left-aligned) toolbar on mobile, so a
+     right-anchored panel would overflow the left edge of the screen. */
+  inset-inline-start: 0;
   width: 20rem;
   max-width: calc(100vw - 2rem);
   border: 1px solid var(--theme-border-color);

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -21,7 +21,6 @@
   --theme-text-md: 1rem;
   --theme-text-sm: 0.9375rem;
   --theme-text-xs: 0.875rem;
-  --docs-toolbar-mobile-breakpoint: 80em;
   /* Animation helpers */
   --theme-ease-bounce: cubic-bezier(0.4, 2.5, 0.6, 1);
 }


### PR DESCRIPTION
## What

Two mobile bugs in the page heading toolbar (breadcrumb + "On this page" / "Copy for LLM" / "View as Markdown" actions):

1. **Breadcrumb and actions overlapped / crowded** on mobile instead of stacking.
2. **The "On this page" dropdown opened off the left edge** of the screen.

## Root causes

1. The stacking rules in `PageContent.astro` and `CopyForLLMButton.astro` used `@media (max-width: var(--docs-toolbar-mobile-breakpoint))`. **CSS custom properties can't be used in media query conditions**, so the browser ignored these rules and the toolbar never stacked.
2. `.toc-mobile-panel` was anchored with `inset-inline-end: 0` at a fixed `20rem` width. With the trigger near the left edge, the panel extended left, off-screen.

## Fixes

- Replace the invalid media query with a literal `@media (max-width: 72em)`. The threshold accounts for the 17rem left sidebar that eats content width from 50em up, so the breadcrumb keeps getting squeezed until ~72em. Below it the breadcrumb sits on its own row with the actions left-aligned underneath.
- Anchor the dropdown to the trigger's leading edge (`inset-inline-start: 0`) so it opens into the viewport.
- Remove the now-unused `--docs-toolbar-mobile-breakpoint` token and the dead `width: 100%` button rule.

## Verified (browser, across widths)

| Width | Toolbar | Dropdown |
|---|---|---|
| 375px (phone) | stacked, breadcrumb full-width then actions | opens `[16–336]`, in viewport |
| 768 / 1100 / 1152px | stacked, clean | in viewport |
| 1200 / 1311px | side-by-side, comfortable | `[725–1045]` / `[836–1156]`, in viewport |
| ≥1312px (desktop) | unchanged — TOC moves to right sidebar, toolbar keeps 2 actions | n/a |

`astro check`, ESLint, and Biome all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)