### PR TITLE
feat(skills): teach docs-gap-analysis about the auto-generated API reference

### DIFF
--- a/.claude/skills/docs-gap-analysis/SKILL.md
+++ b/.claude/skills/docs-gap-analysis/SKILL.md
@@ -43,9 +43,12 @@ Create a todo for each step.
 
 4. **Map against the docs.** For each capability, search `src/content/docs/`:
    - `grep -ri "<feature name / config key / action>" src/content/docs/`
-   - Check whether the schema-driven references already cover new config/CLI
-     options (`OptionsTable`, `CliCommand` pull from the live schema, so a new
-     key may already render in a table while its prose context is missing).
+   - Config/CLI options: `OptionsTable` / `CliCommand` render from the live
+     schema, so a key may show in a table while its prose context is missing —
+     that still counts as a gap (prose needed).
+   - **API endpoints are the exception**: the `/api` reference auto-renders every
+     path in `public/api-schemas.json`, so an endpoint present there is already
+     documented — do NOT flag it as undocumented. See `references/signal-sources.md`.
 
 5. **Classify each capability:**
    - **Undocumented** — no meaningful coverage anywhere.

--- a/.claude/skills/docs-gap-analysis/references/signal-sources.md
+++ b/.claude/skills/docs-gap-analysis/references/signal-sources.md
@@ -77,18 +77,38 @@ To check coverage:
 grep -ri "<feature name | config key | action name>" src/content/docs/
 ```
 
-Remember the schema-driven components: a new config key may already appear in an
-`OptionsTable` (because it renders from the live schema) while having no prose
-explanation. "Appears in a generated table" is not the same as "documented" —
-look for the explanatory context, not just the key.
+Two kinds of "already generated" coverage behave very differently — get this
+right or you will file false gaps:
+
+- **Config keys / CLI options** render only where an author placed an
+  `<OptionsTable>` / `<ActionOptionsTable>` / `<CliCommand>` component. Even
+  then, "appears in a generated table" is not "documented" — a config key needs
+  explanatory prose (what it does, when to use it, defaults, gotchas). Treat
+  prose-less config keys as gaps.
+- **API endpoints are auto-documented.** The `/api` reference
+  (`src/pages/api/[tag].astro`) renders **every path** in
+  `public/api-schemas.json`, grouped by tag. So an endpoint that exists in that
+  spec is already published in the API reference — it is NOT a gap, even with no
+  hand-written prose. Before flagging an API/stats endpoint as undocumented,
+  check whether its path is in `public/api-schemas.json`:
+
+  ```bash
+  python3 -c "import json; print([p for p in json.load(open('public/api-schemas.json'))['paths'] if 'stats' in p])"
+  ```
+
+  A separate prose *guide* may still be nice-to-have, but the reference exists.
 
 ## Schemas
 
-The committed schemas show the current full surface area; diffing intent against
-them helps spot keys/commands with no prose:
+The committed schemas show the current full surface area:
 
-- `public/mergify-configuration-schema.json` — all config keys/models
-- `public/cli-schema.json` — all CLI commands/flags
-- `public/api-schemas.json` — API endpoints
+- `public/mergify-configuration-schema.json` — all config keys/models. A key here
+  with no prose (regardless of whether an OptionsTable renders it) is a gap.
+- `public/cli-schema.json` — all CLI commands/flags (rendered via `CliCommand`).
+- `public/api-schemas.json` — all API endpoints, **auto-rendered** in `/api`
+  (see above). Presence here = documented in the reference, not a gap.
 
-A key present in the schema but absent from any prose page is a coverage gap.
+When a changelog asserts a behavior change (e.g. a changed default), confirm it
+against `mergify-configuration-schema.json` before editing docs — the two can
+disagree (the schema is synced separately and may lag). If they conflict, flag it
+rather than guessing.


### PR DESCRIPTION
The /api reference (src/pages/api/[tag].astro) renders every path in
public/api-schemas.json, so an API endpoint present in that spec is already
documented and must NOT be flagged as a gap. Config keys are different: an
OptionsTable renders from the schema but a key still needs explanatory prose.

Update signal-sources.md and SKILL.md to draw that distinction, and add a
reminder to confirm changelog-asserted default changes against the config schema
before editing (the two can disagree).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>