### PR TITLE
docs(conditions): add per-row anchors to the attributes tables

### DIFF
--- a/src/components/Tables/OptionsTable.tsx
+++ b/src/components/Tables/OptionsTable.tsx
@@ -18,7 +18,7 @@ export default function OptionsTable({ def }: Def) {
   return OptionsTableBase(configSchema, options, def);
 }
 
-function defToIdPrefix(def: string): string {
+export function defToIdPrefix(def: string): string {
   return def.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
 }
 

--- a/src/components/Tables/PullRequestAttributes.module.css
+++ b/src/components/Tables/PullRequestAttributes.module.css
@@ -1,0 +1,33 @@
+.row {
+  scroll-margin-top: calc(var(--theme-navbar-height) + 1rem);
+}
+
+.row:target > td {
+  background-color: color-mix(in srgb, var(--section-accent) 6%, transparent);
+}
+
+.name {
+  white-space: nowrap;
+}
+
+.anchor {
+  margin-left: 0.4rem;
+  color: var(--theme-text-muted);
+  text-decoration: none;
+  font-weight: 500;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease;
+}
+
+.anchor:hover,
+.anchor:focus {
+  color: var(--theme-link);
+}
+
+.row:hover .anchor,
+.row:focus-within .anchor,
+.row:target .anchor {
+  opacity: 1;
+}

--- a/src/components/Tables/PullRequestAttributes.tsx
+++ b/src/components/Tables/PullRequestAttributes.tsx
@@ -1,6 +1,8 @@
 import { getAttributeSource } from '../../util/attributeMetadata';
 import configSchema from '../../util/sanitizedConfigSchema';
 import { getValueType } from './ConfigOptions';
+import { defToIdPrefix } from './OptionsTable';
+import styles from './PullRequestAttributes.module.css';
 
 import { renderMarkdown } from './utils';
 
@@ -16,6 +18,10 @@ interface ConditionMeta {
     length: 'forbidden' | 'optional' | 'required';
   };
 }
+
+// Mirror the config-option anchor scheme: `<def>-<key>`, e.g.
+// `pull-request-attributes-author`.
+const ID_PREFIX = defToIdPrefix('PullRequestAttributes');
 
 interface Props {
   staticAttributes?: Attributes;
@@ -108,11 +114,16 @@ export default function PullRequestAttributes({ staticAttributes, source }: Prop
           {rows.map(([key, value]) => {
             const valueType = getValueType(configSchema, value);
             const meta = value as ConditionMeta;
+            const id = `${ID_PREFIX}-${key}`;
+            const href = `#${encodeURIComponent(id)}`;
 
             return (
-              <tr key={key}>
-                <td style={{ whiteSpace: 'nowrap' }}>
+              <tr key={key} id={id} className={styles.row}>
+                <td className={styles.name}>
                   <code>{key}</code>
+                  <a className={styles.anchor} href={href} aria-label={`Link to ${key}`}>
+                    #
+                  </a>
                 </td>
                 <td>{valueType}</td>
                 {hasConditionMetadata && (

--- a/src/components/Tables/PullRequestAttributes.tsx
+++ b/src/components/Tables/PullRequestAttributes.tsx
@@ -1,7 +1,10 @@
+import { getAttributeSource } from '../../util/attributeMetadata';
 import configSchema from '../../util/sanitizedConfigSchema';
 import { getValueType } from './ConfigOptions';
 
 import { renderMarkdown } from './utils';
+
+type Attributes = typeof configSchema.$defs.PullRequestAttributes.properties;
 
 // The engine annotates each condition attribute with its authoritative operators
 // and modifiers (`x-allowed-operators` / `x-modifiers`). The generated TypeScript
@@ -15,7 +18,10 @@ interface ConditionMeta {
 }
 
 interface Props {
-  staticAttributes: typeof configSchema.$defs.PullRequestAttributes.properties;
+  staticAttributes?: Attributes;
+  // When set, render only attributes whose metadata source matches (e.g. "github").
+  // When unset, render only attributes that have no source (config-writable ones).
+  source?: string;
 }
 
 function renderOperators(operators: string[]) {
@@ -60,8 +66,17 @@ function renderModifiers(modifiers: ConditionMeta['x-modifiers']) {
   return parts.flatMap((part, index) => (index === 0 ? [part] : [' ', part]));
 }
 
-export default function PullRequestAttributes({ staticAttributes }: Props) {
-  const attributes = staticAttributes ?? configSchema.$defs.PullRequestAttributes.properties;
+export default function PullRequestAttributes({ staticAttributes, source }: Props) {
+  // The search-highlight path passes a pre-filtered subset; render it as-is.
+  // Otherwise partition the canonical list by metadata source.
+  const attributes =
+    staticAttributes ??
+    (Object.fromEntries(
+      Object.entries(configSchema.$defs.PullRequestAttributes.properties).filter(([, value]) => {
+        const attributeSource = getAttributeSource(value);
+        return source ? attributeSource === source : attributeSource === undefined;
+      })
+    ) as Attributes);
 
   const entries = Object.entries(attributes).sort(([keyA], [keyB]) => (keyA > keyB ? 1 : -1));
 

--- a/src/content/docs/configuration/conditions.mdx
+++ b/src/content/docs/configuration/conditions.mdx
@@ -67,7 +67,22 @@ Boolean attributes are used on their own or negated with `-`:
 
 ## Attributes List
 
+Conditions are evaluated against the following pull request attributes, split
+into Mergify attributes and a read-only set loaded from GitHub.
+
+### Mergify Attributes
+
 <PullRequestAttributesTable />
+
+### GitHub Rulesets and Branch Protection Attributes
+
+Mergify loads these attributes from the GitHub rulesets and branch protection
+rules active on the pull request's base branch. They are read-only: Mergify
+populates their values from GitHub, so you cannot set them in your
+configuration. Use them in conditions to gate on the same review and protection
+requirements that GitHub enforces.
+
+<PullRequestAttributesTable source="github" />
 
 ## Operators List
 

--- a/src/util/attributeMetadata.test.ts
+++ b/src/util/attributeMetadata.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+import { getAttributeSource } from './attributeMetadata';
+
+describe('getAttributeSource', () => {
+  test('returns the source when present', () => {
+    expect(getAttributeSource({ 'x-mergify-attribute-metadata': { source: 'github' } })).toBe(
+      'github'
+    );
+  });
+
+  test('returns undefined when the attribute has no metadata', () => {
+    expect(getAttributeSource({ type: 'boolean' })).toBeUndefined();
+  });
+
+  test('returns undefined for a missing or malformed source', () => {
+    expect(getAttributeSource({ 'x-mergify-attribute-metadata': {} })).toBeUndefined();
+    expect(getAttributeSource({ 'x-mergify-attribute-metadata': { source: 42 } })).toBeUndefined();
+  });
+
+  test('returns undefined for non-object input', () => {
+    expect(getAttributeSource(null)).toBeUndefined();
+    expect(getAttributeSource('github')).toBeUndefined();
+  });
+});

--- a/src/util/attributeMetadata.ts
+++ b/src/util/attributeMetadata.ts
@@ -1,0 +1,23 @@
+// Pull-request attribute definitions publish provenance under this custom
+// JSON-schema key.
+const ATTRIBUTE_METADATA_KEY = 'x-mergify-attribute-metadata';
+
+/**
+ * Return the `source` recorded on a pull-request attribute definition, or
+ * `undefined` when the attribute carries no metadata. A `github` source marks
+ * attributes that Mergify loads from GitHub rulesets and branch protection:
+ * they are read-only and cannot be set in the configuration.
+ */
+export function getAttributeSource(definition: unknown): string | undefined {
+  if (!definition || typeof definition !== 'object') {
+    return undefined;
+  }
+
+  const metadata = (definition as Record<string, unknown>)[ATTRIBUTE_METADATA_KEY];
+  if (metadata && typeof metadata === 'object') {
+    const source = (metadata as Record<string, unknown>).source;
+    return typeof source === 'string' ? source : undefined;
+  }
+
+  return undefined;
+}

--- a/src/util/schemaToMarkdown.test.ts
+++ b/src/util/schemaToMarkdown.test.ts
@@ -30,6 +30,20 @@ describe('expandMdxComponents', () => {
     expect(result).not.toContain('PullRequestAttributesTable');
   });
 
+  test('default PullRequestAttributesTable excludes GitHub-sourced attributes', () => {
+    const result = expandMdxComponents('<PullRequestAttributesTable />');
+    expect(result).toContain('`author`');
+    expect(result).not.toContain('`github-review-approved`');
+  });
+
+  test('PullRequestAttributesTable source="github" lists only GitHub-sourced attributes', () => {
+    const result = expandMdxComponents('<PullRequestAttributesTable source="github" />');
+    expect(result).toContain('`github-review-approved`');
+    expect(result).toContain('`github-code-owner-review-satisfied`');
+    expect(result).not.toContain('`author`');
+    expect(result).not.toContain('PullRequestAttributesTable');
+  });
+
   test('removes import statements', () => {
     const input = [
       'import OptionsTable from "../../../components/Tables/OptionsTable";',

--- a/src/util/schemaToMarkdown.ts
+++ b/src/util/schemaToMarkdown.ts
@@ -1,5 +1,6 @@
 import jsonpointer from 'jsonpointer';
 
+import { getAttributeSource } from './attributeMetadata';
 import configSchema from './sanitizedConfigSchema';
 
 type Schema = typeof configSchema;
@@ -99,9 +100,14 @@ function generateOptionsTable(defName: string): string {
   return [headerLine, separatorLine, ...rowLines].join('\n');
 }
 
-function generatePullRequestAttributesTable(): string {
+function generatePullRequestAttributesTable(source?: string): string {
   const attributes = (configSchema as any).$defs.PullRequestAttributes.properties;
-  const entries = Object.entries<any>(attributes).sort(([a], [b]) => a.localeCompare(b));
+  const entries = Object.entries<any>(attributes)
+    .filter(([, value]) => {
+      const attributeSource = getAttributeSource(value);
+      return source ? attributeSource === source : attributeSource === undefined;
+    })
+    .sort(([a], [b]) => a.localeCompare(b));
 
   const rows: string[][] = [];
   for (const [key, value] of entries) {
@@ -178,9 +184,10 @@ export function expandMdxComponents(source: string): string {
     generateOptionsTable(def)
   );
 
-  // Replace <PullRequestAttributesTable />
-  source = source.replace(/<PullRequestAttributesTable\s*\/?>/g, () =>
-    generatePullRequestAttributesTable()
+  // Replace <PullRequestAttributesTable /> (optionally filtered by source)
+  source = source.replace(
+    /<PullRequestAttributesTable(?:\s+source=["'](\w+)["'])?\s*\/?>/g,
+    (_match, attributeSource) => generatePullRequestAttributesTable(attributeSource)
   );
 
   // Collapse runs of 3+ blank lines to 2


### PR DESCRIPTION
Each attribute row carries a stable `pull-request-attributes-<key>` id and a
hover-revealed `#` link, so individual attributes are deep-linkable like config
options (e.g. queue-rule-model-allow_inplace_checks). The id scheme reuses
OptionsTable's defToIdPrefix, and the anchor styling mirrors the config-option
pattern: scroll-margin for the sticky nav and a :target highlight.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #11993