### PR TITLE
docs(billing): make contributor-count script work on GHES

### DIFF
--- a/public/mergify-count-contributors.py
+++ b/public/mergify-count-contributors.py
@@ -5,6 +5,9 @@
 # 30 days, either by opening it or by pushing commits to it. This matches how
 # Mergify counts active users for billing.
 #
+# It works with both GitHub.com and GitHub Enterprise Server (GHES): the API
+# endpoint is derived automatically from each repository URL you pass.
+#
 # See https://docs.mergify.com/billing/ for context.
 #
 # Keep in mind that this is not 100% accurate but gives a ballpark estimate.
@@ -13,82 +16,115 @@
 # You can install requests by running:
 # $ pip install requests
 # then run this script with:
-# $ python3 mergify-count-contributors <url of your repo>
+# $ python3 mergify-count-contributors.py <url of your repo>
+#
+# Environment variables:
+# - GITHUB_TOKEN: a token that can read the repositories (required).
+# - GITHUB_SKIP_SSL_VERIFY: set to "1" to disable TLS certificate verification.
+#   Useful for GHES installations that serve a self-signed or internal-CA
+#   certificate. Disabling verification is insecure; prefer trusting the CA.
 
 import collections
-import requests
-import pprint
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
+import requests
+from urllib3.exceptions import InsecureRequestWarning
+
 LOOKBACK_WINDOW = timedelta(days=30)
-SINCE_DATE = datetime.now() - LOOKBACK_WINDOW
+# GitHub timestamps are in UTC, so compare against an explicit UTC "now".
+SINCE_DATE = datetime.now(timezone.utc) - LOOKBACK_WINDOW
 
 HEADERS = {
     "Authorization": f"token {os.environ.get('GITHUB_TOKEN')}",
-    "Accept": "application/vnd.github.v3+json",
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
 }
+
+# GHES installations commonly use a self-signed or internal-CA certificate. Let
+# users opt out of TLS verification when they cannot install the CA locally.
+VERIFY_SSL = os.environ.get("GITHUB_SKIP_SSL_VERIFY", "").lower() not in (
+    "1",
+    "true",
+    "yes",
+)
+if not VERIFY_SSL:
+    # Only silence the "insecure request" warning, so other warnings still surface.
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)  # type: ignore[attr-defined]
 
 
 def get_api_and_repo_name_from_url(url):
-    parsed = urlparse(url)
-    if parsed.netloc.lower() == "github.com":
-        host = "https://api.github.com"
-    else:
-        host = f"https://{parsed.netloc}/api/v3"
+    """Derive the REST API endpoint and "owner/repo" name from a repository URL.
 
-    return host, parsed.path.strip("/")
+    Supports github.com, GitHub Enterprise Cloud with data residency
+    (``*.ghe.com``), and GitHub Enterprise Server (any other host, served under
+    ``/api/v3``).
+    """
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    scheme = parsed.scheme or "https"
+
+    if host in ("github.com", "www.github.com"):
+        api_endpoint = "https://api.github.com"
+    elif host.endswith(".ghe.com"):
+        # GitHub Enterprise Cloud with data residency.
+        api_endpoint = f"{scheme}://api.{host}"
+    else:
+        # GitHub Enterprise Server: the REST API lives under /api/v3.
+        api_endpoint = f"{scheme}://{parsed.netloc}/api/v3"
+
+    return api_endpoint, parsed.path.strip("/")
 
 
 def _requests_get(*args, **kwargs):
+    kwargs.setdefault("headers", HEADERS)
+    kwargs.setdefault("verify", VERIFY_SSL)
     try:
-        response = requests.get(
-            *args,
-            **kwargs,
-        )
+        response = requests.get(*args, **kwargs)
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
-        print("E: Unable to request GitHub: {e}")
+        print(f"E: Unable to request GitHub: {e}")
         raise
     else:
         return response
 
 
-def get_active_prs_for_repo(api_endpoint, repo_name):
+def _iter_pages(url, params=None):
+    """Yield items page by page, incrementing ``page`` until a short page is returned."""
+    params = dict(params or {})
+    params.setdefault("per_page", 100)
     page = 1
-    prs = []
     while True:
-        try:
-            response = _requests_get(
-                f"{api_endpoint}/repos/{repo_name}/pulls",
-                headers=HEADERS,
-                params={
-                    "state": "all",
-                    "page": page,
-                    "per_page": 100,
-                    "sort": "created",
-                    "direction": "desc",
-                },
+        params["page"] = page
+        response = _requests_get(url, params=params)
+        items = response.json()
+        yield from items
+        # Stop once a short page is returned: there is nothing left to fetch.
+        if len(items) < params["per_page"]:
+            return
+        page += 1
+
+
+def get_active_prs_for_repo(api_endpoint, repo_name):
+    prs = []
+    try:
+        pulls = _iter_pages(
+            f"{api_endpoint}/repos/{repo_name}/pulls",
+            params={"state": "all", "sort": "created", "direction": "desc"},
+        )
+        for pr in pulls:
+            created_at = datetime.fromisoformat(
+                pr["created_at"].replace("Z", "+00:00")
             )
-            response.raise_for_status()
-        except Exception:
-            print("W: Unable to retrieve PR list, ignoring")
-        else:
-            # No more PR
-            pr_list = response.json()
-            for pr in pr_list:
-                created_at = datetime.fromisoformat(pr["created_at"].rstrip("Z"))
-                if created_at >= SINCE_DATE:
-                    prs.append(pr)
-                else:
-                    return prs
-
-            # Last page, quit
-            if len(pr_list) < 100:
-                return prs
-
-            page += 1
+            if created_at >= SINCE_DATE:
+                prs.append(pr)
+            else:
+                # PRs are sorted newest first: once we cross the window, stop.
+                break
+    except Exception as e:
+        print(f"W: Unable to retrieve PR list, ignoring: {e}")
+    return prs
 
 
 def is_user_ignored(user):
@@ -114,18 +150,15 @@ def get_users_from_pr(api_endpoint, repo_name, pr):
     # push; the commit author and committer are the closest proxy available
     # from the API.
     try:
-        commits_response = _requests_get(
-            f"{api_endpoint}/repos/{repo_name}/pulls/{pr['number']}/commits?per_page=100",
-            headers=HEADERS,
+        commits = _iter_pages(
+            f"{api_endpoint}/repos/{repo_name}/pulls/{pr['number']}/commits"
         )
-        commits_response.raise_for_status()
-    except Exception:
-        print("W: Unable to retrieve PR commits, ignoring")
-    else:
-        for commit in commits_response.json():
+        for commit in commits:
             for actor in (commit.get("author"), commit.get("committer")):
                 if actor and not is_user_ignored(actor):
                     users.add(actor["login"])
+    except Exception as e:
+        print(f"W: Unable to retrieve PR commits, ignoring: {e}")
 
     return users
 
@@ -146,11 +179,14 @@ def main(repos):
             active_users_per_repo[repo] |= get_users_from_pr(api_endpoint, repo, pr)
 
     print(f"Active users since {SINCE_DATE}:")
-    pprint.pprint(active_users_per_repo)
+    for repo, users in active_users_per_repo.items():
+        print(f"  {repo}: {sorted(users)}")
 
-    unique_users = set().union(*active_users_per_repo.values())
+    unique_users = set()
+    for users in active_users_per_repo.values():
+        unique_users |= users
     print("*** Unique users:")
-    pprint.pprint(unique_users)
+    print(f"  {sorted(unique_users)}")
     print(f"*** Total unique users: {len(unique_users)}")
 
 

--- a/src/content/docs/billing.mdx
+++ b/src/content/docs/billing.mdx
@@ -46,8 +46,9 @@ days.
 
 1. Go to
    [https://github.com/settings/tokens](https://github.com/settings/tokens) (or
-   equivalent on your GHES installation) to create a token. The token must have
-   the permissions to access the repository (read permission is enough);
+   the equivalent page on your GitHub Enterprise Server installation, at
+   `https://<your-ghes-host>/settings/tokens`) to create a token. The token must
+   have the permissions to access the repository (read permission is enough);
 
 2. Export the token as an environment variable with `export
    GITHUB_TOKEN=<your-token>`;
@@ -57,11 +58,22 @@ days.
 
 4. Run the script with `python3 mergify-count-contributors.py <repo1-url>
    <repo2-url> etc`, passing the list of repositories where Mergify will be
-   deployed.
+   deployed. Use the full repository URLs, including the host, so the script can
+   reach the right API endpoint (for example
+   `https://github.com/org/repo` for GitHub.com or
+   `https://github.example.com/org/repo` for GitHub Enterprise Server).
 
 The script will run and print its progress. It can take several minutes for the
 script to complete depending on the number of repositories scanned and the
 number of active pull requests they have.
+
+:::note
+  The script automatically targets the GitHub Enterprise Server REST API
+  (`https://<your-ghes-host>/api/v3`) based on the repository URLs you pass. If
+  your installation serves a self-signed or internal-CA certificate, you can
+  disable TLS verification by setting `export GITHUB_SKIP_SSL_VERIFY=1` before
+  running the script.
+:::
 
 :::caution
   This script provides an **approximate estimate** of the number of users that


### PR DESCRIPTION
Fix the contributor estimation script so it runs reliably against GitHub
Enterprise Server, and document the GHES specifics.

Script:
- Support self-signed/internal-CA certs via GITHUB_SKIP_SSL_VERIFY
- Preserve the URL scheme and handle www.github.com and *.ghe.com data
  residency when deriving the API endpoint
- Compare PR timestamps in UTC instead of local time
- Paginate the PR commits endpoint to avoid undercounting contributors
- Fix uninterpolated f-string in the error path and minor cleanups

Docs:
- Document the GHES token page, full-URL requirement, and the
  GITHUB_SKIP_SSL_VERIFY flag for self-signed certificates

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>