### PR TITLE
refactor(stacks): extract shared install snippets into partials

### DIFF
--- a/src/content/docs/stacks.mdx
+++ b/src/content/docs/stacks.mdx
@@ -7,6 +7,7 @@ import Button from '~/components/Button.astro';
 import DocsetGrid from '~/components/DocsetGrid/DocsetGrid.astro';
 import Docset from '~/components/DocsetGrid/Docset.astro';
 import GitGraph from '~/components/GitGraph.astro';
+import Quickstart from './stacks/_quickstart.mdx';
 
 AI can write 1,000 lines of code in minutes, but nobody wants to review a
 1,000-line pull request. Reviewers skim instead of reading, bugs slip through,
@@ -77,11 +78,7 @@ Your agent installs the CLI and the Stacks skill itself, then you prompt it as u
 
 **For yourself:**
 
-```bash
-uv tool install mergify-cli
-mergify stack setup
-mergify stack push
-```
+<Quickstart />
 
 See the [setup guide](/stacks/setup) for the full walkthrough.
 

--- a/src/content/docs/stacks/_install-setup.mdx
+++ b/src/content/docs/stacks/_install-setup.mdx
@@ -1,0 +1,4 @@
+```bash
+curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
+mergify stack setup
+```

--- a/src/content/docs/stacks/_install.mdx
+++ b/src/content/docs/stacks/_install.mdx
@@ -1,0 +1,3 @@
+```bash
+curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
+```

--- a/src/content/docs/stacks/_quickstart.mdx
+++ b/src/content/docs/stacks/_quickstart.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
+mergify stack setup
+mergify stack push
+```

--- a/src/content/docs/stacks/agents.mdx
+++ b/src/content/docs/stacks/agents.mdx
@@ -3,21 +3,17 @@ title: Stacks for AI Agents
 description: One-page bootstrap for AI coding agents — install the Mergify CLI and the Stacks skill.
 ---
 
+import Install from './_install.mdx';
+
 You are an AI coding agent. Follow these three steps to enable stacked pull
 request support. After step 2, your skill system will contain the full Stacks
 workflow. Consult it for any stack-related task.
 
 ## 1. Install the Mergify CLI
 
-Install `mergify-cli` with `uv` (preferred) or `pipx`:
+Install `mergify-cli` with the install script:
 
-```bash
-uv tool install mergify-cli
-```
-
-```bash
-pipx install mergify-cli
-```
+<Install />
 
 Verify:
 

--- a/src/content/docs/stacks/compare/gh-stack.mdx
+++ b/src/content/docs/stacks/compare/gh-stack.mdx
@@ -6,6 +6,7 @@ description: An honest comparison of Mergify Stacks and GitHub's gh-stack CLI fo
 import GitGraph from '~/components/GitGraph.astro';
 import StacksLocalModel from '~/components/StacksLocalModel.astro';
 import ComparisonLogo from '~/components/ComparisonLogo.astro';
+import InstallSetup from '../_install-setup.mdx';
 
 <ComparisonLogo icon="simple-icons:github" alt="GitHub logo" />
 
@@ -134,7 +135,7 @@ platform.
 
 **Distribution.** gh-stack ships as a `gh` CLI extension and will likely get
 deeper GitHub integration over time. Mergify CLI is a standalone install
-(`uv tool install mergify-cli`).
+via a one-line `install.sh` script.
 
 **Pricing.** Both are free. Mergify Stacks is a standalone CLI that doesn't
 require a Mergify subscription.
@@ -147,10 +148,7 @@ commit per PR on a single branch."
 
 ### Install and setup
 
-```bash
-uv tool install mergify-cli
-mergify stack setup
-```
+<InstallSetup />
 
 This installs the CLI and adds a `commit-msg` hook that generates
 [Change-Ids](/stacks/concepts#change-id) for your commits. See the

--- a/src/content/docs/stacks/compare/graphite.mdx
+++ b/src/content/docs/stacks/compare/graphite.mdx
@@ -6,6 +6,7 @@ description: An honest comparison of Mergify Stacks and Graphite's stacking work
 import GitGraph from '~/components/GitGraph.astro';
 import StacksLocalModel from '~/components/StacksLocalModel.astro';
 import ComparisonLogo from '~/components/ComparisonLogo.astro';
+import InstallSetup from '../_install-setup.mdx';
 
 <ComparisonLogo icon="simple-icons:graphite" alt="Graphite logo" />
 
@@ -201,10 +202,7 @@ is moving from "one branch per PR" to "one commit per PR on a single branch."
 
 ### Install and setup
 
-```bash
-uv tool install mergify-cli
-mergify stack setup
-```
+<InstallSetup />
 
 This installs the CLI and adds a `commit-msg` hook that generates
 [Change-Ids](/stacks/concepts#change-id) for your commits. See the

--- a/src/content/docs/stacks/compare/plain-git.mdx
+++ b/src/content/docs/stacks/compare/plain-git.mdx
@@ -7,6 +7,8 @@ import { Image } from 'astro:assets';
 import StacksLocalModel from '~/components/StacksLocalModel.astro';
 import ComparisonLogo from '~/components/ComparisonLogo.astro';
 import StackComment from '../../../images/stack-comment.png';
+import InstallSetup from '../_install-setup.mdx';
+import Quickstart from '../_quickstart.mdx';
 
 <ComparisonLogo icon="simple-icons:git" alt="Git logo" />
 
@@ -121,10 +123,7 @@ If you already wrap `git rebase` and `gh pr create`, you don't have to throw
 anything away. Stacks runs on the same Git primitives, so you can adopt it
 incrementally:
 
-```bash
-uv tool install mergify-cli
-mergify stack setup
-```
+<InstallSetup />
 
 Setup installs the `commit-msg` hook that adds Change-Ids and a `pre-push` hook
 that nudges you toward `mergify stack push`. From there:
@@ -145,11 +144,7 @@ that nudges you toward `mergify stack push`. From there:
 
 ## Getting Started
 
-```bash
-uv tool install mergify-cli
-mergify stack setup
-mergify stack push
-```
+<Quickstart />
 
 See the [setup guide](/stacks/setup) for the full walkthrough, or
 [Creating Stacks](/stacks/creating) to push your first stack.

--- a/src/content/docs/stacks/setup.mdx
+++ b/src/content/docs/stacks/setup.mdx
@@ -5,6 +5,7 @@ description: Install Mergify CLI and configure your repository for stacked PRs.
 
 import { Image } from 'astro:assets';
 import deleteHeadBranches from '../../images/github-delete-head-branches.png';
+import Install from './_install.mdx';
 
 ## 1. Install the Mergify CLI
 
@@ -12,9 +13,7 @@ See the [CLI installation guide](/cli) for full instructions.
 
 Quick install:
 
-```bash
-uv tool install mergify-cli
-```
+<Install />
 
 ## 2. Install skills for your AI coding agent
 


### PR DESCRIPTION
The install/quickstart command blocks were copy-pasted across the stacks
docs, so a command change meant editing every page. Extract three MDX
partials (_install, _install-setup, _quickstart) and use them on the
landing, setup, agents, plain-git, gh-stack, and graphite pages so the
commands live in one place.

Addresses review feedback on the "vs Plain Git" page where the install
block was duplicated.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>