### PR TITLE
docs: document Mergifyio/setup-cli GitHub Action for CLI install

### DIFF
--- a/src/content/docs/cli/usage.mdx
+++ b/src/content/docs/cli/usage.mdx
@@ -44,6 +44,40 @@ Download `mergify-<version>-x86_64-pc-windows-msvc.zip` from the
 [latest release](https://github.com/Mergifyio/mergify-cli/releases/latest),
 extract it, and put `mergify.exe` anywhere on your `PATH`.
 
+### GitHub Actions
+
+To install the CLI in a GitHub Actions workflow, use the
+[`Mergifyio/setup-cli`](https://github.com/Mergifyio/setup-cli) action. It
+downloads the prebuilt `mergify` binary, verifies it against the release
+`SHA256SUMS`, and adds it to the `PATH`. No Python or extra toolchain is
+required, and it runs on Linux and macOS runners.
+
+```yaml
+- uses: Mergifyio/setup-cli@v2
+- run: mergify --version
+```
+
+By default the action installs a pinned version, which keeps your CI
+reproducible. Set the `mergify_cli_version` input to `latest` to install the
+newest release instead. The action also exposes the version it actually
+installed as the `mergify_cli_version` output:
+
+```yaml
+- uses: Mergifyio/setup-cli@v2
+  id: setup-cli
+  with:
+    mergify_cli_version: latest
+
+- run: echo "Installed mergify-cli ${{ steps.setup-cli.outputs.mergify_cli_version }}"
+```
+
+:::tip
+  Pinning a specific version is the default and works well with
+  [Renovate](https://docs.renovatebot.com/), which can open pull requests to
+  bump the version as new releases ship. Use `latest` only when you always want
+  the most recent build.
+:::
+
 ## Authentication
 
 The CLI needs an authentication token to interact with your repositories.

--- a/src/content/docs/merge-queue/batches.mdx
+++ b/src/content/docs/merge-queue/batches.mdx
@@ -500,7 +500,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install the Mergify CLI
-        uses: Mergifyio/setup-cli@v1
+        uses: Mergifyio/setup-cli@v2
 
       - name: Read the merge queue metadata
         id: queue-info


### PR DESCRIPTION
Add a GitHub Actions installation section to the CLI usage page covering
the Mergifyio/setup-cli action: pinned-version usage, the
mergify_cli_version input/output, and Renovate-based updates. Pin the
existing batches.mdx example to the same v2 tag for consistency.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>