### PR TITLE
docs(test-insights): Document that Prevention is opt-in per repository

### DIFF
--- a/src/content/docs/test-insights/prevention.mdx
+++ b/src/content/docs/test-insights/prevention.mdx
@@ -65,8 +65,11 @@ reliability.
 
 ## Setup
 
-Prevention requires test framework plugins that instrument test runs to track
-flakiness on pull requests.
+Prevention requires a test framework plugin that instruments test runs, and it
+is opt-in per repository. Once a plugin is installed, set a rerun budget on the
+[Prevention page](https://dashboard.mergify.com/test-insights/prevention) in the
+dashboard to enable it — until then, Mergify collects test results but does not
+rerun tests.
 
 See the [test framework configuration](/test-insights#test-framework-configuration)
 for setup instructions specific to your framework (pytest-mergify,


### PR DESCRIPTION
## What

`test-insights/prevention.mdx` now states that Prevention (client-side rerun of newly added tests on PRs) is **opt-in per repository**: install a native test-framework plugin, then set the rerun budget on the [Prevention page](https://dashboard.mergify.com/test-insights/prevention) in the dashboard to enable it.

## Why

The server now returns `404` for the flaky-detection context until a repository saves a rerun budget (Mergifyio/monorepo#36400), and the native clients skip silently until then. The Setup section previously only mentioned installing a plugin, so users had no way to discover they must enable it — the exact discoverability gap MRGFY-7580 exists to close.

Wording mirrors the existing Mitigation / Quarantine pages ("enable … per repository from the … page in the dashboard").

## Scope

One paragraph, one file. Detection's unhealthy-rerun budget UI is still unmerged (Mergifyio/monorepo#36409), so `detection.mdx` is intentionally left unchanged. No other docs page presents the feature as zero-setup, and the private `_MERGIFY_TEST_NEW_FLAKY_DETECTION` flag never appeared in these docs.

## ⚠️ Rollout dependency

Docs deploy on merge. Keep this a **draft** until the flag-free client releases are published (pytest-mergify#440, rspec-mergify#24, mergify-ci-plugins-ts#205) — until then, "install the latest plugin + set a budget" only fully works on the new client versions.

Part of MRGFY-7580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
