### PR TITLE
feat(skills): add screenshot-scenarios skill (stage real states, then capture)

### DIFF
--- a/.claude/skills/screenshot-scenarios/SKILL.md
+++ b/.claude/skills/screenshot-scenarios/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: screenshot-scenarios
+description: >-
+  Produce meaningful Mergify dashboard screenshots for the docs by staging a real
+  product state in the Mergifyio/sandbox repo, capturing it, then cleaning up. Use
+  when a docs page needs a screenshot that shows an actual state (a queue with PRs,
+  a batch, a freeze, priority ordering), when auditing which pages are missing or
+  have stale screenshots, or when asked to build a scenario and screenshot it. Sets
+  up state via gh + the mergify CLI, captures via the capture-screenshots skill,
+  and tears the scenario down. Defers CI/Test Insights shots (they need real CI
+  data). Composes with capture-screenshots, document-a-feature, docs-gap-analysis.
+---
+
+# Screenshot Scenarios
+
+A dashboard screenshot is only useful if the UI shows something worth seeing. An
+empty queue view teaches nothing. This skill **stages a real state** in a sandbox
+repo, captures it with `capture-screenshots`, and tears it back down.
+
+`capture-screenshots` is the mechanical primitive (navigate → capture → save →
+emit `<Image>`). This skill is the layer above it: *what state to produce, how to
+produce it, and where the shot belongs*.
+
+## Prerequisites
+
+- Logged into `app.mergify.com` in Chrome (for capture — see `capture-screenshots`).
+- `gh` authenticated with write access to `Mergifyio/sandbox`.
+- The `mergify` CLI available.
+- Mergify enabled on the sandbox. See `references/sandbox.md` for first-run setup.
+
+## Two entry points
+
+- **Coverage sweep** — find docs pages that describe a dashboard feature but have
+  no screenshot or a stale one, and map each to a scenario. This is the
+  visual-focused cousin of `docs-gap-analysis`. See [Coverage](#coverage).
+- **Targeted** — you already know the shot you need; pick or build its recipe.
+
+## Workflow (per screenshot)
+
+Create a todo per step.
+
+1. **Pick the recipe.** Read `references/scenario-recipes.md`. If a recipe fits,
+   use it. If not, build a custom one following [Building a scenario](#building-a-custom-scenario).
+2. **Stage the state** in the sandbox. Follow the recipe using the driver in
+   `references/sandbox.md` (push config, open PRs, queue/freeze, then **poll**
+   until the target state is reached). The `mergify:mergify-merge-queue`,
+   `mergify:mergify-config`, and `mergify:mergify-merge-protections` plugin skills
+   help with the mechanics when installed; the sandbox driver's raw CLI works
+   without them.
+3. **Capture.** Invoke the **capture-screenshots** skill with the recipe's
+   dashboard URL and framing. It saves to the right `images/` dir and emits the
+   `<Image>` snippet.
+4. **Clean up** (always). Run the light teardown in `references/sandbox.md`:
+   close the PRs, delete the branches, lift any freeze, revert the config. Leave
+   the sandbox at baseline.
+5. **Wire it in.** Drop the snippet into the page, or hand off to
+   `document-a-feature` if this is part of a new feature page.
+
+## Building a custom scenario
+
+When no recipe fits, define one by answering four questions, then add it to
+`references/scenario-recipes.md` so it is reusable:
+
+1. **What must the shot show?** The exact UI state (e.g. "two PRs in one batch").
+2. **What produces that state?** The minimal `.mergify.yml` + the PRs/actions
+   needed (open N PRs, queue them, add a label, create a freeze…).
+3. **How do I know it's ready?** The poll/wait condition (e.g. queue shows 2 PRs
+   with a shared batch id) — never screenshot before the state has settled.
+4. **Where is it captured?** The dashboard URL and the region to frame.
+
+## Coverage
+
+To find where screenshots are missing or stale:
+
+- Grep docs for pages that describe a dashboard/UI action but import no image:
+  a page under `src/content/docs/` whose prose says "in the dashboard" / "the
+  queue view" / "the statistics page" but has no `<Image>` is a candidate.
+- Cross-check existing `src/content/docs/images/**` against the pages that use
+  them; flag images that predate a feature change (a stale-shot candidate).
+- Produce a prioritized list, each mapped to a recipe, and work it with the
+  per-screenshot workflow above.
+
+## Composition
+
+`docs-gap-analysis` / coverage finds the need → **screenshot-scenarios** stages
+and captures it → `capture-screenshots` does the mechanical capture →
+`document-a-feature` places it.
+
+## Guardrails
+
+- **Sandbox only.** Only ever mutate `Mergifyio/sandbox`. Confirm the repo before
+  any write. Never open PRs, push config, or create freezes anywhere else, and
+  never screenshot another customer's data.
+- **Always clean up**, even on failure — leave the sandbox at baseline so the next
+  run starts clean.
+- **Poll, don't guess** — wait for the state to settle before capturing; a
+  half-formed queue makes a misleading shot.
+- **Defer CI / Test Insights** shots for now: they need real CI runs and test
+  results, which this sandbox flow does not stage. Focus on merge-queue,
+  merge-protections, freeze, and priority states.
+- Stop and ask if the sandbox setup or the queue won't reach the target state
+  after a couple of attempts. Don't loop.

--- a/.claude/skills/screenshot-scenarios/references/sandbox.md
+++ b/.claude/skills/screenshot-scenarios/references/sandbox.md
@@ -1,0 +1,101 @@
+# Sandbox Driver
+
+How to drive `Mergifyio/sandbox` to stage a state, then tear it down. All writes
+target **only** this repo — confirm before every mutating command.
+
+## Table of contents
+
+- [First-run setup](#first-run-setup)
+- [Primitives](#primitives)
+- [Polling for state](#polling-for-state)
+- [Cleanup (always)](#cleanup-always)
+- [Safety](#safety)
+
+## First-run setup
+
+The sandbox may be empty. Ensure once (idempotent):
+
+1. **Mergify enabled** — the Mergify GitHub App must be installed on
+   `Mergifyio/sandbox`. If the queue never reacts, this is the first thing to
+   check (stop and ask the user to enable it; you cannot install the app).
+2. **A base branch with content** — `main` needs at least a `README.md` so
+   branches can diverge and PRs can be opened.
+   ```bash
+   gh api repos/Mergifyio/sandbox/contents/README.md >/dev/null 2>&1 \
+     || gh api -X PUT repos/Mergifyio/sandbox/contents/README.md \
+        -f message="init" -f content="$(printf 'sandbox' | base64)"
+   ```
+3. **Baseline config** — keep a minimal known-good `.mergify.yml` on `main` as the
+   baseline that cleanup restores to.
+
+## Primitives
+
+Set `REPO=Mergifyio/sandbox`. The `mergify:mergify-merge-queue`,
+`mergify:mergify-config`, and `mergify:mergify-merge-protections` skills (from the
+mergify plugin, when it is installed) give the higher-level semantics; the raw
+`gh` / `mergify` CLI calls below are the mechanics and work without the plugin.
+
+**Push a scenario config** (Mergify reads config from the default branch):
+```bash
+# Validate first with the mergify CLI, then commit .mergify.yml to main
+mergify config validate --config-file /tmp/scenario.mergify.yml
+# commit it to main via gh api contents (PUT) or a short-lived branch + merge
+```
+
+**Open a PR** (repeat N times for multi-PR scenarios). Keep the file path
+slash-free — the `/` belongs in the branch name, not the Contents API path:
+```bash
+BR="scenario/pr-1"; FILE="scenario-1.txt"
+gh api -X PUT "repos/$REPO/contents/$FILE" -f message="scenario pr 1" \
+  -f branch="$BR" -f content="$(printf 'x' | base64)"
+gh pr create --repo "$REPO" --head "$BR" --base main \
+  --title "Scenario PR 1" --body "screenshot scenario"
+```
+
+**Queue a PR** — either auto-queue via the pushed config, or explicitly:
+```bash
+gh pr comment <num> --repo "$REPO" --body "@mergifyio queue"
+```
+
+**Freeze** (for freeze shots) — `mergify freeze create …` against the sandbox
+(or the `mergify:mergify-merge-protections` skill).
+
+**Labels / priority** — `gh pr edit <num> --repo "$REPO" --add-label <label>` to
+drive priority-rule scenarios.
+
+## Polling for state
+
+Never capture before the state has settled. Poll until the target is reached:
+
+```bash
+mergify stack list        # or the mergify:mergify-merge-queue status view
+gh pr checks <num> --repo "$REPO"
+```
+
+For a queue shot, wait until the expected PRs actually appear in the queue (and,
+for batches, share a batch). Give it a bounded number of tries; if it never
+settles, stop and ask (usually a config or app-enablement problem).
+
+## Cleanup (always)
+
+Light teardown — return the sandbox to baseline, even if the run failed:
+
+```bash
+# Close only the scenario PRs this run created (scenario/ branch prefix)
+for n in $(gh pr list --repo "$REPO" --state open --json number,headRefName \
+  --jq '.[] | select(.headRefName | startswith("scenario/")) | .number'); do
+  gh pr close "$n" --repo "$REPO" --delete-branch
+done
+# Lift any freeze created for the shot (mergify CLI)
+# Restore .mergify.yml on main to the baseline config
+```
+
+Only close PRs / delete branches that this run created (they use the
+`scenario/` branch prefix and "Scenario" titles) — don't touch unrelated ones.
+
+## Safety
+
+- **Repo allowlist of one:** every write must target `Mergifyio/sandbox`. Before
+  any mutating `gh`/`mergify` call, confirm the repo string is exactly that.
+- Use the `scenario/` branch prefix so cleanup can identify what to remove.
+- If a command would target any other repo, stop — that is a bug.

--- a/.claude/skills/screenshot-scenarios/references/scenario-recipes.md
+++ b/.claude/skills/screenshot-scenarios/references/scenario-recipes.md
@@ -1,0 +1,114 @@
+# Scenario Recipes
+
+A library of repeatable states to stage in `Mergifyio/sandbox`, capture, and tear
+down. Each recipe names the config, the PRs/actions, the wait condition, and the
+capture view. Drive them with `references/sandbox.md`; capture with the
+`capture-screenshots` skill; always run the standard cleanup afterward.
+
+Dashboard URLs follow the pattern
+`https://app.mergify.com/github/Mergifyio/sandbox/<view>` — confirm the exact
+path from the app (see `capture-screenshots`' conventions).
+
+## Table of contents
+
+- [Recipe format](#recipe-format)
+- [Queue with multiple PRs](#queue-with-multiple-prs)
+- [Batch of PRs](#batch-of-prs)
+- [Priority ordering](#priority-ordering)
+- [Active freeze](#active-freeze)
+- [A queued PR's check run](#a-queued-prs-check-run)
+- [Paused queue](#paused-queue)
+
+## Recipe format
+
+- **Goal** — what the shot must show.
+- **Serves** — the docs page(s) it illustrates.
+- **Config** — `.mergify.yml` pushed to `main` for the scenario.
+- **Stage** — PRs/actions to create.
+- **Wait** — the poll condition before capturing.
+- **Capture** — the view + framing.
+
+Cleanup is always the standard teardown (`references/sandbox.md`).
+
+## Queue with multiple PRs
+
+- **Goal** — the merge queue view with 2–3 pull requests queued.
+- **Serves** — `merge-queue/lifecycle.mdx`, `merge-queue.mdx`, setup pages.
+- **Config**
+  ```yaml
+  queue_rules:
+    - name: default
+      merge_conditions: []
+  ```
+- **Stage** — open 3 PRs, comment `@mergifyio queue` on each.
+- **Wait** — the queue view lists all 3 PRs.
+- **Capture** — `…/queues`, frame the queue list.
+
+## Batch of PRs
+
+- **Goal** — several PRs grouped into one batch.
+- **Serves** — `merge-queue/batches.mdx`.
+- **Config**
+  ```yaml
+  queue_rules:
+    - name: default
+      batch_size: 3
+      merge_conditions: []
+  ```
+- **Stage** — open 3 PRs, queue all three.
+- **Wait** — the queue shows the 3 PRs sharing one batch.
+- **Capture** — `…/queues`, frame the batch grouping.
+
+## Priority ordering
+
+- **Goal** — a higher-priority PR ahead of normal ones in the queue.
+- **Serves** — `merge-queue/priority.mdx`.
+- **Config**
+  ```yaml
+  queue_rules:
+    - name: default
+      merge_conditions: []
+  priority_rules:
+    - name: urgent
+      conditions:
+        - label = urgent
+      priority: high
+  ```
+- **Stage** — open 3 PRs; add the `urgent` label to the last one; queue all.
+- **Wait** — the urgent PR sits ahead of the earlier ones.
+- **Capture** — `…/queues`, frame the ordering.
+
+## Active freeze
+
+- **Goal** — the dashboard showing an active queue freeze.
+- **Serves** — `merge-protections/freeze.mdx`.
+- **Config** — baseline queue config is enough; the freeze is created via CLI.
+- **Stage** — create a freeze on the sandbox with `mergify freeze create` (or the
+  `mergify:mergify-merge-protections` skill), optionally with one PR queued behind it.
+- **Wait** — the freeze shows as active.
+- **Capture** — the freeze view.
+
+## A queued PR's check run
+
+- **Goal** — a pull request showing the unified "Mergify Merge Queue" check run.
+- **Serves** — `merge-queue/lifecycle.mdx` (the check-run section).
+- **Config** — baseline queue config.
+- **Stage** — open 1 PR and queue it.
+- **Wait** — the "Mergify Merge Queue" check appears on the PR.
+- **Capture** — the PR's checks tab (GitHub) or the dashboard PR view, framing the
+  check run.
+
+## Paused queue
+
+- **Goal** — the queue in a paused state.
+- **Serves** — `merge-queue/pause.mdx`.
+- **Config** — baseline queue config with a PR or two queued.
+- **Stage** — queue 1–2 PRs, then pause the queue with the mergify CLI (or the
+  `mergify:mergify-merge-queue` skill).
+- **Wait** — the queue shows the paused banner/state.
+- **Capture** — `…/queues`, frame the paused indicator.
+
+---
+
+When you build a new state not covered here, add it in this format so the next
+run can reuse it.


### PR DESCRIPTION
Docs screenshots are only useful when the UI shows a meaningful state (a queue
with PRs, a batch, a freeze, priority ordering). This skill stages that state in
the Mergifyio/sandbox repo, captures it via the capture-screenshots primitive,
then tears it down.

Contents:
- SKILL.md: coverage sweep + per-screenshot workflow (stage → poll → capture →
  clean up → wire in) + a pattern for building custom scenarios
- references/sandbox.md: how to drive Mergifyio/sandbox with gh + the mergify
  CLI, first-run setup, polling, and always-run light cleanup; writes are locked
  to the sandbox repo
- references/scenario-recipes.md: a starter recipe library (queue with N PRs,
  batch, priority ordering, freeze, unified check run, paused queue)

Composes with capture-screenshots (mechanical capture), document-a-feature
(placement), and docs-gap-analysis (coverage). CI/Test Insights shots are
deferred (they need real CI data). Recipe configs validated with
mergify config validate.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>