### PR TITLE
docs(merge-queue): document orphan queue-branch cleanup

### DIFF
--- a/src/content/docs/merge-queue/github-rulesets.mdx
+++ b/src/content/docs/merge-queue/github-rulesets.mdx
@@ -165,6 +165,13 @@ error.
   [`queue_branch_prefix`](/configuration/file-format/#queue-rules), substitute
   your prefix and its `tmp-` counterpart.
 
+:::note
+  Mergify also periodically deletes leftover queue branches that match these
+  prefixes. See [Queue Branch
+  Cleanup](/merge-queue/lifecycle#queue-branch-cleanup) for how branches are
+  matched and an important caveat about naming your own branches.
+:::
+
 ### Require Branches to Be Up to Date
 
 The `strict_required_status_checks_policy` setting (labeled *Require branches

--- a/src/content/docs/merge-queue/lifecycle.mdx
+++ b/src/content/docs/merge-queue/lifecycle.mdx
@@ -230,6 +230,42 @@ merge_queue:
   reset_on_external_merge: never
 ```
 
+## Queue Branch Cleanup
+
+To test a pull request, Mergify creates a queue branch, runs the required
+checks against it, and deletes that branch once the pull request leaves the
+queue. This deletion is normally immediate, triggered by a GitHub webhook.
+
+When that deletion fails, the queue branch is left behind. To keep these
+orphaned branches from piling up, Mergify periodically scans your
+repository for leftover queue branches and deletes them in the background.
+There is nothing to clean up by hand.
+
+### How Leftover Branches Are Matched
+
+Mergify identifies a leftover queue branch by its name alone. A branch is
+deleted only when **both** of the following are true:
+
+- Its name is the
+  [`queue_branch_prefix`](/configuration/file-format/#queue-rules), optionally
+  prefixed with `tmp-`, followed by exactly 10 hexadecimal characters
+  (`0`–`9`, `a`–`f`).
+
+- It is not in use by an active queue.
+
+With the default prefix, a matching branch looks like
+`mergify/merge-queue/a76b1f3d25`. With a custom `queue_branch_prefix` such as
+`mergify-`, it looks like `mergify-a76b1f3d25`. The temporary `tmp-` branch
+Mergify creates during setup (for example, `tmp-mergify/merge-queue/a76b1f3d25`)
+is matched the same way. A CI retry generates a fresh name of the same shape,
+with no extra suffix.
+
+:::caution
+  Matching is by name only: Mergify does not track which branches it created.
+  A branch **you** create will be deleted if its name matches the pattern
+  above. Avoid naming your own branches this way.
+:::
+
 ## Monitoring the Status of PRs in the Merge Queue
 
 To keep track of the status and progress of your pull requests in the merge


### PR DESCRIPTION
Add a "Queue Branch Cleanup" section to the lifecycle page describing the background sweep that deletes queue branches left behind when the post-merge webhook deletion fails. Document the match shape — queue_branch_prefix followed by exactly 10 hex characters and not in use by an active queue — and caution that a user branch matching that shape is deleted too.

Cross-link the section from the "Branch Name Pattern" section of the GitHub rulesets page.

MRGFY-7758

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>