### PR TITLE
chore(biome): exclude synced public/cli-schema.json from format checks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,6 +6,7 @@
       "!.astro/*",
       "!src/@types/*",
       "!public/api-schemas.json",
+      "!public/cli-schema.json",
       "!public/mergify-configuration-schema.json",
       "!dist/*"
     ]


### PR DESCRIPTION
The schemas-sync workflow in ci-bot now generates public/cli-schema.json
from the released mergify-cli (serde_json pretty output), which does not
match Biome's array formatting. Ignore it like the other synced schema
files so the sync PRs pass lint.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>