### PR TITLE
fix(diagrams): improve dark-mode contrast on git and graphviz diagrams

### DIFF
--- a/plugins/remark-graphviz.ts
+++ b/plugins/remark-graphviz.ts
@@ -8,6 +8,68 @@ const viz = await instance();
 
 const validLanguages = [`dot`, `circo`, `neato`];
 
+// Dark neutral colors used for structural chrome (edges, arrowheads, connector
+// labels, cluster borders/labels). These vanish on the dark-mode surface, so we
+// swap them for `currentColor` and let the page drive the value via
+// --theme-diagram-edge. Saturated/product colors are intentional highlights and
+// are left untouched. Compared case-insensitively.
+const DARK_NEUTRALS = new Set([
+  '#374151', // gray-700
+  '#4b5563', // gray-600
+  '#6b7280', // gray-500
+  '#000000',
+  'black',
+  '#999999',
+]);
+
+/** Replace an element's stroke/fill with currentColor when it is a dark neutral. */
+function themeNeutral($el: ReturnType<ReturnType<typeof load>>): void {
+  for (const attr of ['stroke', 'fill'] as const) {
+    const value = $el.attr(attr);
+    if (value === undefined) {
+      // Graphviz omits `fill` on default-black text (edge/cluster labels), so an
+      // absent fill on a <text> is an implicit dark neutral that must be themed.
+      if (attr === 'fill' && $el.is('text')) {
+        $el.attr('fill', 'currentColor');
+      }
+      continue;
+    }
+    if (DARK_NEUTRALS.has(value.toLowerCase())) {
+      $el.attr(attr, 'currentColor');
+    }
+  }
+}
+
+/**
+ * Make the neutral structural chrome of a rendered Graphviz SVG theme-aware so
+ * it stays legible in dark mode. Content nodes (their fills and labels) and
+ * saturated edge colors are deliberately left alone.
+ */
+function themeDiagram($: ReturnType<typeof load>): void {
+  // Drop the opaque canvas background so the page surface shows through.
+  $('svg > g.graph > polygon').first().attr('fill', 'none').attr('stroke', 'none');
+
+  // Edges: lines, arrowheads, and connector labels all sit on the page surface.
+  $('g.edge').each((_, edge) => {
+    $(edge)
+      .find('path, polygon, text')
+      .each((__, el) => themeNeutral($(el)));
+  });
+
+  // Clusters: only re-theme the border and label when the cluster has no fill,
+  // so labels that sit on a tinted cluster background keep their color.
+  $('g.cluster').each((_, cluster) => {
+    const $cluster = $(cluster);
+    const clusterFill = $cluster.find('> polygon').first().attr('fill');
+    if (!clusterFill || clusterFill.toLowerCase() === 'none') {
+      $cluster.find('polygon, path, text').each((__, el) => themeNeutral($(el)));
+    }
+  });
+
+  // Graph-level captions (text rendered directly under the graph group).
+  $('svg > g.graph > text').each((_, el) => themeNeutral($(el)));
+}
+
 // Layered style defaults injected into dot blocks based on their CSS classes.
 // Diagrams can override any of these by redeclaring the same attributes.
 const themes: Record<string, string> = {
@@ -64,9 +126,15 @@ export function remarkGraphvizPlugin(): unified.Plugin<[], mdast.Root> {
           const source = injectDefaults(value, attrString);
           // Perform actual render
           const svgString = viz.renderString(source, { format: 'svg', engine: lang });
-          // Add default inline styling
+          // Add default inline styling. `color` drives `currentColor` for the
+          // neutral chrome re-themed in themeDiagram().
           const $ = load(svgString);
-          $(`svg`).attr(`style`, `max-width: 100%; height: auto;`);
+          $(`svg`).attr(
+            `style`,
+            `max-width: 100%; height: auto; color: var(--theme-diagram-edge);`
+          );
+          // Make structural chrome track the theme so diagrams read in dark mode.
+          themeDiagram($);
           // Merge custom attributes if provided by user (adds and overwrites)
           if (attrString) {
             const attrElement = load(`<element ${attrString}></element>`);

--- a/src/components/GitGraph.astro
+++ b/src/components/GitGraph.astro
@@ -14,6 +14,12 @@ const COLORS: Record<string, string> = {
   ghost: '#9CA3AF',
 };
 
+/**
+ * Neutral edge/connector color. Emitted verbatim into the Graphviz source, then
+ * swapped for `currentColor` in the rendered SVG so it follows the theme.
+ */
+const EDGE_COLOR = '#374151';
+
 // ── Types ──────────────────────────────────────────────
 
 interface PR {
@@ -127,7 +133,7 @@ function renderLinear(p: {
 
   // branch label
   push(
-    `<text x="${cx(0) - 34}" y="${COMMIT_Y + 4}" text-anchor="end" fill="${COLORS.gray}" font-size="${FONT}" font-weight="500">${branch}</text>`
+    `<text x="${cx(0) - 34}" y="${COMMIT_Y + 4}" text-anchor="end" fill="currentColor" font-size="${FONT}" font-weight="500">${branch}</text>`
   );
 
   // commits
@@ -185,7 +191,7 @@ async function renderGraph(p: {
   dot.push(
     '  node [style=filled, shape=circle, fontname="sans-serif", fontcolor="white", width=0.5, height=0.5, fixedsize=true];'
   );
-  dot.push('  edge [color="#374151", fontname="sans-serif"];');
+  dot.push(`  edge [color="${EDGE_COLOR}", fontname="sans-serif"];`);
 
   // nodes
   for (const n of nodes) {
@@ -212,7 +218,7 @@ async function renderGraph(p: {
       attrs.push(`style=dashed, color="${COLORS.ghost}"`);
     }
     if (e.label) {
-      const edgeColor = e.dashed ? COLORS.ghost : '#374151';
+      const edgeColor = e.dashed ? COLORS.ghost : EDGE_COLOR;
       attrs.push(`label="${e.label}", fontsize=9, fontcolor="${edgeColor}"`);
     }
     const attrStr = attrs.length ? ` [${attrs.join(', ')}]` : '';
@@ -227,7 +233,9 @@ async function renderGraph(p: {
   $('svg').attr('class', 'git-graph');
   // Strip Graphviz background
   $('svg > g > polygon').first().attr('fill', 'none').attr('stroke', 'none');
-  return $.html('svg');
+  // Route the neutral edge color through currentColor so it tracks the theme
+  // (the page sets `.git-graph { color: var(--theme-diagram-edge) }`).
+  return $.html('svg').replaceAll(EDGE_COLOR, 'currentColor');
 }
 ---
 
@@ -240,6 +248,8 @@ async function renderGraph(p: {
     max-width: 560px;
     width: 100%;
     height: auto;
+    /* Drives `currentColor` for neutral edges, arrowheads, and the branch label. */
+    color: var(--theme-diagram-edge);
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   }
 </style>

--- a/src/components/StackMapping.astro
+++ b/src/components/StackMapping.astro
@@ -26,10 +26,19 @@ const FONT = 11;
 const HEAD_FONT = 10;
 const ARROW_GAP = 8;
 
+// `color` fills the boxes (needs to stay dark enough for white labels in both
+// themes); `headColor` is the column header. The neutral gray header would be
+// too faint on the dark surface, so it tracks --theme-diagram-edge via
+// currentColor instead.
 const cols = [
-  { label: 'Local Commits', color: '#347D39', x: PAD },
-  { label: 'Remote Branches', color: '#6B7280', x: PAD + COL_W + COL_GAP },
-  { label: 'GitHub PRs', color: '#2563EB', x: PAD + 2 * (COL_W + COL_GAP) },
+  { label: 'Local Commits', color: '#347D39', headColor: '#347D39', x: PAD },
+  {
+    label: 'Remote Branches',
+    color: '#6B7280',
+    headColor: 'currentColor',
+    x: PAD + COL_W + COL_GAP,
+  },
+  { label: 'GitHub PRs', color: '#2563EB', headColor: '#2563EB', x: PAD + 2 * (COL_W + COL_GAP) },
 ];
 
 const totalW = cols[2].x + COL_W + PAD;
@@ -55,7 +64,7 @@ const BOX_H = ROW_H - 12;
       x={col.x + COL_W / 2}
       y={HEAD_H - 10}
       text-anchor="middle"
-      fill={col.color}
+      fill={col.headColor}
       font-size={HEAD_FONT}
       font-weight="600"
       text-transform="uppercase"
@@ -126,6 +135,8 @@ const BOX_H = ROW_H - 12;
     max-width: 620px;
     width: 100%;
     height: auto;
+    /* Drives `currentColor` for the neutral column header. */
+    color: var(--theme-diagram-edge);
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   }
 </style>

--- a/src/content/docs/enterprise/architecture.mdx
+++ b/src/content/docs/enterprise/architecture.mdx
@@ -30,7 +30,7 @@ full control over data flows.
   digraph Architecture {
     rankdir=TB;
     graph [label="Mergify Enterprise – High-Level Architecture", labelloc=t, fontsize=26, pad=1.2, nodesep=1.4, ranksep=1.9, splines=ortho, fontname="Helvetica"];
-    node [shape=box, style="rounded,filled", fontname="Helvetica", fontsize=18, fillcolor="#F6F8FB", color="#C6D4F3", margin="0.45,0.35", width=3.4];
+    node [shape=box, style="rounded,filled", fontname="Helvetica", fontsize=18, fillcolor="#F6F8FB", color="#C6D4F3", fontcolor="#1F2937", margin="0.45,0.35", width=3.4];
 
     edge [color="#8892BF", arrowsize=0.9, fontsize=16, fontname="Helvetica"];
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -104,6 +104,11 @@
   --theme-border-color: var(--theme-border);
   --theme-shade-subtle: var(--color-gray-200);
 
+  /* Diagrams — neutral chrome (edges, arrowheads, connector labels, cluster
+     borders) for the git-graph and graphviz diagrams. Dark mode brightens it
+     so structural lines and captions stay legible over the dark surface. */
+  --theme-diagram-edge: var(--color-gray-700);
+
   /* Links + accents */
   --theme-link: var(--color-blue-700);
   --theme-link-hover: var(--color-blue-800);
@@ -172,6 +177,9 @@
   --theme-divider: var(--color-gray-800);
   --theme-border-color: var(--theme-border);
   --theme-shade-subtle: var(--color-gray-700);
+
+  /* Diagrams — brighten the neutral chrome so edges and labels read on dark. */
+  --theme-diagram-edge: var(--color-gray-400);
 
   /* Links + accents */
   --theme-link: var(--color-blue-400);


### PR DESCRIPTION
Structural chrome (edges, arrowheads, connector labels, cluster borders)
used hardcoded gray/black colors that vanished on the dark surface. Route
it through a new --theme-diagram-edge token (gray-700 light, gray-400 dark)
via currentColor, leaving content nodes and product/accent colors untouched.

Also fix the enterprise architecture diagram, which had white node text on
light fills (broken in both modes) by inheriting the theme's white default.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>