### PR TITLE
docs(rulesets): surface required-reviewers support in compatibility table

### DIFF
--- a/src/content/docs/merge-queue/github-rulesets.mdx
+++ b/src/content/docs/merge-queue/github-rulesets.mdx
@@ -94,7 +94,7 @@ Mergify handles each GitHub ruleset rule type as follows.
 | Ruleset rule type | Mergify behavior | Notes |
 |---|---|---|
 | `required_status_checks` | Injected as conditions | See [below](#require-branches-to-be-up-to-date) |
-| `pull_request` | Injected as conditions | Limited code owner support. See [Required Reviewers](#required-reviewers) |
+| `pull_request` | Injected as conditions | Required reviewers injected as [`github-require-review-from-specific-teams`](#required-reviewers). Limited code owner support. |
 | `required_deployments` | Used by [Merge Protections](/merge-protections) | -- |
 | `merge_queue` (GitHub native) | **Incompatible** | See [below](#github-native-merge-queue-rule) |
 | `creation` | Checked when creating batch PRs | May block batch PR creation if Mergify is not a bypass actor |


### PR DESCRIPTION
The Ruleset Rule Compatibility table's `pull_request` row only pointed to
the Required Reviewers section via a generic "See" link, bundled with the
unrelated code-owner caveat. Name the injected
`github-require-review-from-specific-teams` condition directly in the row so
the support is discoverable from the table itself, and separate it from the
code-owner limitation.

`require_review_from_specific_teams` is not a distinct GitHub ruleset rule
type, it is the `required_reviewers` parameter of the `pull_request` rule, so
it belongs in that row rather than a new one.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>