### PR TITLE
fix(docsets): render Queue action icon in neutral color

### DIFF
--- a/src/components/DocsetGrid/Docset.astro
+++ b/src/components/DocsetGrid/Docset.astro
@@ -7,11 +7,13 @@ interface Props {
   title: string;
   path: string;
   icon?: string;
+  /** Render a product icon in the neutral text color instead of its brand color. */
+  neutral?: boolean;
 }
 
-const { title, path, icon } = Astro.props;
+const { title, path, icon, neutral } = Astro.props;
 const productIconName = parseProductIcon(icon);
-const productKey = productIconName ?? (path === '/workflow' ? 'workflow' : null);
+const productKey = neutral ? null : (productIconName ?? (path === '/workflow' ? 'workflow' : null));
 ---
 
 <a href={path} class="container" data-product={productKey}>

--- a/src/content/docs/workflow.mdx
+++ b/src/content/docs/workflow.mdx
@@ -66,7 +66,7 @@ a pull request when its state flips back from unmatched to matched.
   <Docset title="Merge" path="/workflow/actions/merge" icon="octicon:git-merge-16">
     Automate the merging of your pull requests.
   </Docset>
-  <Docset title="Queue" path="/workflow/actions/queue" icon="mergify:merge-queue">
+  <Docset title="Queue" path="/workflow/actions/queue" icon="mergify:merge-queue" neutral>
     Add the pull request to the merge queue.
   </Docset>
   <Docset title="Label" path="/workflow/actions/label" icon="lucide:badge-check">

--- a/src/content/docs/workflow/actions.mdx
+++ b/src/content/docs/workflow/actions.mdx
@@ -54,7 +54,7 @@ management.
   <Docset title="Post Check (Deprecated)" path="post_check" icon="lucide:circle-check">
     Deprecated — use Merge Protections instead.
   </Docset>
-  <Docset title="Queue" path="queue" icon="mergify:merge-queue">
+  <Docset title="Queue" path="queue" icon="mergify:merge-queue" neutral>
     Add the pull request to the merge queue.
   </Docset>
   <Docset title="Rebase" path="rebase" icon="lucide:git-branch">


### PR DESCRIPTION
The Queue action card used the merge-queue product icon, which is painted
teal. In the action grids (Popular Actions and the full actions catalog) it
sits among monochrome action icons, so the teal looked out of place. Add a
`neutral` prop to Docset that keeps the glyph but drops the product-brand
color (and its teal hover border), and apply it to both Queue action cards.
The homepage Products grid keeps its brand color.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>