### PR TITLE
docs(test-insights): Document rerunning unhealthy tests from Detection

### DIFF
--- a/src/content/docs/test-insights/detection.mdx
+++ b/src/content/docs/test-insights/detection.mdx
@@ -35,6 +35,17 @@ Confidence indicates how much data is available to assess a test's health.
 
 Confidence increases as more CI runs are collected for a given test.
 
+## Rerunning unhealthy tests
+
+Mergify can rerun unhealthy tests automatically so they reach high confidence
+sooner, instead of waiting for them to run again on their own. Reruns stay
+within a budget you control, which caps the extra CI time they add.
+
+This is opt-in per repository and requires a test framework plugin. Once a
+plugin is installed, set a rerun budget on the
+[Detection page](https://dashboard.mergify.com/test-insights/detection) in the
+dashboard to enable it.
+
 ## Prioritizing with impact
 
 The impact metric reflects how many failed executions a test causes. A


### PR DESCRIPTION
Detection surfaces unhealthy tests from observed CI runs, but Mergify can also
rerun them to reach confidence sooner — from a per-repository rerun budget on
the Detection page (budget_ratio_for_unhealthy_tests), consumed by the native
clients. This capability was undocumented, so users had no way to discover it.

Add a short section tying the reruns to the confidence metric, mirroring the
Prevention page's opt-in wording.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
References: MRGFY-7580