### PR TITLE
docs: reframe assign/bot_account/assignees as simple-template fields

### DIFF
--- a/src/components/Tables/ConfigOptions.tsx
+++ b/src/components/Tables/ConfigOptions.tsx
@@ -27,9 +27,12 @@ const valueTypeFormatLinks: { [key: string]: string } = {
 // the title as the field type, linking to the matching data-types section.
 const simpleTemplateTitleLinks: { [key: string]: string } = {
   'Message template': '/configuration/data-types#message-template',
-  'Copy title template': '/configuration/data-types#copy-title-template',
-  'Copy body template': '/configuration/data-types#copy-body-template',
+  'Title template': '/configuration/data-types#title-template',
+  'Body template': '/configuration/data-types#body-template',
   'Workflow input template': '/configuration/data-types#workflow-input-template',
+  User: '/configuration/data-types#user',
+  Assignee: '/configuration/data-types#assignee',
+  'Bot account': '/configuration/data-types#bot-account',
 };
 
 export type OptionDefinitionRef = string;

--- a/src/content/docs/configuration/data-types.mdx
+++ b/src/content/docs/configuration/data-types.mdx
@@ -291,14 +291,14 @@ message fields.
 
 <TemplateVariablesTable def="CommentActionModel" field="message" />
 
-### Copy title template
+### Title template
 
 Used by the [`copy`](/workflow/actions/copy) and
 [`backport`](/workflow/actions/backport) `title` field.
 
 <TemplateVariablesTable def="CopyActionModel" field="title" />
 
-### Copy body template
+### Body template
 
 Used by the [`copy`](/workflow/actions/copy) and
 [`backport`](/workflow/actions/backport) `body` field.
@@ -311,6 +311,37 @@ Used by the [`github_actions`](/workflow/actions/github_actions) workflow input
 values.
 
 <TemplateVariablesTable def="GhaActionModelDispatch" field="inputs" />
+
+### User
+
+A GitHub login. You can also use the `{{ author }}` variable to target the pull
+request author. Used by the [`assign`](/workflow/actions/assign) `users`,
+`add_users` and `remove_users` fields.
+
+<TemplateVariablesTable def="AssignActionModel" field="add_users" />
+
+### Assignee
+
+A GitHub login. You can also use `{{ author }}` (the pull request author) and
+`{{ merged_by }}` (the user who merged the original pull request). Used by the
+[`copy`](/workflow/actions/copy) and [`backport`](/workflow/actions/backport)
+`assignees` field.
+
+<TemplateVariablesTable def="CopyActionModel" field="assignees" />
+
+### Bot account
+
+A GitHub login Mergify impersonates to perform an action. You can also use the
+`{{ author }}` variable to act as the pull request author. Used by the
+`bot_account` field of the [`comment`](/workflow/actions/comment),
+[`edit`](/workflow/actions/edit), [`copy`](/workflow/actions/copy),
+[`merge`](/workflow/actions/merge), [`rebase`](/workflow/actions/rebase),
+[`request_reviews`](/workflow/actions/request_reviews),
+[`review`](/workflow/actions/review), [`squash`](/workflow/actions/squash) and
+[`update`](/workflow/actions/update) actions, and the merge queue
+`draft_bot_account`, `merge_bot_account` and `update_bot_account`.
+
+<TemplateVariablesTable def="CommentActionModel" field="bot_account" />
 
 ### Legacy template
 

--- a/src/content/docs/workflow/actions/assign.mdx
+++ b/src/content/docs/workflow/actions/assign.mdx
@@ -16,9 +16,10 @@ pull requests that require their attention.
 
 <ActionOptionsTable def="AssignActionModel"/>
 
-As the list of users in `add_users` or `remove_users` is based on
-[templates](/configuration/data-types#legacy-template), you can use, e.g.,
-`{{author}}` to assign the pull request to its author.
+Each entry in `users`, `add_users` or `remove_users` is a
+[`User`](/configuration/data-types#user): a GitHub login, or the `{{ author }}`
+variable to assign the pull request to its author. Other Jinja2 templating in
+these fields is deprecated.
 
 :::caution
   Make sure the users you specify in the assign action have the necessary
@@ -57,5 +58,5 @@ pull_request_rules:
     actions:
       assign:
         add_users:
-          - "{{author}}"
+          - "{{ author }}"
 ```


### PR DESCRIPTION
After MRGFY-7796 migrated assignees and bot_account off blessed literals to the
simple-template framework, document them as simple-template field types instead
of full Jinja2 templates:

- data-types.mdx: add `User` / `Assignee` / `Bot account` sections; rename the
  copy/backport title & body sections to `Title template` / `Body template`
  (the engine renamed those types).
- assign.mdx: `add_users`/`remove_users` are a `User` (a GitHub login or the
  `{{ author }}` variable), not a legacy Jinja2 template; canonicalize the
  `{{ author }}` example.
- ConfigOptions.tsx: link the new/renamed simple-template titles to their
  data-types sections.

The per-field variable tables and field-type links populate once the config
schema syncs from the merged engine PRs.

Fixes MRGFY-7794
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>