### PR TITLE
fix(api): Add CI Insights to the API reference sidebar

### DIFF
--- a/src/content/navItems.tsx
+++ b/src/content/navItems.tsx
@@ -356,6 +356,7 @@ const navItems: NavItem[] = [
           { title: 'Event Logs', path: '/api/eventlogs' },
           { title: 'Badges', path: '/api/badges' },
           { title: 'Scheduled Freeze', path: '/api/scheduled-freeze' },
+          { title: 'CI Insights', path: '/api/ci-insights' },
           { title: 'Test Insights', path: '/api/test-insights' },
         ],
       },


### PR DESCRIPTION
The `/api/ci-insights` page is generated from the OpenAPI schema's
`ci_insights` tag and already appears on the auto-generated API index
grid, but the hand-maintained reference sidebar in `navItems.tsx`
omitted it. Readers could not reach the page from the reference menu.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>