### PR TITLE
docs(merge-queue): document skip_intermediate_results in parallel mode

### DIFF
--- a/src/content/docs/merge-queue/batches.mdx
+++ b/src/content/docs/merge-queue/batches.mdx
@@ -607,9 +607,13 @@ need every intermediate state validated for compliance, or while debugging CI
 and want to see all failures.
 
 :::note
-  `skip_intermediate_results` depends on the strict cumulative ordering of serial
-  mode and is not available in [parallel
-  mode](/merge-queue/queue-modes#parallel-mode).
+  `skip_intermediate_results` works in serial and [parallel
+  mode](/merge-queue/queue-modes#parallel-mode). In parallel mode it applies
+  within each [scope](/merge-queue/scopes), where batches build on one another: a
+  passing batch vouches for the earlier batches whose changes it includes, so they
+  still merge even if their own checks were flaky. It is not supported in [isolated
+  mode](/merge-queue/queue-modes#isolated-mode), where batches are fully
+  independent, so no batch can vouch for another.
 :::
 
 ## Important Considerations

--- a/src/content/docs/merge-queue/queue-modes.mdx
+++ b/src/content/docs/merge-queue/queue-modes.mdx
@@ -476,8 +476,9 @@ single-queue ordering are not available:
 - **`fast-forward` merge is not supported.** Because batches merge independently, Mergify needs to
   rebase them. Use `merge` or `rebase` as your `merge_method`.
 
-- **`skip_intermediate_results` is not available.** This feature depends on the strict cumulative
-  ordering of serial mode.
+- **`skip_intermediate_results` is not supported in isolated mode.** Isolated batches are fully
+  independent, so a passing batch can't vouch for another. It does work in parallel mode, where
+  batches sharing a scope build on one another.
 
 - **`partition_rules` are not supported.** Partitions rely on serial ordering; use scopes instead.
 


### PR DESCRIPTION
skip_intermediate_results is now supported in parallel mode and is
rejected only in isolated mode. Update the batches.mdx note and the
queue-modes compatibility bullet to match.

Fixes MRGFY-7684

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>