### PR TITLE
docs(cli): recommend Homebrew tap for macOS installation

### DIFF
--- a/src/content/docs/cli.mdx
+++ b/src/content/docs/cli.mdx
@@ -8,23 +8,24 @@ terminal.
 
 ## Installation
 
-Install the CLI using [uv](https://docs.astral.sh/uv/):
+On macOS, the recommended way to install the CLI is through Mergify's
+[Homebrew tap](https://github.com/Mergifyio/homebrew-tap):
+
+```bash
+brew install mergifyio/tap/mergify-cli
+```
+
+On other platforms, or if you prefer a Python-based install, use
+[uv](https://docs.astral.sh/uv/):
 
 ```bash
 uv tool install mergify-cli
 ```
 
-Or using [pipx](https://pipx.pypa.io/):
+Or [pipx](https://pipx.pypa.io/):
 
 ```bash
 pipx install mergify-cli
-```
-
-On macOS, you can install these tools via Homebrew:
-
-```bash
-brew install uv
-uv tool install mergify-cli
 ```
 
 ## Authentication


### PR DESCRIPTION
Lead the macOS install instructions with Mergify's dedicated Homebrew
tap (brew install Mergifyio/tap/mergify-cli) and keep uv/pipx as the
cross-platform alternatives.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>