### PR TITLE
docs: document per-attribute condition operators and modifiers

### DIFF
--- a/src/components/Tables/PullRequestAttributes.tsx
+++ b/src/components/Tables/PullRequestAttributes.tsx
@@ -3,12 +3,79 @@ import { getValueType } from './ConfigOptions';
 
 import { renderMarkdown } from './utils';
 
+// The engine annotates each condition attribute with its authoritative operators
+// and modifiers (`x-allowed-operators` / `x-modifiers`). The generated TypeScript
+// types drop `x-` keys, so they are read from the imported JSON via this shape.
+interface ConditionMeta {
+  'x-allowed-operators'?: string[];
+  'x-modifiers'?: {
+    negate: 'forbidden' | 'optional';
+    length: 'forbidden' | 'optional' | 'required';
+  };
+}
+
 interface Props {
   staticAttributes: typeof configSchema.$defs.PullRequestAttributes.properties;
 }
 
+function renderOperators(operators: string[]) {
+  if (operators.length === 0) {
+    // Boolean attributes take no operator: used on their own or negated with `-`.
+    return <span title="No operator — used on its own or negated">—</span>;
+  }
+
+  return operators.flatMap((operator, index) => {
+    const chip = (
+      <code key={operator} style={{ whiteSpace: 'nowrap' }}>
+        {operator}
+      </code>
+    );
+    return index === 0 ? [chip] : [' ', chip];
+  });
+}
+
+function renderModifiers(modifiers: ConditionMeta['x-modifiers']) {
+  if (!modifiers) {
+    return <span>—</span>;
+  }
+
+  const parts: React.ReactNode[] = [];
+  if (modifiers.negate === 'optional') {
+    parts.push(<code key="negate">-</code>);
+  }
+  if (modifiers.length === 'optional') {
+    parts.push(<code key="length">#</code>);
+  } else if (modifiers.length === 'required') {
+    parts.push(
+      <span key="length" style={{ whiteSpace: 'nowrap' }}>
+        <code>#</code> (required)
+      </span>
+    );
+  }
+
+  if (parts.length === 0) {
+    return <span>—</span>;
+  }
+
+  return parts.flatMap((part, index) => (index === 0 ? [part] : [' ', part]));
+}
+
 export default function PullRequestAttributes({ staticAttributes }: Props) {
   const attributes = staticAttributes ?? configSchema.$defs.PullRequestAttributes.properties;
+
+  const entries = Object.entries(attributes).sort(([keyA], [keyB]) => (keyA > keyB ? 1 : -1));
+
+  // Only render the operator/modifier columns once the schema carries the
+  // metadata. Until then (or if a sync drops it), fall back to the bare table.
+  const hasConditionMetadata = entries.some(([, value]) =>
+    Array.isArray((value as ConditionMeta)['x-allowed-operators'])
+  );
+
+  // Attributes without `x-allowed-operators` (e.g. `check`, `co-authors`) are not
+  // valid condition operands, so drop them once the metadata is available.
+  const rows = hasConditionMetadata
+    ? entries.filter(([, value]) => Array.isArray((value as ConditionMeta)['x-allowed-operators']))
+    : entries;
 
   return (
     <div className="table-wrap">
@@ -17,28 +84,33 @@ export default function PullRequestAttributes({ staticAttributes }: Props) {
           <tr>
             <th>Attribute name</th>
             <th>Value type</th>
+            {hasConditionMetadata && <th>Operators</th>}
+            {hasConditionMetadata && <th>Modifiers</th>}
             <th>Description</th>
           </tr>
         </thead>
         <tbody>
-          {Object.entries(attributes)
-            .sort(([keyA, _valueA], [keyB, _valueB]) => (keyA > keyB ? 1 : -1))
-            .map(([key, value]) => {
-              const valueType = getValueType(configSchema, value);
+          {rows.map(([key, value]) => {
+            const valueType = getValueType(configSchema, value);
+            const meta = value as ConditionMeta;
 
-              return (
-                <tr key={key}>
-                  <td style={{ whiteSpace: 'nowrap' }}>
-                    <code>{key}</code>
-                  </td>
-                  <td>{valueType}</td>
-                  <td
-                    dangerouslySetInnerHTML={{ __html: renderMarkdown(value.description) }}
-                    style={{ width: '100%' }}
-                  />
-                </tr>
-              );
-            })}
+            return (
+              <tr key={key}>
+                <td style={{ whiteSpace: 'nowrap' }}>
+                  <code>{key}</code>
+                </td>
+                <td>{valueType}</td>
+                {hasConditionMetadata && (
+                  <td>{renderOperators(meta['x-allowed-operators'] ?? [])}</td>
+                )}
+                {hasConditionMetadata && <td>{renderModifiers(meta['x-modifiers'])}</td>}
+                <td
+                  dangerouslySetInnerHTML={{ __html: renderMarkdown(value.description) }}
+                  style={{ width: '100%' }}
+                />
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/src/content/docs/configuration/conditions.mdx
+++ b/src/content/docs/configuration/conditions.mdx
@@ -18,8 +18,13 @@ The grammar for a condition is:
 
 ### Modifiers
 
-- The optional minus (`-`) prefix negates the condition ("not").
-- The optional hash (`#`) prefix evaluates the length of a list attribute.
+- The optional minus (`-`) prefix negates the condition ("not"). Time-based
+  attributes (timestamps, `schedule`, and `current-datetime`) cannot be negated
+  this way.
+
+- The optional hash (`#`) prefix evaluates the length of an attribute (for
+  example, the number of items in a list). The `commits-behind` attribute is
+  only available in this counted form and always requires the `#` prefix.
 
 ### Attributes
 

--- a/src/content/docs/configuration/data-types.mdx
+++ b/src/content/docs/configuration/data-types.mdx
@@ -122,6 +122,12 @@ standard](https://en.wikipedia.org/wiki/ISO_8601). If the timezone is missing,
 the timestamp is assumed to be in UTC. The supported timezones come from the
 [IANA database](https://www.iana.org/time-zones).
 
+:::caution
+Timestamp attributes support only the ordering operators `>=`, `<=`, `<`, and
+`>`. The `=` and `!=` operators are not available, and timestamps cannot be
+negated with the `-` prefix.
+:::
+
 Supported formats:
 
 ```text


### PR DESCRIPTION
Surface the engine's authoritative per-attribute operator and modifier
rules in the conditions documentation.

- Add Operators and Modifiers columns to the pull request attributes
  table, read from the schema's x-allowed-operators / x-modifiers
  annotations. The columns feature-detect: they appear automatically once
  the schema sync carries the keys, and the table falls back to its
  current form until then.
- Drop check and co-authors from the table once the metadata is present;
  they are not valid condition operands.
- Correct the modifier description: the # prefix evaluates the length of
  an attribute (not only lists), and commits-behind is only valid in this
  counted form; time-based attributes cannot be negated with -.
- Add a Timestamp caution: only the ordering operators >= <= < > are
  supported (not = / !=), and timestamps cannot be negated.

Related to MRGFY-7843
Related to MRGFY-7844

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>