### PR TITLE
docs(cli-reference): document the completions command

### DIFF
--- a/src/components/CliReference/cli-schema.ts
+++ b/src/components/CliReference/cli-schema.ts
@@ -230,6 +230,7 @@ export const GROUP_ORDER: string[] = [
   'freeze',
   'config',
   'self-update',
+  'completions',
 ];
 
 /** Card/page headings — the CLI counterpart of `TAG_LABELS`. */
@@ -241,6 +242,7 @@ export const GROUP_LABELS: Record<string, string> = {
   freeze: 'Scheduled Freezes',
   config: 'Configuration',
   'self-update': 'Maintenance',
+  completions: 'Shell Completions',
 };
 
 /**
@@ -256,6 +258,7 @@ export const GROUP_DESCRIPTIONS: Record<string, string> = {
   freeze: 'Schedule and manage merge freezes for release windows and maintenance.',
   config: 'Validate your Mergify configuration and simulate actions before you merge.',
   'self-update': 'Update the Mergify CLI to the latest release.',
+  completions: 'Generate a shell completion script to tab-complete Mergify CLI commands and flags.',
 };
 
 /**


### PR DESCRIPTION
The CLI added a top-level `completions` command (prints a shell-completion
script). The schemas-sync bot picks it up automatically, but the editorial
gate — `every group has an editorial label and description` — blocks the sync
PR until the new command is given outward-facing copy.

Add the label, one-line value prop, and grid/nav order for `completions` so it
renders its own card and `/cli/completions` page alongside the other commands.
Unblocks the JSON-schema sync PR Mergifyio/docs#11933.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>