### PR TITLE
docs(conditions): link GitHub-sourced attributes to their GitHub documentation

### DIFF
--- a/src/components/Tables/PullRequestAttributes.module.css
+++ b/src/components/Tables/PullRequestAttributes.module.css
@@ -10,6 +10,11 @@
   white-space: nowrap;
 }
 
+.documentationLink {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}
+
 .anchor {
   margin-left: 0.4rem;
   color: var(--theme-text-muted);

--- a/src/components/Tables/PullRequestAttributes.tsx
+++ b/src/components/Tables/PullRequestAttributes.tsx
@@ -1,4 +1,4 @@
-import { getAttributeSource } from '../../util/attributeMetadata';
+import { getAttributeDocumentationUrl, getAttributeSource } from '../../util/attributeMetadata';
 import configSchema from '../../util/sanitizedConfigSchema';
 import { getValueType } from './ConfigOptions';
 import { defToIdPrefix } from './OptionsTable';
@@ -121,6 +121,12 @@ export default function PullRequestAttributes({ staticAttributes, source }: Prop
             const meta = value as ConditionMeta;
             const id = `${ID_PREFIX}-${key}`;
             const href = `#${encodeURIComponent(id)}`;
+            // The search-highlight path injects <em> markers into attribute
+            // values, which would corrupt the URL — only link from the
+            // canonical schema render.
+            const documentationUrl = staticAttributes
+              ? undefined
+              : getAttributeDocumentationUrl(value);
 
             return (
               <tr key={key} id={id} className={styles.row}>
@@ -135,10 +141,21 @@ export default function PullRequestAttributes({ staticAttributes, source }: Prop
                   <td>{renderOperators(meta['x-allowed-operators'] ?? [])}</td>
                 )}
                 {hasConditionMetadata && <td>{renderModifiers(meta['x-modifiers'])}</td>}
-                <td
-                  dangerouslySetInnerHTML={{ __html: renderMarkdown(value.description) }}
-                  style={{ width: '100%' }}
-                />
+                <td style={{ width: '100%' }}>
+                  <div dangerouslySetInnerHTML={{ __html: renderMarkdown(value.description) }} />
+                  {documentationUrl && (
+                    <p className={styles.documentationLink}>
+                      <a
+                        href={documentationUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={`GitHub documentation for ${key}`}
+                      >
+                        GitHub documentation
+                      </a>
+                    </p>
+                  )}
+                </td>
               </tr>
             );
           })}

--- a/src/util/attributeMetadata.test.ts
+++ b/src/util/attributeMetadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { getAttributeSource } from './attributeMetadata';
+import { getAttributeDocumentationUrl, getAttributeSource } from './attributeMetadata';
 
 describe('getAttributeSource', () => {
   test('returns the source when present', () => {
@@ -20,5 +20,36 @@ describe('getAttributeSource', () => {
   test('returns undefined for non-object input', () => {
     expect(getAttributeSource(null)).toBeUndefined();
     expect(getAttributeSource('github')).toBeUndefined();
+  });
+});
+
+describe('getAttributeDocumentationUrl', () => {
+  test('returns the documentation URL when present', () => {
+    expect(
+      getAttributeDocumentationUrl({
+        'x-mergify-attribute-metadata': {
+          source: 'github',
+          documentation_url: 'https://docs.github.com/some-page',
+        },
+      })
+    ).toBe('https://docs.github.com/some-page');
+  });
+
+  test('returns undefined when the attribute has no metadata', () => {
+    expect(getAttributeDocumentationUrl({ type: 'boolean' })).toBeUndefined();
+  });
+
+  test('returns undefined for a missing or malformed URL', () => {
+    expect(
+      getAttributeDocumentationUrl({ 'x-mergify-attribute-metadata': { source: 'github' } })
+    ).toBeUndefined();
+    expect(
+      getAttributeDocumentationUrl({ 'x-mergify-attribute-metadata': { documentation_url: 42 } })
+    ).toBeUndefined();
+  });
+
+  test('returns undefined for non-object input', () => {
+    expect(getAttributeDocumentationUrl(null)).toBeUndefined();
+    expect(getAttributeDocumentationUrl('github')).toBeUndefined();
   });
 });

--- a/src/util/attributeMetadata.ts
+++ b/src/util/attributeMetadata.ts
@@ -2,6 +2,19 @@
 // JSON-schema key.
 const ATTRIBUTE_METADATA_KEY = 'x-mergify-attribute-metadata';
 
+function getAttributeMetadata(definition: unknown): Record<string, unknown> | undefined {
+  if (!definition || typeof definition !== 'object') {
+    return undefined;
+  }
+
+  const metadata = (definition as Record<string, unknown>)[ATTRIBUTE_METADATA_KEY];
+  if (metadata && typeof metadata === 'object') {
+    return metadata as Record<string, unknown>;
+  }
+
+  return undefined;
+}
+
 /**
  * Return the `source` recorded on a pull-request attribute definition, or
  * `undefined` when the attribute carries no metadata. A `github` source marks
@@ -9,15 +22,17 @@ const ATTRIBUTE_METADATA_KEY = 'x-mergify-attribute-metadata';
  * they are read-only and cannot be set in the configuration.
  */
 export function getAttributeSource(definition: unknown): string | undefined {
-  if (!definition || typeof definition !== 'object') {
-    return undefined;
-  }
+  const source = getAttributeMetadata(definition)?.source;
+  return typeof source === 'string' ? source : undefined;
+}
 
-  const metadata = (definition as Record<string, unknown>)[ATTRIBUTE_METADATA_KEY];
-  if (metadata && typeof metadata === 'object') {
-    const source = (metadata as Record<string, unknown>).source;
-    return typeof source === 'string' ? source : undefined;
-  }
-
-  return undefined;
+/**
+ * Return the GitHub documentation URL recorded on a pull-request attribute
+ * definition, or `undefined` when the attribute carries none. Sourced
+ * attributes link to the GitHub documentation of the enforcement option they
+ * mirror.
+ */
+export function getAttributeDocumentationUrl(definition: unknown): string | undefined {
+  const url = getAttributeMetadata(definition)?.documentation_url;
+  return typeof url === 'string' ? url : undefined;
 }

--- a/src/util/schemaToMarkdown.ts
+++ b/src/util/schemaToMarkdown.ts
@@ -1,6 +1,6 @@
 import jsonpointer from 'jsonpointer';
 
-import { getAttributeSource } from './attributeMetadata';
+import { getAttributeDocumentationUrl, getAttributeSource } from './attributeMetadata';
 import configSchema from './sanitizedConfigSchema';
 
 type Schema = typeof configSchema;
@@ -111,10 +111,14 @@ function generatePullRequestAttributesTable(source?: string): string {
 
   const rows: string[][] = [];
   for (const [key, value] of entries) {
+    const documentationUrl = getAttributeDocumentationUrl(value);
+    const description = value.description ? escapeCell(value.description) : '';
     rows.push([
       `\`${key}\``,
       escapeCell(getValueTypeText(configSchema, value)),
-      value.description ? escapeCell(value.description) : '',
+      documentationUrl
+        ? `${description} [GitHub documentation](${escapeCell(documentationUrl)})`
+        : description,
     ]);
   }
 


### PR DESCRIPTION
Render a "GitHub documentation" link from the documentation_url published in
the schema's x-mergify-attribute-metadata extension: under the attribute
description in the HTML attributes table, and appended inline to the
description cell in the markdown/LLM export. The link is omitted in the
search-highlight render path, whose highlight markers would corrupt the URL.

Until the engine schema carrying documentation_url is synced, the tables
render unchanged.

Depends-On: Mergifyio/monorepo#36225

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012ZfAq32gVtFih34eYFeEAr