### PR TITLE
docs: clarify assignees and bot_account accept a login or the author shortcut

### DIFF
--- a/src/content/docs/workflow/actions/assign.mdx
+++ b/src/content/docs/workflow/actions/assign.mdx
@@ -16,9 +16,8 @@ pull requests that require their attention.
 
 <ActionOptionsTable def="AssignActionModel"/>
 
-As the list of users in `add_users` or `remove_users` is based on
-[templates](/configuration/data-types#legacy-template), you can use, e.g.,
-`{{author}}` to assign the pull request to its author.
+Each entry in `add_users` and `remove_users` is a GitHub login. You can also use
+`{{ author }}` to target the pull request author.
 
 :::caution
   Make sure the users you specify in the assign action have the necessary
@@ -57,5 +56,5 @@ pull_request_rules:
     actions:
       assign:
         add_users:
-          - "{{author}}"
+          - "{{ author }}"
 ```

--- a/src/content/docs/workflow/actions/backport.mdx
+++ b/src/content/docs/workflow/actions/backport.mdx
@@ -54,6 +54,12 @@ pull_request_rules:
           - "{{ author }}"
 ```
 
+:::note
+  In `assignees`, `{{ author }}` and `{{ merged_by }}` are built-in shortcuts for
+  the pull request author and its merger; `bot_account` accepts `{{ author }}`.
+  They resolve automatically.
+:::
+
 ### Combining Automatic Merge
 
 You can also combine the `backport` action with other actions like `merge`.


### PR DESCRIPTION
These fields take a GitHub login plus the blessed `{{ author }}` (and `{{ merged_by }}` for copy/backport assignees) literal, resolved statically; other Jinja2 in them is deprecated. assign.mdx wrongly framed add_users/remove_users as full Jinja2 templates linking to the legacy-template type. Reframe the description, canonicalize the `{{author}}` example, and add a clarifying note to the backport examples.

Fixes MRGFY-7794
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Depends-On: #11913