### PR TITLE
docs: fix Jinja2 mislabeling and drop deprecated Jinja2 examples

### DIFF
--- a/src/content/docs/configuration/data-types.mdx
+++ b/src/content/docs/configuration/data-types.mdx
@@ -17,15 +17,7 @@ commit](https://docs.github.com/en/pull-requests/committing-changes-to-your-proj
 
 <OptionsTable def="Commit" />
 
-You can use a commit object in templates:
-
-```jinja
-{% for commit in commits %}
-Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
-{% endfor %}
-```
-
-You can also use those objects in conditions:
+You can use commit objects in conditions:
 
 ```yaml
 pull_request_rules:

--- a/src/content/docs/workflow/actions/assign.mdx
+++ b/src/content/docs/workflow/actions/assign.mdx
@@ -18,8 +18,7 @@ pull requests that require their attention.
 
 Each entry in `users`, `add_users` or `remove_users` is a
 [`User`](/configuration/data-types#user): a GitHub login, or the `{{ author }}`
-variable to assign the pull request to its author. Other Jinja2 templating in
-these fields is deprecated.
+variable to assign the pull request to its author.
 
 :::caution
   Make sure the users you specify in the assign action have the necessary

--- a/src/content/docs/workflow/rule-syntax.mdx
+++ b/src/content/docs/workflow/rule-syntax.mdx
@@ -54,15 +54,16 @@ pull_request_rules:
       - conflict
     actions:
       comment:
-        message: "@{{author}} this pull request is now in conflict 😩"
+        message: "@{{ author }} this pull request is now in conflict 😩"
       label:
         toggle:
           - conflict
 ```
 
-The `{{author}}` placeholder is a [template](/configuration/data-types#legacy-template)
-that Mergify fills in with the pull request's data. Browse every available
-action and its parameters in the [Actions catalog](/workflow/actions).
+The `{{ author }}` placeholder uses [variable
+substitution](/configuration/data-types#variable-substitution): Mergify fills it
+in with the pull request's data. Browse every available action and its
+parameters in the [Actions catalog](/workflow/actions).
 
 ## Combining Rules
 


### PR DESCRIPTION
- rule-syntax: the `{{ author }}` placeholder in the comment.message
  example is variable substitution, not a legacy template; relabel it,
  link to #variable-substitution, and normalize the spacing to
  `{{ author }}`.
- assign: drop the "Other Jinja2 templating ... is deprecated" sentence
  (users/add_users accept only `{{ author }}`, never general Jinja2).
- data-types (Commit): remove the `{% for commit in commits %}`
  Co-Authored-By Jinja2 example; the static replacement is merge's
  `commit_message_format` trailers. Keep the conditions example.

Fixes MRGFY-7826

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>