### PR TITLE
docs(cli): centralize repeated CLI snippets into components

### DIFF
--- a/src/components/CliInstall.astro
+++ b/src/components/CliInstall.astro
@@ -1,0 +1,22 @@
+---
+/**
+ * The Mergify CLI install command as a single themed code block — one source of
+ * truth for the install line, which otherwise gets copy-pasted across the stacks
+ * and CI docs. Pass `steps` to append follow-up commands (e.g. the `stack setup`
+ * / `stack push` a quickstart shows right after install).
+ */
+import { Code } from 'astro-expressive-code/components';
+
+const INSTALL_COMMAND =
+  'curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh';
+
+export interface Props {
+  /** Commands appended after the install line, shown in the same block. */
+  steps?: string[];
+}
+
+const { steps = [] } = Astro.props as Props;
+const code = [INSTALL_COMMAND, ...steps].join('\n');
+---
+
+<Code code={code} lang="bash" />

--- a/src/components/ScopesDetection.astro
+++ b/src/components/ScopesDetection.astro
@@ -1,0 +1,50 @@
+---
+/**
+ * The "detect scopes from any CI with the Mergify CLI" block shared by the
+ * monorepo scopes pages. The git-refs preamble, the scopes-send upload, and the
+ * batch-aware note are identical across build tools — only the command that
+ * turns the BASE..HEAD diff into scopes.json differs, passed as `command`.
+ *
+ * Pass `command` with String.raw so the bash keeps its literal backslashes
+ * (line continuations, `\n` in awk/jq) instead of the JS template literal eating
+ * them.
+ */
+import { Code as InlineCode } from 'astro:components';
+import { Code } from 'astro-expressive-code/components';
+import Aside from '~/components/Aside.astro';
+
+const inlineThemes = { light: 'github-light', dark: 'github-dark' } as const;
+
+export interface Props {
+  /** The build-tool command that writes the affected projects to scopes.json. */
+  command: string;
+}
+
+const { command } = Astro.props as Props;
+
+const code = `REFS=$(mergify ci git-refs)
+BASE=$(echo "$REFS" | awk '/^Base:/ {print $2}')
+HEAD=$(echo "$REFS" | awk '/^Head:/ {print $2}')
+
+${command}
+
+mergify ci scopes-send --file scopes.json`;
+---
+
+<p>
+  Install the <a href="/cli/usage">Mergify CLI</a> in your pipeline and export
+  <InlineCode code="MERGIFY_TOKEN" inline lang="bash" themes={inlineThemes} />. Use
+  <InlineCode code="mergify ci git-refs" inline lang="bash" themes={inlineThemes} /> to get the
+  merge-queue-aware base and head SHAs and
+  <InlineCode code="mergify ci scopes-send" inline lang="bash" themes={inlineThemes} /> to upload the
+  detected scopes:
+</p>
+
+<Code code={code} lang="bash" />
+
+<Aside type="note">
+  In the context of merge queue pull requests, the <code>HEAD</code> and <code>BASE</code> git
+  references are specifically calculated to detect changed projects in the current batch only, not in
+  the batches this one depends on. This ensures that your monorepo tool identifies only the projects
+  affected by the PRs in the current batch, allowing for more granular and efficient testing.
+</Aside>

--- a/src/content/docs/cli/usage.mdx
+++ b/src/content/docs/cli/usage.mdx
@@ -3,6 +3,8 @@ title: CLI Installation & Authentication
 description: Install the Mergify CLI and authenticate it to manage your merge queue, freezes, and stacked pull requests from the terminal.
 ---
 
+import CliInstall from '~/components/CliInstall.astro';
+
 The Mergify CLI lets you interact with Mergify features directly from your
 terminal. This page covers installation and authentication; for the commands
 themselves, see the [CLI reference](/cli).
@@ -25,9 +27,7 @@ Upgrade with `brew upgrade mergify-cli`.
 On Linux, or on macOS if you'd rather not use Homebrew, install with the
 official script:
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
-```
+<CliInstall />
 
 This installs `mergify` to `~/.local/bin`. Set `MERGIFY_INSTALL_DIR` to pick a
 different location, or `MERGIFY_VERSION` to pin a specific release:

--- a/src/content/docs/merge-queue/scopes/bazel.mdx
+++ b/src/content/docs/merge-queue/scopes/bazel.mdx
@@ -3,6 +3,8 @@ title: Scopes with Bazel
 description: Configure merge queue scopes using Bazel's dependency graph for precise batching.
 ---
 
+import ScopesDetection from '~/components/ScopesDetection.astro';
+
 If you're using monorepo tools like Bazel that have built-in dependency graph analysis,
 you can leverage their affected project detection instead of using file patterns.
 This approach is often more accurate because these tools understand your project's
@@ -101,26 +103,9 @@ steps:
 
 ### Any CI (Mergify CLI)
 
-Install the [Mergify CLI](/cli/usage) in your pipeline and export `MERGIFY_TOKEN`.
-Use `mergify ci git-refs` to get the merge-queue-aware base and head SHAs and
-`mergify ci scopes-send` to upload the detected scopes:
-
-```bash
-REFS=$(mergify ci git-refs)
-BASE=$(echo "$REFS" | awk '/^Base:/ {print $2}')
-HEAD=$(echo "$REFS" | awk '/^Head:/ {print $2}')
-
-bazel query --keep_going --noshow_progress --output=package \
+<ScopesDetection
+  command={String.raw`bazel query --keep_going --noshow_progress --output=package \
   "buildfiles(set($(git diff --name-only --diff-filter=ACMR \"$BASE\" \"$HEAD\" | tr '\n' ' ')))" \
   2>/dev/null | sort -u \
-  | jq -R -s '{scopes: split("\n") | map(select(length > 0))}' > scopes.json
-
-mergify ci scopes-send --file scopes.json
-```
-
-:::note
-In the context of merge queue pull requests, the `HEAD` and `BASE` git references are specifically
-calculated to detect changed projects in the current batch only, not in the batches this one depends
-on. This ensures that your monorepo tool identifies only the projects affected by the PRs in the
-current batch, allowing for more granular and efficient testing.
-:::
+  | jq -R -s '{scopes: split("\n") | map(select(length > 0))}' > scopes.json`}
+/>

--- a/src/content/docs/merge-queue/scopes/nx.mdx
+++ b/src/content/docs/merge-queue/scopes/nx.mdx
@@ -3,6 +3,8 @@ title: Scopes with Nx
 description: Configure merge queue scopes using Nx's dependency graph to drive batching.
 ---
 
+import ScopesDetection from '~/components/ScopesDetection.astro';
+
 If you're using tools like the Nx build system that have built-in dependency graph analysis,
 you can leverage their affected project detection instead of using file patterns.
 This approach is often more accurate because these tools understand your project's
@@ -94,24 +96,7 @@ steps:
 
 ### Any CI (Mergify CLI)
 
-Install the [Mergify CLI](/cli/usage) in your pipeline and export `MERGIFY_TOKEN`.
-Use `mergify ci git-refs` to get the merge-queue-aware base and head SHAs and
-`mergify ci scopes-send` to upload the detected scopes:
-
-```bash
-REFS=$(mergify ci git-refs)
-BASE=$(echo "$REFS" | awk '/^Base:/ {print $2}')
-HEAD=$(echo "$REFS" | awk '/^Head:/ {print $2}')
-
-npx nx show projects --affected --base="$BASE" --head="$HEAD" \
-  | jq -R -s '{scopes: split("\n") | map(select(length > 0))}' > scopes.json
-
-mergify ci scopes-send --file scopes.json
-```
-
-:::note
-In the context of merge queue pull requests, the `HEAD` and `BASE` git references are specifically
-calculated to detect changed projects in the current batch only, not in the batches this one depends
-on. This ensures that your monorepo tool identifies only the projects affected by the PRs in the
-current batch, allowing for more granular and efficient testing.
-:::
+<ScopesDetection
+  command={String.raw`npx nx show projects --affected --base="$BASE" --head="$HEAD" \
+  | jq -R -s '{scopes: split("\n") | map(select(length > 0))}' > scopes.json`}
+/>

--- a/src/content/docs/merge-queue/scopes/others.mdx
+++ b/src/content/docs/merge-queue/scopes/others.mdx
@@ -3,6 +3,8 @@ title: Scopes with Other Build Tools
 description: Configure merge queue scopes using your preferred monorepo tooling.
 ---
 
+import ScopesDetection from '~/components/ScopesDetection.astro';
+
 If you're using monorepo tools that have built-in
 dependency graph analysis, you can leverage their affected project detection instead of using file
 patterns. This approach is often more accurate because these tools understand your project's
@@ -94,24 +96,7 @@ steps:
 
 ### Any CI (Mergify CLI)
 
-Install the [Mergify CLI](/cli/usage) in your pipeline and export `MERGIFY_TOKEN`.
-Use `mergify ci git-refs` to get the merge-queue-aware base and head SHAs and
-`mergify ci scopes-send` to upload the detected scopes:
-
-```bash
-REFS=$(mergify ci git-refs)
-BASE=$(echo "$REFS" | awk '/^Base:/ {print $2}')
-HEAD=$(echo "$REFS" | awk '/^Head:/ {print $2}')
-
-my_monorepo_command_to_get_impacted_projects "$BASE" "$HEAD" \
-  | jq -R -s '{scopes: split("\n") | map(select(length > 0))}' > scopes.json
-
-mergify ci scopes-send --file scopes.json
-```
-
-:::note
-In the context of merge queue pull requests, the `HEAD` and `BASE` git references are specifically
-calculated to detect changed projects in the current batch only, not in the batches this one depends
-on. This ensures that your monorepo tool identifies only the projects affected by the PRs in the
-current batch, allowing for more granular and efficient testing.
-:::
+<ScopesDetection
+  command={String.raw`my_monorepo_command_to_get_impacted_projects "$BASE" "$HEAD" \
+  | jq -R -s '{scopes: split("\n") | map(select(length > 0))}' > scopes.json`}
+/>

--- a/src/content/docs/merge-queue/scopes/turborepo.mdx
+++ b/src/content/docs/merge-queue/scopes/turborepo.mdx
@@ -3,6 +3,8 @@ title: Scopes with Turborepo
 description: Configure merge queue scopes using Turborepo's dependency graph awareness.
 ---
 
+import ScopesDetection from '~/components/ScopesDetection.astro';
+
 If you're using monorepo tools like Turborepo that have built-in
 dependency graph analysis, you can leverage their affected project detection instead of using file
 patterns. This approach is often more accurate because these tools understand your project's
@@ -94,24 +96,7 @@ steps:
 
 ### Any CI (Mergify CLI)
 
-Install the [Mergify CLI](/cli/usage) in your pipeline and export `MERGIFY_TOKEN`.
-Use `mergify ci git-refs` to get the merge-queue-aware base and head SHAs and
-`mergify ci scopes-send` to upload the detected scopes:
-
-```bash
-REFS=$(mergify ci git-refs)
-BASE=$(echo "$REFS" | awk '/^Base:/ {print $2}')
-HEAD=$(echo "$REFS" | awk '/^Head:/ {print $2}')
-
-npx turbo run build --dry=json --filter="[$BASE...$HEAD]" \
-  | jq '{scopes: .packages}' > scopes.json
-
-mergify ci scopes-send --file scopes.json
-```
-
-:::note
-In the context of merge queue pull requests, the `HEAD` and `BASE` git references are specifically
-calculated to detect changed projects in the current batch only, not in the batches this one depends
-on. This ensures that your monorepo tool identifies only the projects affected by the PRs in the
-current batch, allowing for more granular and efficient testing.
-:::
+<ScopesDetection
+  command={String.raw`npx turbo run build --dry=json --filter="[$BASE...$HEAD]" \
+  | jq '{scopes: .packages}' > scopes.json`}
+/>

--- a/src/content/docs/stacks.mdx
+++ b/src/content/docs/stacks.mdx
@@ -7,7 +7,7 @@ import Button from '~/components/Button.astro';
 import DocsetGrid from '~/components/DocsetGrid/DocsetGrid.astro';
 import Docset from '~/components/DocsetGrid/Docset.astro';
 import GitGraph from '~/components/GitGraph.astro';
-import Quickstart from './stacks/_quickstart.mdx';
+import CliInstall from '~/components/CliInstall.astro';
 
 AI can write 1,000 lines of code in minutes, but nobody wants to review a
 1,000-line pull request. Reviewers skim instead of reading, bugs slip through,
@@ -78,7 +78,7 @@ Your agent installs the CLI and the Stacks skill itself, then you prompt it as u
 
 **For yourself:**
 
-<Quickstart />
+<CliInstall steps={['mergify stack setup', 'mergify stack push']} />
 
 See the [setup guide](/stacks/setup) for the full walkthrough.
 

--- a/src/content/docs/stacks/_install-setup.mdx
+++ b/src/content/docs/stacks/_install-setup.mdx
@@ -1,4 +1,0 @@
-```bash
-curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
-mergify stack setup
-```

--- a/src/content/docs/stacks/_install.mdx
+++ b/src/content/docs/stacks/_install.mdx
@@ -1,3 +1,0 @@
-```bash
-curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
-```

--- a/src/content/docs/stacks/_quickstart.mdx
+++ b/src/content/docs/stacks/_quickstart.mdx
@@ -1,5 +1,0 @@
-```bash
-curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
-mergify stack setup
-mergify stack push
-```

--- a/src/content/docs/stacks/agents.mdx
+++ b/src/content/docs/stacks/agents.mdx
@@ -3,7 +3,7 @@ title: Stacks for AI Agents
 description: One-page bootstrap for AI coding agents — install the Mergify CLI and the Stacks skill.
 ---
 
-import Install from './_install.mdx';
+import CliInstall from '~/components/CliInstall.astro';
 
 You are an AI coding agent. Follow these three steps to enable stacked pull
 request support. After step 2, your skill system will contain the full Stacks
@@ -13,7 +13,7 @@ workflow. Consult it for any stack-related task.
 
 Install `mergify-cli` with the install script:
 
-<Install />
+<CliInstall />
 
 Verify:
 

--- a/src/content/docs/stacks/compare/gh-stack.mdx
+++ b/src/content/docs/stacks/compare/gh-stack.mdx
@@ -6,7 +6,7 @@ description: An honest comparison of Mergify Stacks and GitHub's gh-stack CLI fo
 import GitGraph from '~/components/GitGraph.astro';
 import StacksLocalModel from '~/components/StacksLocalModel.astro';
 import ComparisonLogo from '~/components/ComparisonLogo.astro';
-import InstallSetup from '../_install-setup.mdx';
+import CliInstall from '~/components/CliInstall.astro';
 
 <ComparisonLogo icon="simple-icons:github" alt="GitHub logo" />
 
@@ -148,7 +148,7 @@ commit per PR on a single branch."
 
 ### Install and setup
 
-<InstallSetup />
+<CliInstall steps={['mergify stack setup']} />
 
 This installs the CLI and adds a `commit-msg` hook that generates
 [Change-Ids](/stacks/concepts#change-id) for your commits. See the

--- a/src/content/docs/stacks/compare/graphite.mdx
+++ b/src/content/docs/stacks/compare/graphite.mdx
@@ -6,7 +6,7 @@ description: An honest comparison of Mergify Stacks and Graphite's stacking work
 import GitGraph from '~/components/GitGraph.astro';
 import StacksLocalModel from '~/components/StacksLocalModel.astro';
 import ComparisonLogo from '~/components/ComparisonLogo.astro';
-import InstallSetup from '../_install-setup.mdx';
+import CliInstall from '~/components/CliInstall.astro';
 
 <ComparisonLogo icon="simple-icons:graphite" alt="Graphite logo" />
 
@@ -202,7 +202,7 @@ is moving from "one branch per PR" to "one commit per PR on a single branch."
 
 ### Install and setup
 
-<InstallSetup />
+<CliInstall steps={['mergify stack setup']} />
 
 This installs the CLI and adds a `commit-msg` hook that generates
 [Change-Ids](/stacks/concepts#change-id) for your commits. See the

--- a/src/content/docs/stacks/compare/plain-git.mdx
+++ b/src/content/docs/stacks/compare/plain-git.mdx
@@ -7,8 +7,7 @@ import { Image } from 'astro:assets';
 import StacksLocalModel from '~/components/StacksLocalModel.astro';
 import ComparisonLogo from '~/components/ComparisonLogo.astro';
 import StackComment from '../../../images/stack-comment.png';
-import InstallSetup from '../_install-setup.mdx';
-import Quickstart from '../_quickstart.mdx';
+import CliInstall from '~/components/CliInstall.astro';
 
 <ComparisonLogo icon="simple-icons:git" alt="Git logo" />
 
@@ -123,7 +122,7 @@ If you already wrap `git rebase` and `gh pr create`, you don't have to throw
 anything away. Stacks runs on the same Git primitives, so you can adopt it
 incrementally:
 
-<InstallSetup />
+<CliInstall steps={['mergify stack setup']} />
 
 Setup installs the `commit-msg` hook that adds Change-Ids and a `pre-push` hook
 that nudges you toward `mergify stack push`. From there:
@@ -144,7 +143,7 @@ that nudges you toward `mergify stack push`. From there:
 
 ## Getting Started
 
-<Quickstart />
+<CliInstall steps={['mergify stack setup', 'mergify stack push']} />
 
 See the [setup guide](/stacks/setup) for the full walkthrough, or
 [Creating Stacks](/stacks/creating) to push your first stack.

--- a/src/content/docs/stacks/setup.mdx
+++ b/src/content/docs/stacks/setup.mdx
@@ -5,7 +5,7 @@ description: Install Mergify CLI and configure your repository for stacked PRs.
 
 import { Image } from 'astro:assets';
 import deleteHeadBranches from '../../images/github-delete-head-branches.png';
-import Install from './_install.mdx';
+import CliInstall from '~/components/CliInstall.astro';
 
 ## 1. Install the Mergify CLI
 
@@ -13,7 +13,7 @@ See the [CLI installation guide](/cli/usage) for full instructions.
 
 Quick install:
 
-<Install />
+<CliInstall />
 
 ## 2. Install skills for your AI coding agent
 


### PR DESCRIPTION
The CLI install command was copy-pasted across the stacks and CI docs,
and the monorepo scopes pages each repeated the same git-refs preamble,
scopes-send upload, and batch note around a tool-specific command.

Add two components that own the shared parts:
- CliInstall renders the install line from one constant, with an
  optional `steps` prop for follow-up commands (stack setup/push).
  Replaces the _install / _install-setup / _quickstart partials.
- ScopesDetection wraps the shared scopes-detection block; each page
  passes only its build-tool command. Bazel/Nx/Turborepo/other stay
  one edit each.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>