### PR TITLE
docs(rulesets): state that only listed ruleset rules are supported

### DIFF
--- a/src/content/docs/merge-queue/github-rulesets.mdx
+++ b/src/content/docs/merge-queue/github-rulesets.mdx
@@ -103,6 +103,11 @@ Mergify handles each GitHub ruleset rule type as follows.
 | `required_review_thread_resolution` | Injected as conditions | -- |
 | All other rule types | Ignored | See [below](#ignored-rule-types) |
 
+Mergify supports only the ruleset rule types named above. Every other rule
+type is ignored: Mergify neither injects it as a condition nor checks it for
+compatibility. Do not assume full ruleset parity. Enforce any
+unlisted rule through GitHub directly.
+
 :::caution
   Branch protection support has some limitations. For example, GitHub does
   not provide an API to support [code


### PR DESCRIPTION
The Ruleset Rule Compatibility table already has an "All other rule types
-> Ignored" row, but nothing in prose set the expectation that the listed
types are an allowlist. Customers assumed full ruleset parity, which drove
security reports about matcher/semantic divergences for rules Mergify never
processes.

Add a sentence after the table making the allowlist nature explicit.

Fixes MRGFY-7702