### PR TITLE
fix(tables): keep short inline code from breaking mid-word

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -304,6 +304,14 @@ tbody th {
   font-weight: 600;
 }
 
+/* Don't break short inline code (mode names, config keys) mid-word in
+   narrow table columns. `.table-wrap` scrolls horizontally if a token
+   is genuinely too long to fit. */
+:is(td, th) code:not([class*="language"]) {
+  word-break: normal;
+  overflow-wrap: normal;
+}
+
 tbody tr:last-child td,
 tbody tr:last-child th {
   border-bottom: none;


### PR DESCRIPTION
Narrow table columns let `word-break: break-word` split short
identifiers like `serial`/`parallel`/`isolated` across lines. Scope
inline code in table cells to `word-break: normal` so the column sizes
to the whole token; `.table-wrap` still scrolls if a token is too long.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>