### PR TITLE
docs(security): per-repo product enablement is repository write level

### DIFF
--- a/src/content/docs/security.mdx
+++ b/src/content/docs/security.mdx
@@ -75,12 +75,12 @@ IPs must be allowlisted for OAuth sign-in to succeed.
 
 ### Delegated Roles
 
-Some Mergify operations — such as managing the subscription, configuring CI
-Insights, or enabling integrations — require the GitHub organization
-`Owner` role by default. To avoid granting full GitHub `Owner` rights to a
-teammate who only needs one of these capabilities, GitHub `Owner`s can
-delegate scoped Mergify admin powers to any organization member or
-collaborator from the Mergify dashboard.
+Some Mergify operations (such as managing the subscription, managing CI
+Insights self-hosted runners, or configuring third-party integrations)
+require the GitHub organization `Owner` role by default. To avoid granting
+full GitHub `Owner` rights to a teammate who only needs one of these
+capabilities, GitHub `Owner`s can delegate scoped Mergify admin powers to any
+organization member or collaborator from the Mergify dashboard.
 
 Delegated roles are managed from **Settings → Roles** on the Mergify
 dashboard. Only GitHub `Owner`s and users holding the **Delegation Admin**
@@ -113,7 +113,7 @@ Each user can hold any combination of the following roles:
     <tr>
       <th scope="row">Integrations Admin</th>
       <td>
-        Enable or disable Mergify products and configure the Slack and
+        Configure the default products for new repositories and the Slack and
         Datadog notification integrations at the organization level.
       </td>
     </tr>
@@ -328,12 +328,12 @@ relevant account or resource. Permissions are inherited from GitHub roles.
       <td>✓</td>
     </tr>
     <tr>
-      <td>Activate CI Insights or configure its repositories</td>
+      <td>Activate CI Insights on a repository</td>
       <td>✗</td>
       <td>✗</td>
-      <td>✗</td>
-      <td>✗</td>
-      <td>✗</td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>✓</td>
       <td>✓</td>
     </tr>
     <tr>
@@ -451,12 +451,11 @@ relevant account or resource. Permissions are inherited from GitHub roles.
 
   - **Billing Admin** — manage Mergify subscription.
 
-  - **CI Admin** — manage API keys (CI scope only), activate CI Insights,
-    and manage CI Insights self-hosted runners.
+  - **CI Admin** — manage API keys (CI scope only) and manage CI Insights
+    self-hosted runners.
 
-  - **Integrations Admin** — enable or disable Mergify products,
-    configure default products for new repositories, and configure third-party
-    integrations (Slack, Datadog, etc.).
+  - **Integrations Admin** — configure default products for new repositories
+    and configure third-party integrations (Slack, Datadog, etc.).
 
   - **Delegation Admin** — grant or revoke any of the roles above.
 


### PR DESCRIPTION
Per-repository product enablement, including activating CI Insights, is
enforced at repository WRITE level via PUT /v1/products/{owner}/{repository}.
Only the org-level default-products configuration requires Integrations Admin.

Correct the security page so the documented model matches enforcement:
- Features Permissions: "Activate CI Insights on a repository" is write-level,
  not Owner-only.
- Delegated Roles: Integrations Admin grants org-level default products and
  third-party integrations, not per-repo product enablement; drop "activate
  CI Insights" from CI Admin since per-repo activation is write-level, not a
  delegated owner power.
- Tighten the Delegated Roles intro so its examples reference org-level
  operations only.

Surfaced by HackerOne #3801915: a write collaborator activated CI Insights
and the reporter cited these rows as the owner-only boundary. The docs were
wrong; the access-control behavior is correct.

Fixes MRGFY-7644

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>