### PR TITLE
fix(conditions): render the attributes tables as stacked entries

### DIFF
--- a/src/components/Tables/PullRequestAttributes.module.css
+++ b/src/components/Tables/PullRequestAttributes.module.css
@@ -1,13 +1,8 @@
-.row {
-  scroll-margin-top: calc(var(--theme-navbar-height) + 1rem);
-}
-
-.row:target > td {
-  background-color: color-mix(in srgb, var(--section-accent) 6%, transparent);
-}
-
-.name {
-  white-space: nowrap;
+/* Operators/modifiers get their own row under the name + value type heading;
+   composes with OptionsTable's .meta for the shared font and chip styling. */
+.conditionMeta {
+  display: flex;
+  margin-bottom: 0.5rem;
 }
 
 .documentationLink {
@@ -15,24 +10,11 @@
   font-size: 0.875rem;
 }
 
-.anchor {
-  margin-left: 0.4rem;
-  color: var(--theme-text-muted);
-  text-decoration: none;
-  font-weight: 500;
-  opacity: 0;
-  transition:
-    opacity 0.15s ease,
-    color 0.15s ease;
-}
-
-.anchor:hover,
-.anchor:focus {
+.documentationLink a {
   color: var(--theme-link);
+  text-decoration: underline;
 }
 
-.row:hover .anchor,
-.row:focus-within .anchor,
-.row:target .anchor {
-  opacity: 1;
+.documentationLink a:hover {
+  color: var(--theme-link-hover);
 }

--- a/src/components/Tables/PullRequestAttributes.tsx
+++ b/src/components/Tables/PullRequestAttributes.tsx
@@ -2,6 +2,10 @@ import { getAttributeDocumentationUrl, getAttributeSource } from '../../util/att
 import configSchema from '../../util/sanitizedConfigSchema';
 import { getValueType } from './ConfigOptions';
 import { defToIdPrefix } from './OptionsTable';
+// Attributes render with the OptionsTable layout (stacked entries, full-width
+// description) so schema reference sections read the same across the site and
+// the description is never squeezed into a table column.
+import optionStyles from './OptionsTable.module.css';
 import styles from './PullRequestAttributes.module.css';
 
 import { renderMarkdown } from './utils';
@@ -91,8 +95,8 @@ export default function PullRequestAttributes({ staticAttributes, source }: Prop
 
   const entries = Object.entries(attributes).sort(([keyA], [keyB]) => (keyA > keyB ? 1 : -1));
 
-  // Only render the operator/modifier columns once the schema carries the
-  // metadata. Until then (or if a sync drops it), fall back to the bare table.
+  // Only render the operator/modifier metadata once the schema carries it.
+  // Until then (or if a sync drops it), fall back to name/type/description.
   const hasConditionMetadata = entries.some(([, value]) =>
     Array.isArray((value as ConditionMeta)['x-allowed-operators'])
   );
@@ -104,63 +108,54 @@ export default function PullRequestAttributes({ staticAttributes, source }: Prop
     : entries;
 
   return (
-    <div className="table-wrap">
-      <table>
-        <thead>
-          <tr>
-            <th>Attribute name</th>
-            <th>Value type</th>
-            {hasConditionMetadata && <th>Operators</th>}
-            {hasConditionMetadata && <th>Modifiers</th>}
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map(([key, value]) => {
-            const valueType = getValueType(configSchema, value);
-            const meta = value as ConditionMeta;
-            const id = `${ID_PREFIX}-${key}`;
-            const href = `#${encodeURIComponent(id)}`;
-            // The search-highlight path injects <em> markers into attribute
-            // values, which would corrupt the URL — only link from the
-            // canonical schema render.
-            const documentationUrl = staticAttributes
-              ? undefined
-              : getAttributeDocumentationUrl(value);
+    <div className={optionStyles.list}>
+      {rows.map(([key, value]) => {
+        const valueType = getValueType(configSchema, value);
+        const meta = value as ConditionMeta;
+        const id = `${ID_PREFIX}-${key}`;
+        const href = `#${encodeURIComponent(id)}`;
+        // The search-highlight path injects <em> markers into attribute
+        // values, which would corrupt the URL — only link from the
+        // canonical schema render.
+        const documentationUrl = staticAttributes ? undefined : getAttributeDocumentationUrl(value);
 
-            return (
-              <tr key={key} id={id} className={styles.row}>
-                <td className={styles.name}>
-                  <code>{key}</code>
-                  <a className={styles.anchor} href={href} aria-label={`Link to ${key}`}>
-                    #
-                  </a>
-                </td>
-                <td>{valueType}</td>
-                {hasConditionMetadata && (
-                  <td>{renderOperators(meta['x-allowed-operators'] ?? [])}</td>
-                )}
-                {hasConditionMetadata && <td>{renderModifiers(meta['x-modifiers'])}</td>}
-                <td style={{ width: '100%' }}>
-                  <div dangerouslySetInnerHTML={{ __html: renderMarkdown(value.description) }} />
-                  {documentationUrl && (
-                    <p className={styles.documentationLink}>
-                      <a
-                        href={documentationUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`GitHub documentation for ${key}`}
-                      >
-                        GitHub documentation
-                      </a>
-                    </p>
-                  )}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+        return (
+          <div key={key} id={id} className={optionStyles.option}>
+            <div className={optionStyles.heading}>
+              <code className={optionStyles.key}>{key}</code>
+              <a className={optionStyles.anchor} href={href} aria-label={`Link to ${key}`}>
+                #
+              </a>
+              <span className={optionStyles.meta}>{valueType}</span>
+            </div>
+            {hasConditionMetadata && (
+              <div className={`${optionStyles.meta} ${styles.conditionMeta}`}>
+                <span className={optionStyles.metaLabel}>operators</span>
+                {renderOperators(meta['x-allowed-operators'] ?? [])}
+                <span className={optionStyles.metaSeparator}>·</span>
+                <span className={optionStyles.metaLabel}>modifiers</span>
+                {renderModifiers(meta['x-modifiers'])}
+              </div>
+            )}
+            <div
+              className={optionStyles.description}
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(value.description) }}
+            />
+            {documentationUrl && (
+              <p className={styles.documentationLink}>
+                <a
+                  href={documentationUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`GitHub documentation for ${key}`}
+                >
+                  GitHub documentation
+                </a>
+              </p>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
Replace the five-column table in PullRequestAttributes with the
OptionsTable layout: each attribute is a block with a heading row
(name, value type), an operators/modifiers row, and a full-width
description below. The table could not fit a readable description
column next to the other four — long enum value types forced it past
its container, leaving the description clipped behind the horizontal
scroll.

The component reuses OptionsTable.module.css so both schema reference
layouts share one look. Per-attribute anchors, the :target highlight,
GitHub documentation links, and the search-highlight path are
unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VNu82oCUPhc9eNYBhU91sW