### PR TITLE
docs(integrations): document Test Insights Slack notifications

### DIFF
--- a/src/content/docs/integrations/slack.mdx
+++ b/src/content/docs/integrations/slack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using Slack with Mergify
-description: Learn how you can send Slack notifications for Merge Queue events, CI Insights, and pull request activities.
+description: Learn how you can send Slack notifications for Merge Queue events, CI Insights, Test Insights quarantine activity, and pull request activities.
 ---
 
 import { Image } from "astro:assets"
@@ -13,8 +13,9 @@ import ciInsightsConfig from "../../images/integrations/slack/ci-insights.png"
 
 Mergify offers comprehensive Slack integration, allowing you to receive
 notifications about your development workflow directly in Slack. You can get
-updates about Merge Queue activities, CI job completions, and pull request
-events, keeping your team informed without leaving Slack.
+updates about Merge Queue activities, CI job completions, test quarantine
+activity, and pull request events, keeping your team informed without leaving
+Slack.
 
 ## Setting Up the Mergify Slack Integration
 
@@ -121,6 +122,35 @@ Alert on any test failures across all branches:
 
 5. **Team-Specific Filters**: Configure different notification rules for
    different teams based on their responsibilities
+
+## Test Insights Notifications
+
+[Mergify's Test Insights](/test-insights) can post a Slack message whenever a
+test is [quarantined or dequarantined](/test-insights/quarantine), so your team
+sees mitigation activity as it happens (whether a teammate acted from the
+dashboard or CLI, or Mergify quarantined the test automatically).
+
+Test Insights notifications include:
+- **Test**: The affected test, linked to its details page
+- **Repository**: The repository the test belongs to
+- **Action**: Whether the test was quarantined or dequarantined
+- **Source**: Who acted: a teammate or Mergify's automatic quarantine
+- **Health status**: The test's health at the time of the event
+- **Reason**: Why the test was quarantined (on quarantine events)
+
+To configure Test Insights Slack notifications:
+
+1. **Enable Test Insights**: Make sure you have [Test Insights](/test-insights)
+   set up for your repositories
+
+2. **Connect Slack**: In your Mergify dashboard, navigate to **Integrations → Slack**
+
+3. **Add the notification**: On a channel, add a **Test Insights** notification,
+   then choose the repositories to monitor and which events (quarantine,
+   dequarantine) to subscribe to
+
+Test Insights notifications are available on the same plans as the
+[quarantine feature](/test-insights/quarantine).
 
 ## Pull Request Notifications via GitHub-Slack Integration
 

--- a/src/content/docs/test-insights/quarantine.mdx
+++ b/src/content/docs/test-insights/quarantine.mdx
@@ -47,3 +47,11 @@ mergify tests quarantines list -r owner/repo
 ```
 
 See the [Test Insights CLI](/test-insights/cli) reference for all flags and exit codes.
+
+## Staying Notified
+
+Quarantine and dequarantine actions, whether you make them yourself or Mergify
+applies them automatically, are recorded as events you can review on the
+dashboard and act on. You can also have Mergify post them to a Slack channel as
+they happen: see [Test Insights notifications](/integrations/slack#test-insights-notifications)
+to set one up.


### PR DESCRIPTION
Add a Test Insights Notifications section to the Slack integration page covering quarantine and dequarantine events, and link to it from the quarantine page.

Related to MRGFY-7705

Depends-On: https://github.com/Mergifyio/monorepo/pull/35027
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>