### PR TITLE
docs(test-insights): generate the CLI page from cli-schema.json

### DIFF
--- a/src/components/ApiReference/openapi.ts
+++ b/src/components/ApiReference/openapi.ts
@@ -1,3 +1,5 @@
+import { slugify } from '~/util/slugify';
+
 export interface OpenAPISpec {
   openapi: string;
   info: {
@@ -192,13 +194,6 @@ export function humanizeTag(tag: string): string {
 
 export function slugifyTag(tag: string): string {
   return tag.toLowerCase().replace(/_/g, '-');
-}
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
 }
 
 export function groupByTag(schema: OpenAPISpec): Map<string, GroupedEndpoint[]> {

--- a/src/components/CliReference/CliArgRow.astro
+++ b/src/components/CliReference/CliArgRow.astro
@@ -1,0 +1,76 @@
+---
+/**
+ * One row in a command's Arguments / Options / Global options table. Renders a
+ * positional, an option, or a flag uniformly so the three sections stay in sync.
+ */
+import {
+  type CliArg,
+  helpToHtml,
+  isVariadic,
+  optionSignature,
+  typeLabel,
+  valuePlaceholder,
+} from './cli-schema';
+
+interface Props {
+  arg: CliArg;
+  /** Positionals show their value placeholder as the name and an "optional" badge. */
+  positional?: boolean;
+}
+
+const { arg, positional = false } = Astro.props;
+
+const value = valuePlaceholder(arg);
+// Row description: the short help, falling back to the long help.
+const description = arg.help ?? arg.longHelp;
+---
+
+<div class="cli-arg">
+  <div class="cli-arg-signature">
+    <code class="cli-arg-name">
+      {positional ? (value ?? arg.id) : optionSignature(arg)}
+      {!positional && value && (
+        <>
+          {' '}
+          <span class="cli-arg-value">{value}</span>
+        </>
+      )}
+    </code>
+    <span class="cli-type-badge">{typeLabel(arg)}</span>
+    {arg.required && <span class="cli-required-badge">required</span>}
+    {positional && !arg.required && <span class="cli-optional-badge">optional</span>}
+    {isVariadic(arg) && <span class="cli-hint-badge">repeatable</span>}
+  </div>
+
+  {description && <p class="cli-arg-description" set:html={helpToHtml(description)} />}
+
+  {
+    arg.possibleValues.length > 0 && (
+      <p class="cli-arg-enum">
+        Values:{' '}
+        {arg.possibleValues.map((v, i) => (
+          <>
+            {i > 0 && ' '}
+            <code>{v.name}</code>
+          </>
+        ))}
+      </p>
+    )
+  }
+
+  {
+    arg.default && arg.kind !== 'flag' && (
+      <p class="cli-arg-meta">
+        Default: <code>{arg.default}</code>
+      </p>
+    )
+  }
+
+  {
+    arg.env && (
+      <p class="cli-arg-meta">
+        Environment variable: <code>{arg.env}</code>
+      </p>
+    )
+  }
+</div>

--- a/src/components/CliReference/CliCommand.astro
+++ b/src/components/CliReference/CliCommand.astro
@@ -1,14 +1,26 @@
 ---
 /**
  * A structured reference card for a single CLI command, mirroring the HTTP API
- * reference's endpoint cards: the command sits as the card's heading, with the
- * description as the card body.
+ * reference's endpoint cards. Everything — description, usage, arguments,
+ * options, and inherited global options — is generated from
+ * `public/cli-schema.json`, the single source of truth; the card carries no
+ * hand-written prose. Enrich a command's clap definition to enrich the card.
  *
  * The heading is rendered by this component (not a markdown `##`), so it gives
  * a deep-link `#` anchor but does not appear in the compile-time "on this page"
  * TOC — that list only sees markdown headings.
  */
+import { slugify } from '~/util/slugify';
 import '~/styles/cli-reference.css';
+import CliArgRow from './CliArgRow.astro';
+import {
+  collectInheritedGlobals,
+  findCommand,
+  helpToHtml,
+  loadCliSchema,
+  partitionArgs,
+  splitCommand,
+} from './cli-schema';
 
 interface Props {
   /** The command shown as the card's heading, e.g. `mergify tests show`. */
@@ -16,11 +28,27 @@ interface Props {
 }
 
 const { command } = Astro.props;
+const slug = slugify(command);
 
-const slug = command
-  .toLowerCase()
-  .replace(/[^a-z0-9]+/g, '-')
-  .replace(/^-+|-+$/g, '');
+const schema = loadCliSchema();
+const path = splitCommand(command);
+const node = findCommand(schema.command, path);
+if (!node) {
+  throw new Error(
+    `CliCommand: "${command}" not found in public/cli-schema.json. ` +
+      `Check the command name or regenerate the schema.`
+  );
+}
+if (node.commands.length > 0) {
+  throw new Error(
+    `CliCommand: "${command}" is a command group, not a runnable command. ` +
+      `Point the card at one of its subcommands.`
+  );
+}
+
+const description = node.longAbout ?? node.about;
+const { positionals, options } = partitionArgs(node.args);
+const globals = collectInheritedGlobals(schema.command, path);
 ---
 
 <div class="cli-command">
@@ -30,5 +58,64 @@ const slug = command
       #
     </a>
   </h2>
-  <slot />
+
+  {description && <p class="cli-command-description" set:html={helpToHtml(description)} />}
+
+  <div class="cli-usage">
+    <span class="cli-section-label">Usage</span>
+    <pre><code>{node.usage}</code></pre>
+  </div>
+
+  {
+    node.aliases.length > 0 && (
+      <p class="cli-aliases">
+        Alias{node.aliases.length > 1 ? 'es' : ''}:{' '}
+        {node.aliases.map((a, i) => (
+          <>
+            {i > 0 && ', '}
+            <code>{a}</code>
+          </>
+        ))}
+      </p>
+    )
+  }
+
+  {
+    positionals.length > 0 && (
+      <div class="cli-section">
+        <span class="cli-section-label">Arguments</span>
+        <div class="cli-args">
+          {positionals.map((arg) => (
+            <CliArgRow arg={arg} positional />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  {
+    options.length > 0 && (
+      <div class="cli-section">
+        <span class="cli-section-label">Options</span>
+        <div class="cli-args">
+          {options.map((arg) => (
+            <CliArgRow arg={arg} />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  {
+    globals.length > 0 && (
+      <div class="cli-section">
+        <span class="cli-section-label">Global options</span>
+        <div class="cli-args">
+          {globals.map((arg) => (
+            <CliArgRow arg={arg} />
+          ))}
+        </div>
+      </div>
+    )
+  }
 </div>

--- a/src/components/CliReference/cli-schema.ts
+++ b/src/components/CliReference/cli-schema.ts
@@ -1,0 +1,184 @@
+import fs from 'node:fs';
+import { escape } from '~/util/html-entities';
+
+/**
+ * Types and helpers for the CLI reference, mirroring the HTTP API reference's
+ * `openapi.ts`. The source of truth is `public/cli-schema.json`, produced by
+ * `mergify _internal dump-cli-schema` (clap introspection) — the CLI counterpart
+ * of the OpenAPI spec that drives `/api`.
+ */
+
+export interface CliPossibleValue {
+  name: string;
+  help: string | null;
+}
+
+export interface CliArg {
+  id: string;
+  kind: 'flag' | 'option' | 'positional';
+  short: string | null;
+  long: string | null;
+  valueNames: string[];
+  help: string | null;
+  longHelp: string | null;
+  required: boolean;
+  global: boolean;
+  default: string | null;
+  possibleValues: CliPossibleValue[];
+  numArgs: string;
+  env: string | null;
+  valueHint: string | null;
+}
+
+export interface CliCommandNode {
+  name: string;
+  path: string[];
+  about: string | null;
+  longAbout: string | null;
+  usage: string;
+  aliases: string[];
+  subcommandRequired: boolean;
+  source: string;
+  args: CliArg[];
+  commands: CliCommandNode[];
+}
+
+export interface CliSchema {
+  schemaVersion: number;
+  generator: string;
+  cli: { name: string; version: string; about: string | null };
+  command: CliCommandNode;
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+let cached: CliSchema | null = null;
+
+/** Read and memoize the CLI schema. cwd is the project root at build time. */
+export function loadCliSchema(): CliSchema {
+  if (!cached) {
+    cached = JSON.parse(fs.readFileSync('public/cli-schema.json', 'utf-8')) as CliSchema;
+  }
+  return cached;
+}
+
+/** Split a display command string ("mergify tests show") into its path. */
+export function splitCommand(command: string): string[] {
+  return command.trim().split(/\s+/);
+}
+
+/** Locate a command node by its full path, walking the subcommand tree. */
+export function findCommand(root: CliCommandNode, path: string[]): CliCommandNode | undefined {
+  if (path.length === 0) return undefined;
+  let node: CliCommandNode | undefined = root.name === path[0] ? root : undefined;
+  for (const segment of path.slice(1)) {
+    node = node?.commands.find((c) => c.name === segment);
+    if (!node) return undefined;
+  }
+  return node;
+}
+
+/**
+ * Global args (`global: true`) declared on ancestor commands, which the leaf
+ * accepts but doesn't re-list. Deduped by flag name, nearest the root first.
+ * Mirrors how clap surfaces global options on every subcommand.
+ */
+export function collectInheritedGlobals(root: CliCommandNode, path: string[]): CliArg[] {
+  const result: CliArg[] = [];
+  const seen = new Set<string>();
+  let node: CliCommandNode | undefined = root.name === path[0] ? root : undefined;
+  // Visit every ancestor strictly above the leaf command.
+  for (let i = 0; node && i < path.length - 1; i++) {
+    for (const arg of node.args) {
+      const key = arg.long ?? arg.short ?? arg.id;
+      if (!arg.global || seen.has(key)) continue;
+      seen.add(key);
+      result.push(arg);
+    }
+    node = node.commands.find((c) => c.name === path[i + 1]);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Argument helpers
+// ---------------------------------------------------------------------------
+
+/** A positional or option that accepts more than one value (clap `1..`, `0..`). */
+export function isVariadic(arg: CliArg): boolean {
+  return arg.numArgs.includes('..');
+}
+
+/** Positionals first, then options and flags, preserving schema order. */
+export function partitionArgs(args: CliArg[]): {
+  positionals: CliArg[];
+  options: CliArg[];
+} {
+  return {
+    positionals: args.filter((a) => a.kind === 'positional'),
+    options: args.filter((a) => a.kind === 'option' || a.kind === 'flag'),
+  };
+}
+
+/** The flag signature shown as the row name, e.g. `-r, --repository` or `--json`. */
+export function optionSignature(arg: CliArg): string {
+  const names: string[] = [];
+  if (arg.short) names.push(`-${arg.short}`);
+  if (arg.long) names.push(`--${arg.long}`);
+  return names.join(', ') || arg.id;
+}
+
+/** The value placeholder for an option/positional, e.g. `<REPOSITORY>`; null for flags. */
+export function valuePlaceholder(arg: CliArg): string | null {
+  if (arg.kind === 'flag' || arg.valueNames.length === 0) return null;
+  const placeholder = arg.valueNames.map((n) => `<${n}>`).join(' ');
+  return isVariadic(arg) ? `${placeholder}...` : placeholder;
+}
+
+/**
+ * Render help text to safe HTML, turning backtick spans into inline `<code>`.
+ * clap help uses both RST double-backticks (``ENV_VAR``) and single backticks
+ * (`--flag`); everything else is HTML-escaped.
+ */
+export function helpToHtml(text: string): string {
+  const pattern = /``([^`]+)``|`([^`]+)`/g;
+  let html = '';
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    html += escape(text.slice(lastIndex, match.index));
+    html += `<code>${escape(match[1] ?? match[2])}</code>`;
+    lastIndex = pattern.lastIndex;
+  }
+  html += escape(text.slice(lastIndex));
+  return html;
+}
+
+/** clap value hints (camelCased variant names) → friendly type labels. */
+const VALUE_HINT_LABELS: Record<string, string> = {
+  anyPath: 'path',
+  filePath: 'path',
+  dirPath: 'path',
+  executablePath: 'path',
+  url: 'url',
+  hostname: 'hostname',
+  emailAddress: 'email',
+  username: 'username',
+  commandName: 'command',
+  commandString: 'command',
+};
+
+/**
+ * Short type label for the badge: enum values, the value hint, or the kind.
+ * The schema carries no numeric type, so plain options fall back to 'string'.
+ */
+export function typeLabel(arg: CliArg): string {
+  if (arg.possibleValues.length > 0) {
+    return arg.possibleValues.map((v) => v.name).join(' | ');
+  }
+  if (arg.kind === 'flag') return 'flag';
+  if (arg.valueHint) return VALUE_HINT_LABELS[arg.valueHint] ?? 'string';
+  return 'string';
+}

--- a/src/content/docs/test-insights/cli.mdx
+++ b/src/content/docs/test-insights/cli.mdx
@@ -1,76 +1,20 @@
 ---
 title: CLI
-description: Interact with Test Insights data from the terminal — search for tests, branch on health via exit codes, and chain into AI coding agents like Claude Code and Cursor.
+description: Search Test Insights test health and manage quarantine from the terminal with the Mergify CLI.
 ---
 
 import CliCommand from '~/components/CliReference/CliCommand.astro';
 
-The [Mergify CLI](/cli) lets you interact with Test Insights data from
-the terminal. It's handy when you want to triage a failing test
-quickly, or when an AI coding agent needs to decide whether to retry,
-fix, or ignore a failure.
+The [Mergify CLI](/cli) lets you search Test Insights test health and manage
+quarantine from the terminal. Run any command with `--help` for the same
+reference shown below.
 
-:::tip
-  Run these commands from inside a repository checkout and you can drop the
-  `-r owner/repo` flag — the CLI detects the repository from your `origin` git
-  remote, or from the CI environment when it runs in a pipeline.
-:::
+<CliCommand command="mergify tests show" />
 
-Every command also accepts `--json` for machine-readable output and `--help`
-for the full list of flags.
+<CliCommand command="mergify tests quarantines add" />
 
-<CliCommand command="mergify tests show">
+<CliCommand command="mergify tests quarantines remove" />
 
-Search the Test Insights catalog by test name and print each match's health,
-failure ratios, and most recent failure context. Names accept glob patterns
-(`*`, `?`), and several can be passed in one call. See the
-[API reference](/api/test-insights) for the underlying endpoints and response
-schemas.
+<CliCommand command="mergify tests quarantines get" />
 
-</CliCommand>
-
-<CliCommand command="mergify tests quarantines add">
-
-Add a test to [quarantine](/test-insights/quarantine) so its failures stop
-blocking merges and no longer mark the pipeline as failed. The test keeps
-running, and its results keep flowing into Test Insights. Pass the fully
-qualified test name and a `--reason`; the quarantine covers every branch unless
-you scope it with `--branch`. The command prints a quarantine ID you can pass to
-`remove` or `get`.
-
-</CliCommand>
-
-<CliCommand command="mergify tests quarantines remove">
-
-Remove a test from quarantine, addressed either by its fully qualified name or
-by the quarantine ID that `add` printed. A UUID-shaped argument is treated as
-the ID and removed directly; anything else is looked up by name.
-
-</CliCommand>
-
-<CliCommand command="mergify tests quarantines get">
-
-Print a single quarantine, addressed by the test's fully qualified name or its
-quarantine ID (a UUID-shaped argument is matched against the ID). The output
-mirrors one record of `list`.
-
-</CliCommand>
-
-<CliCommand command="mergify tests quarantines list">
-
-List every test currently in [quarantine](/test-insights/quarantine) for a
-repository. It's handy for reviewing what's being ignored, or for looking up a
-quarantine ID to pass to `remove` or `get`. Each record carries its quarantine
-ID, the branch it's scoped to (`*` for all branches), the source (`manual` or
-`auto`), whether it has recovered, and the reason.
-
-</CliCommand>
-
-## Use with AI coding agents
-
-`mergify tests show` reports a test's health through its exit code, so an agent
-can branch on a failure without parsing output: `0` healthy or unknown, `1`
-flaky, `6` broken. Wire it into Claude Code as a
-[skill](https://docs.claude.com/en/docs/claude-code/skills) or Cursor as a
-project rule to rerun flaky tests, surface broken ones, and treat healthy ones
-as real regressions.
+<CliCommand command="mergify tests quarantines list" />

--- a/src/styles/cli-reference.css
+++ b/src/styles/cli-reference.css
@@ -55,6 +55,166 @@
 }
 
 /* ---------------------------------------------------------------------------
+   Generated sections — usage, arguments, options.
+
+   Rendered from public/cli-schema.json by CliCommand.astro, parallel to the API
+   reference's parameter tables. Section dividers and badges mirror
+   api-reference.css so the two references read the same.
+   --------------------------------------------------------------------------- */
+
+/* Usage block and each labelled section share a top divider — parallels
+   .endpoint-section. */
+.cli-usage,
+.cli-section {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--theme-border-color);
+}
+
+.cli-section-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--theme-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+/* The command's description, sourced from the schema's about/long-about. */
+.cli-command-description {
+  margin: 0 0 0.5rem;
+  color: var(--theme-text);
+  line-height: 1.6;
+}
+
+.cli-command-description code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  color: var(--theme-code-inline-text);
+  background: var(--theme-code-inline-bg);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+}
+
+/* Reset the global code-block padding (pre + pre>code double up) and let long
+   usage strings scroll within the box rather than overflowing the card. */
+.cli-usage pre {
+  margin: 0;
+  overflow-x: auto;
+}
+
+.cli-usage pre > code {
+  display: block;
+  padding: 0;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--theme-text);
+}
+
+.cli-aliases {
+  font-size: 0.85rem;
+  color: var(--theme-text-muted);
+  margin: 0.75rem 0 0;
+}
+
+/* Argument / option rows — parallels .params-table / .param-row */
+.cli-args {
+  display: flex;
+  flex-direction: column;
+}
+
+.cli-arg {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--theme-divider);
+}
+
+.cli-arg:last-child {
+  border-bottom: none;
+}
+
+.cli-arg-signature {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.cli-arg-name {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--theme-text);
+}
+
+.cli-arg-value {
+  font-weight: 400;
+  color: var(--theme-link);
+  font-style: italic;
+}
+
+.cli-arg-description {
+  font-size: 0.8rem;
+  color: var(--theme-text-muted);
+  margin: 0.2rem 0 0;
+  line-height: 1.5;
+}
+
+.cli-arg-description code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  color: var(--theme-code-inline-text);
+  background: var(--theme-code-inline-bg);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+}
+
+.cli-arg-enum,
+.cli-arg-meta {
+  font-size: 0.75rem;
+  color: var(--theme-text-muted);
+  margin: 0.2rem 0 0;
+}
+
+.cli-arg-enum code,
+.cli-arg-meta code {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--theme-code-inline-text);
+  background: var(--theme-code-inline-bg);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+}
+
+/* Badges — same look as the API reference, but CLI-scoped class names so the
+   two global stylesheets can't collide or silently override each other. */
+.cli-type-badge {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--theme-code-inline-text);
+  background: var(--theme-code-inline-bg);
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+}
+
+.cli-required-badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-orange-700);
+}
+
+.cli-optional-badge,
+.cli-hint-badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--theme-text-muted);
+}
+
+/* ---------------------------------------------------------------------------
    Responsive — mirrors the api-reference 50em breakpoint
    --------------------------------------------------------------------------- */
 

--- a/src/util/slugify.ts
+++ b/src/util/slugify.ts
@@ -1,0 +1,11 @@
+/**
+ * Slugify text into a URL/anchor-safe id: lowercase, runs of non-alphanumerics
+ * collapsed to a single dash, leading/trailing dashes trimmed. Shared by the
+ * API and CLI references so their deep-link anchors follow one convention.
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
Render the /test-insights/cli command cards entirely from
public/cli-schema.json — description, usage, arguments, options, and inherited
global options — mirroring the OpenAPI→/api pipeline. The schema is the single
source of truth; the cards carry no hand-written prose, so enriching a command
means enriching its clap definition.

- Add cli-schema.ts (typed loader + helpers) and CliArgRow.astro (one row
  renderer for positionals, options, flags, and globals).
- CliCommand.astro resolves a command by path, renders its schema description,
  walks ancestors for global:true flags, and fails the build on an unknown or
  group command.
- Extract a shared util/slugify.ts used by both the CLI and API references.
- Reuse the shared html-entities escape; CLI-scoped badge classes avoid
  colliding with the API reference's global styles; reset the usage `<pre>` so it
  doesn't double-pad or overflow.
- Strip the test-insights/cli.mdx prose to a short intro plus self-closing cards.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>