### PR TITLE
feat(skills): add docs-from-code skill (code as source of truth)

### DIFF
--- a/.claude/skills/docs-from-code/SKILL.md
+++ b/.claude/skills/docs-from-code/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: docs-from-code
+description: >-
+  Use the Mergify product source code (Mergifyio/monorepo) as the source of
+  truth to verify or draft documentation. Use when checking whether a docs page
+  matches how the product actually behaves, when a config key's default/enum/
+  behavior needs confirming against the implementation, when the schema and
+  changelog disagree, or when drafting docs for a feature from its code/PR. Two
+  modes: verify (audit docs against code) and draft (generate a code-grounded
+  first draft). Reads a temporary local clone of the engine (Python/pydantic) and
+  dashboard. Composes with proofread-technical, document-a-feature, and
+  docs-gap-analysis.
+---
+
+# Docs From Code
+
+The changelog and the JSON schemas are *summaries* of the product; they omit
+detail and they drift (the committed schema can lag the code). The engine source
+is the only source of truth that cannot be stale. This skill reads that source to
+**verify** docs against the real implementation and to **draft** docs grounded in
+it.
+
+## Shared core
+
+Both modes start the same way. Read `references/monorepo-map.md` for the exact
+clone command, repo layout, and where each doc concept lives in the code.
+
+1. **Get the code.** Obtain a temporary shallow clone of `Mergifyio/monorepo`
+   (see the map for the command). Reuse an existing fresh clone; refresh if
+   stale. Never add it to the docs repo (it lives in a scratch dir).
+2. **Locate the implementation.** Map the doc concept to its code:
+   - config keys / defaults / enums → pydantic `Field(...)` in
+     `engine/mergify_engine/rules/config/*.py`
+   - actions → `engine/mergify_engine/workflow_automation/actions/`
+   - behavior → the relevant engine module (queue, merge_protections, …)
+   - dashboard / UI features → `dashboard/src/modules/*`
+
+   Grep the clone to find the definition; the map lists the recipes.
+
+## Mode: verify (audit docs against code)
+
+Input: a docs page, or a specific config key / action / feature.
+
+1. Locate the implementation (shared core).
+2. Extract the **actual** default, enum values, required-ness, and behavior from
+   the code — for config keys, read the pydantic `Field(default=..., description=...)`
+   directly; that value is authoritative even when the committed schema disagrees.
+3. Diff the code against what the docs claim.
+4. Report each discrepancy as `docs <path:line>` vs `engine <path:line>` with the
+   code value quoted. Fix clear, unambiguous doc errors directly; flag anything
+   where the intent is uncertain rather than guessing.
+
+This is `proofread-technical` upgraded from "matches the schema" to "matches the
+implementation" — it catches defaults/enums that drifted from the code (the
+`allow_checks_interruption` class of bug) at the source.
+
+## Mode: draft (generate docs from code)
+
+Input: a feature — a PR number, or a code area / config key.
+
+1. Locate the implementation (shared core). If given a PR, also read its diff
+   (`gh pr view <n> --repo Mergifyio/monorepo --json title,body,files` +
+   `gh pr diff`).
+2. Extract the user-facing surface from the code: config keys and their
+   defaults/enums, behavior, edge cases, validation errors, and any user-visible
+   messages. Translate code truth into a **user-facing lens** — document what the
+   user configures and observes, not engine internals.
+3. Produce a first-draft page (prose + valid config examples).
+4. Hand the draft to the **document-a-feature** skill for placement, component
+   selection, and site plumbing, then run the proofread pipeline and
+   **validate-config-examples**.
+
+## Composition
+
+- `docs-gap-analysis` finds a gap → **draft** writes a code-grounded first pass →
+  `document-a-feature` structures and wires it → proofread + `pnpm check`.
+- **verify** runs standalone, or as the deep technical dimension behind
+  `proofread-technical` when a claim must be checked against behavior, not just
+  the schema.
+
+## Guardrails
+
+- The clone is read-only and disposable — never edit it, never commit it into the
+  docs repo, never add it to `.gitignore` (keep it in the scratch dir).
+- Document the user-facing contract, not implementation details. Code is the
+  source of truth for *what is true*, not for *how to say it*.
+- When code and a doc disagree, the code wins for facts (defaults, enums,
+  behavior) — but if you cannot tell whether a difference is intentional, flag it
+  rather than "fixing" it.
+- Never touch `src/content/changelog/`.
+- The monorepo is large; scope greps to the concept at hand (one key/action),
+  don't bulk-read.

--- a/.claude/skills/docs-from-code/references/monorepo-map.md
+++ b/.claude/skills/docs-from-code/references/monorepo-map.md
@@ -1,0 +1,118 @@
+# Monorepo Navigation Map
+
+Where documented concepts live in `Mergifyio/monorepo`, and how to extract the
+truth from the code.
+
+## Table of contents
+
+- [Get the code](#get-the-code)
+- [Repo layout](#repo-layout)
+- [Config keys, defaults, enums](#config-keys-defaults-enums)
+- [Actions](#actions)
+- [Behavior](#behavior)
+- [Dashboard / UI](#dashboard--ui)
+- [Grep recipes](#grep-recipes)
+
+## Get the code
+
+Shallow, single-branch clone into a scratch dir (never inside the docs repo).
+Reuse if it already exists and is fresh; otherwise refresh.
+
+```bash
+CLONE="${TMPDIR:-/tmp}/mergify-monorepo"
+if [ -d "$CLONE/.git" ]; then
+  git -C "$CLONE" fetch --depth 1 origin main && git -C "$CLONE" reset --hard origin/main
+else
+  git clone --depth 1 --single-branch --branch main \
+    https://github.com/Mergifyio/monorepo.git "$CLONE"
+fi
+```
+
+Read-only and disposable. Do not edit it, commit it, or reference it from the
+docs repo.
+
+## Repo layout
+
+Top level (the two that matter for docs):
+
+- `engine/` — the product engine (Python). The behavioral source of truth:
+  config models, defaults, actions, queue/merge logic.
+- `dashboard/` — the web dashboard (TypeScript/React). UI-only features
+  (Activity Log, adoption tabs, in-app editors) live here.
+
+## Config keys, defaults, enums
+
+Config is defined with **pydantic models** under
+`engine/mergify_engine/rules/config/`. Each key is a `pydantic.Field(...)` whose
+`default=` and `description=` are authoritative — the committed
+`public/mergify-configuration-schema.json` is *generated from these models*, so
+when the schema (or a changelog) disagrees with the docs, the `Field` in code is
+the tiebreaker.
+
+Modules by area:
+
+Paths below are full, relative to the clone root.
+
+| Concept | Module |
+| --- | --- |
+| Queue rules (`queue_rules`) — `max_checks_retries`, `checks_timeout`, `batch_size`, `merge_method`, … | `engine/mergify_engine/rules/config/queue_rules.py` |
+| Global `merge_queue` settings — `status_comments`, capacities, … | `engine/mergify_engine/rules/config/merge_queue.py` |
+| Priority rules — `allow_checks_interruption`, `priority`, … | `engine/mergify_engine/rules/config/priority_rules.py` |
+| Merge protections | `engine/mergify_engine/rules/config/merge_protections.py`, `engine/mergify_engine/rules/config/merge_protection_rules.py` |
+| Pull request rules | `engine/mergify_engine/rules/config/pull_request_rules.py` |
+| Scopes | `engine/mergify_engine/rules/config/scopes.py` |
+| Commit message format | `engine/mergify_engine/rules/config/commit_message.py` |
+| Command restrictions | `engine/mergify_engine/rules/config/commands_restrictions.py` |
+| Global defaults | `engine/mergify_engine/rules/config/defaults.py` |
+
+To read a key's real default/description:
+
+```bash
+grep -n -A6 "max_checks_retries" "$CLONE/engine/mergify_engine/rules/config/queue_rules.py"
+```
+
+Look for the `pydantic.Field(default=..., description="...")`. The `default=` is
+the current runtime default; the `description=` is what feeds the schema and is
+often close to doc-ready prose (but write for the reader, not copy verbatim).
+
+## Actions
+
+Each documented action in `src/content/docs/workflow/actions/<name>.mdx` maps 1:1
+to `engine/mergify_engine/workflow_automation/actions/<name>.py` (e.g. `merge.py`,
+`rebase.py`, `comment.py`, `backport.py`, `copy.py`, `label.py`, `squash.py`,
+`update.py`, `post_check.py`, `delete_head_branch.py`). The action's option model
+(pydantic) in that file gives its real parameters, defaults, and deprecations
+(look for `deprecated=True`).
+
+## Behavior
+
+For "what actually happens" (not just config shape), read the engine logic:
+
+- Merge queue lifecycle / batches / checks → `engine/mergify_engine/queue/…`
+- Merge protections behavior → `engine/mergify_engine/merge_protections/…`
+- Conditions / attributes → `engine/mergify_engine/rules/…`
+
+Start from the config model that references the behavior, then follow the imports.
+
+## Dashboard / UI
+
+UI-only features (no config key) live in `dashboard/src/modules/<feature>/`. Use
+these to confirm what a dashboard screen shows, but remember these pages usually
+still need a screenshot pass (see the `capture-screenshots` skill) — code tells
+you the fields, not the pixels.
+
+## Grep recipes
+
+```bash
+# Where is a config key defined / defaulted?
+grep -rn "<key>" "$CLONE/engine/mergify_engine/rules/config/"
+
+# A key's default + description block
+grep -n -A6 "<key>" "$CLONE/engine/mergify_engine/rules/config/<module>.py"
+
+# An action's parameters and deprecations
+grep -n -E "Field\(|deprecated" "$CLONE/engine/mergify_engine/workflow_automation/actions/<action>.py"
+
+# Anything, anywhere (scoped)
+grep -rn "<term>" "$CLONE/engine/mergify_engine/"
+```


### PR DESCRIPTION
Add a skill that reads the Mergify product source (Mergifyio/monorepo) to
verify or draft documentation, since the changelog and JSON schemas are
summaries that drift while the code cannot be stale.

Two modes over a temporary shallow clone:
- verify: locate a config key/action/feature in the engine and check the docs
  against the real implementation (pydantic Field defaults/enums/behavior).
  Upgrades proofread-technical from "matches the schema" to "matches the code".
- draft: read a feature's implementation/PR and produce a code-grounded first
  draft, then hand off to document-a-feature for structure and plumbing.

Includes references/monorepo-map.md: the clone command, repo layout, and where
config/actions/behavior/dashboard concepts live, with grep recipes.

Validated on allow_checks_interruption: priority_rules.py defines
`default=False`, confirming the changelog (false) over the committed schema JSON
(true) — the exact schema-vs-code drift this skill catches.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>