### PR TITLE
docs(api): generate a description for tags without editorial copy

### DIFF
--- a/src/components/ApiReference/openapi.ts
+++ b/src/components/ApiReference/openapi.ts
@@ -196,6 +196,14 @@ export function slugifyTag(tag: string): string {
   return tag.toLowerCase().replace(/_/g, '-');
 }
 
+/**
+ * Outward-facing tag description: editorial copy, else a generated sentence.
+ * Always non-blank, so a new tag renders on the index grid before it has copy.
+ */
+export function tagDescription(tag: string): string {
+  return TAG_DESCRIPTIONS[tag] || `${humanizeTag(tag)} endpoints for the Mergify API.`;
+}
+
 export function groupByTag(schema: OpenAPISpec): Map<string, GroupedEndpoint[]> {
   const groups = new Map<string, GroupedEndpoint[]>();
   const methods = ['get', 'post', 'put', 'delete', 'patch'];

--- a/src/pages/api/[tag].astro
+++ b/src/pages/api/[tag].astro
@@ -8,7 +8,7 @@ import {
   humanizeTag,
   preprocessSchema,
   slugifyTag,
-  TAG_DESCRIPTIONS,
+  tagDescription,
 } from '~/components/ApiReference/openapi';
 import MainLayout from '~/layouts/MainLayout.astro';
 import '~/styles/api-reference.css';
@@ -27,7 +27,7 @@ export function getStaticPaths() {
 const { tag, endpoints, schema } = Astro.props;
 const headings = getHeadingsForEndpoints(endpoints);
 const label = humanizeTag(tag);
-const description = TAG_DESCRIPTIONS[tag] ?? `${label} endpoints for the Mergify API.`;
+const description = tagDescription(tag);
 
 const content = {
   title: label,

--- a/src/pages/api/index.astro
+++ b/src/pages/api/index.astro
@@ -6,7 +6,7 @@ import {
   humanizeTag,
   preprocessSchema,
   slugifyTag,
-  TAG_DESCRIPTIONS,
+  tagDescription,
 } from '~/components/ApiReference/openapi';
 import MainLayout from '~/layouts/MainLayout.astro';
 import '~/styles/api-reference.css';
@@ -20,7 +20,7 @@ const sections = [...groups.entries()].map(([tag, endpoints]) => ({
   tag,
   label: humanizeTag(tag),
   slug: slugifyTag(tag),
-  description: TAG_DESCRIPTIONS[tag] ?? '',
+  description: tagDescription(tag),
   count: endpoints.length,
   methods: [...new Set(endpoints.map((e) => e.method))],
 }));


### PR DESCRIPTION
tagDescription resolves a tag's description as the editorial entry, then a
generated sentence; the index grid and tag pages route through it, so a tag with
no TAG_DESCRIPTIONS entry no longer renders a blank description on the grid.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #11939