### PR TITLE
feat(test-insights): structured CLI reference cards

### DIFF
--- a/src/components/CliReference/CliCommand.astro
+++ b/src/components/CliReference/CliCommand.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * A structured reference card for a single CLI command, mirroring the HTTP API
+ * reference's endpoint cards: the command sits as the card's heading, with the
+ * description as the card body.
+ *
+ * The heading is rendered by this component (not a markdown `##`), so it gives
+ * a deep-link `#` anchor but does not appear in the compile-time "on this page"
+ * TOC — that list only sees markdown headings.
+ */
+import '~/styles/cli-reference.css';
+
+interface Props {
+  /** The command shown as the card's heading, e.g. `mergify tests show`. */
+  command: string;
+}
+
+const { command } = Astro.props;
+
+const slug = command
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-')
+  .replace(/^-+|-+$/g, '');
+---
+
+<div class="cli-command">
+  <h2 id={slug} class="cli-command-heading">
+    {command}
+    <a class="cli-anchor" href={`#${slug}`} aria-label={`Link to ${command}`}>
+      #
+    </a>
+  </h2>
+  <slot />
+</div>

--- a/src/content/docs/test-insights/cli.mdx
+++ b/src/content/docs/test-insights/cli.mdx
@@ -3,6 +3,8 @@ title: CLI
 description: Interact with Test Insights data from the terminal — search for tests, branch on health via exit codes, and chain into AI coding agents like Claude Code and Cursor.
 ---
 
+import CliCommand from '~/components/CliReference/CliCommand.astro';
+
 The [Mergify CLI](/cli) lets you interact with Test Insights data from
 the terminal. It's handy when you want to triage a failing test
 quickly, or when an AI coding agent needs to decide whether to retry,
@@ -14,165 +16,61 @@ fix, or ignore a failure.
   remote, or from the CI environment when it runs in a pipeline.
 :::
 
-## `mergify tests show`
+Every command also accepts `--json` for machine-readable output and `--help`
+for the full list of flags.
 
-Search the Test Insights catalog by test name and print health, ratios,
-and the most recent failure context for each match.
+<CliCommand command="mergify tests show">
 
-```bash
-mergify tests show -r owner/repo "tests/auth/test_login.py::test_login_timeout"
-```
+Search the Test Insights catalog by test name and print each match's health,
+failure ratios, and most recent failure context. Names accept glob patterns
+(`*`, `?`), and several can be passed in one call. See the
+[API reference](/api/test-insights) for the underlying endpoints and response
+schemas.
 
-Names accept glob patterns (`*`, `?`), and several can be passed in one
-call. Add `--json` for a machine-readable payload. Run
-`mergify tests show --help` for the full list of flags, and see the
-[API reference](/api/test-insights) for the underlying endpoints and
-response schemas.
+</CliCommand>
 
-### Exit codes
+<CliCommand command="mergify tests quarantines add">
 
-The exit code reflects the worst health observed across the matched
-tests, so callers can branch without parsing output:
+Add a test to [quarantine](/test-insights/quarantine) so its failures stop
+blocking merges and no longer mark the pipeline as failed. The test keeps
+running, and its results keep flowing into Test Insights. Pass the fully
+qualified test name and a `--reason`; the quarantine covers every branch unless
+you scope it with `--branch`. The command prints a quarantine ID you can pass to
+`remove` or `get`.
 
-| Code | Meaning |
-|---|---|
-| `0` | All matched tests are healthy or unknown, or nothing matched. |
-| `1` | At least one matched test is flaky. |
-| `6` | At least one matched test is broken. |
+</CliCommand>
 
-Exit code `2` is reserved for CLI argument errors.
+<CliCommand command="mergify tests quarantines remove">
 
-## `mergify tests quarantines add`
+Remove a test from quarantine, addressed either by its fully qualified name or
+by the quarantine ID that `add` printed. A UUID-shaped argument is treated as
+the ID and removed directly; anything else is looked up by name.
 
-Add a test to [quarantine](/test-insights/quarantine) so its failures
-stop blocking merges and no longer mark the pipeline as failed. The
-test keeps running, and its results keep flowing into Test Insights.
+</CliCommand>
 
-```bash
-mergify tests quarantines add -r owner/repo \
-  --reason "flaky — tracked in MRGFY-1234" \
-  "tests/auth/test_login.py::test_login_timeout"
-```
+<CliCommand command="mergify tests quarantines get">
 
-Pass the fully qualified test name and a `--reason` (both required). The
-quarantine applies to every branch by default; scope it to one branch or
-pattern with `--branch` (`-b`). The command prints a quarantine ID you
-can pass to `remove` or `get`. Add `--json` for a machine-readable
-payload, and run `mergify tests quarantines add --help` for the full
-list of flags.
+Print a single quarantine, addressed by the test's fully qualified name or its
+quarantine ID (a UUID-shaped argument is matched against the ID). The output
+mirrors one record of `list`.
 
-The command exits `0` on success and `6` on a Mergify API error, for
-example when the test is already quarantined.
+</CliCommand>
 
-## `mergify tests quarantines remove`
+<CliCommand command="mergify tests quarantines list">
 
-Remove a test from quarantine, addressed either by its fully qualified
-name or by the quarantine ID that `add` printed.
+List every test currently in [quarantine](/test-insights/quarantine) for a
+repository. It's handy for reviewing what's being ignored, or for looking up a
+quarantine ID to pass to `remove` or `get`. Each record carries its quarantine
+ID, the branch it's scoped to (`*` for all branches), the source (`manual` or
+`auto`), whether it has recovered, and the reason.
 
-```bash
-# By test name.
-mergify tests quarantines remove -r owner/repo \
-  "tests/auth/test_login.py::test_login_timeout"
+</CliCommand>
 
-# By quarantine ID.
-mergify tests quarantines remove -r owner/repo \
-  12345678-1234-5678-1234-567812345678
-```
+## Use with AI coding agents
 
-A UUID-shaped argument is treated as the quarantine ID and removed
-directly; anything else is looked up by name. Add `--json` for a
-machine-readable payload, and run
-`mergify tests quarantines remove --help` for the full list of flags.
-
-The command exits `0` on success and `6` on a Mergify API error, for
-example when the test is not quarantined.
-
-## `mergify tests quarantines get`
-
-Print a single quarantine, addressed either by its fully qualified test
-name or by the quarantine ID. The output mirrors one record of `list`.
-
-```bash
-# By test name.
-mergify tests quarantines get -r owner/repo \
-  "tests/auth/test_login.py::test_login_timeout"
-
-# By quarantine ID.
-mergify tests quarantines get -r owner/repo \
-  12345678-1234-5678-1234-567812345678
-```
-
-A UUID-shaped argument is matched against the quarantine ID; anything
-else is matched against the test name. Add `--json` for a
-machine-readable record (`id`, `test_name`, `reason`, `branch`,
-`created_at`, `source`, `is_recovered`), and run
-`mergify tests quarantines get --help` for the full list of flags.
-
-The command exits `0` when a quarantine is found and `6` on a Mergify
-API error, for example when no quarantine matches.
-
-## `mergify tests quarantines list`
-
-List every test currently in [quarantine](/test-insights/quarantine)
-for a repository. It's handy for reviewing what's being ignored, or for
-looking up a quarantine ID to pass to `remove` or `get`.
-
-```bash
-mergify tests quarantines list -r owner/repo
-```
-
-Each test is listed with its quarantine ID, the branch it's scoped to
-(`*` for all branches), the source (`manual` or `auto`), whether it
-has recovered, and the reason. Add `--json` for a machine-readable
-payload (`{"quarantined_tests": [...]}`, which also carries each
-quarantine's `created_at` timestamp), and run
-`mergify tests quarantines list --help` for the full list of flags.
-
-The command always exits `0`, including when nothing is quarantined:
-an empty quarantine is a normal state, not an error.
-
-## AI coding agent recipes
-
-The exit-code contract is designed to be chained from agents that ran
-a test, saw it fail, and need to decide what to do next.
-
-### Should the agent retry, fix, or ignore?
-
-```bash
-if mergify tests show -r owner/repo "$FAILED_TEST" --json > /tmp/health.json; then
-  status=0
-else
-  status=$?
-fi
-
-case $status in
-  0) echo "Healthy or unknown: investigate as a real regression." ;;
-  1) echo "Known flaky: retry before touching code." ;;
-  6) echo "Broken: fix is required; skip the retry loop." ;;
-esac
-```
-
-### Claude Code
-
-Add a [skill](https://docs.claude.com/en/docs/claude-code/skills) or a
-prompt snippet that points the agent at the CLI:
-
-```md
-When a test fails locally or in CI, before attempting a fix, run:
-
-  mergify tests show -r OWNER/REPO --json "<failed-test-name>"
-
-Then branch on the exit code:
-- 0, non-empty payload → healthy in Mergify; investigate as a real
-  regression.
-- 0, empty payload → unknown to Mergify; treat as a new test or one on
-  a non-default branch.
-- 1 → known flaky. Rerun once; only investigate if it fails again.
-- 6 → known broken (pre-existing). Surface to the user instead of
-  attempting a fix.
-```
-
-### Cursor
-
-In Cursor, add the same guidance to a project rule
-(`.cursor/rules/test-triage.mdc`) so it auto-loads in agent sessions.
+`mergify tests show` reports a test's health through its exit code, so an agent
+can branch on a failure without parsing output: `0` healthy or unknown, `1`
+flaky, `6` broken. Wire it into Claude Code as a
+[skill](https://docs.claude.com/en/docs/claude-code/skills) or Cursor as a
+project rule to rerun flaky tests, surface broken ones, and treat healthy ones
+as real regressions.

--- a/src/styles/cli-reference.css
+++ b/src/styles/cli-reference.css
@@ -1,0 +1,65 @@
+/* ---------------------------------------------------------------------------
+   CLI reference — structured command cards.
+
+   Mirrors the HTTP API reference's endpoint cards (api-reference.css): one
+   bordered card per command, with the command as the card's heading. Loaded on
+   demand by CliCommand.astro, so it only ships on pages that render a card.
+   --------------------------------------------------------------------------- */
+
+/* Command card — parallels .endpoint */
+.cli-command {
+  border: 1px solid var(--theme-border-color);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  margin: 0.5rem 0 1.5rem;
+  background: var(--theme-bg-content);
+  transition: border-color 0.15s;
+}
+
+/* Deep links land on the heading id; highlight the enclosing card. */
+.cli-command:has(.cli-command-heading:target) {
+  border-color: var(--theme-link);
+  box-shadow: 0 0 0 1px var(--theme-link);
+}
+
+/* In-box command heading — inherits the global h2 size (matching the API
+   reference headings under #main-content); monospace because it's a command. */
+.cli-command-heading {
+  font-family: var(--font-mono);
+  margin: 0 0 0.5rem !important;
+  color: var(--theme-text);
+  scroll-margin-top: calc(var(--theme-navbar-height) + 1rem);
+}
+
+/* Hover-reveal anchor — parallels .endpoint-anchor */
+.cli-anchor {
+  margin-left: 0.4rem;
+  color: var(--theme-text-muted);
+  text-decoration: none;
+  font-weight: 500;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease;
+}
+
+.cli-anchor:hover,
+.cli-anchor:focus {
+  color: var(--theme-link);
+}
+
+.cli-command:hover .cli-anchor,
+.cli-command:focus-within .cli-anchor,
+.cli-command-heading:target .cli-anchor {
+  opacity: 1;
+}
+
+/* ---------------------------------------------------------------------------
+   Responsive — mirrors the api-reference 50em breakpoint
+   --------------------------------------------------------------------------- */
+
+@media (max-width: 50em) {
+  .cli-command {
+    padding: 1rem;
+  }
+}


### PR DESCRIPTION
Render each `mergify tests` command as a bordered reference card that
mirrors the HTTP API reference's endpoint cards: the command as the
card's heading with a hover-reveal anchor, the description as the body.
Add the CliCommand component and a cli-reference stylesheet that reuse
the API reference's visual language, and rewrite the Test Insights CLI
page to use them.

The heading is rendered by the component, so commands no longer appear
in the page's on-this-page TOC (deep links still work); a generated
route can restore it if the template graduates beyond the pilot.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>