### PR TITLE
docs: use a static label example for target-branch labeling

### DIFF
--- a/src/content/docs/workflow/actions/label.mdx
+++ b/src/content/docs/workflow/actions/label.mdx
@@ -92,16 +92,17 @@ pull_request_rules:
           - "CI:fail"
 ```
 
-### Add A Label Based on The Name of The Branch
+### Add A Label Based on The Target Branch
 
-This rule add a label with the name of the branch.
+This rule adds a static label to pull requests targeting a given branch.
 
 ```yaml
 pull_request_rules:
-  - name: add a label with the name of the branch
-    conditions: []
+  - name: label pull requests targeting the release branch
+    conditions:
+      - base = release
     actions:
       label:
         add:
-          - "branch:{{base}}"
+          - "release"
 ```


### PR DESCRIPTION
Replace the `label` action's "Add A Label Based on The Name of The
Branch" example (`add: - "branch:{{base}}"`) with a static `release`
label gated by a `base = release` condition.

Related to MRGFY-7822

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>