### PR TITLE
docs(conditions): generate the dequeue-reason table from the engine schema

### DIFF
--- a/src/components/Tables/QueueDequeueReasons.tsx
+++ b/src/components/Tables/QueueDequeueReasons.tsx
@@ -1,0 +1,81 @@
+import configSchema from '../../util/sanitizedConfigSchema';
+
+import { renderMarkdown } from './utils';
+
+// The `queue-dequeue-reason` condition attribute accepts one of the merge queue
+// dequeue codes. The engine is the single source of truth: the codes come from
+// the attribute's enum, and a one-line description for each is published
+// alongside it under `x-enum-descriptions` (keyed by the raw code). Driving the
+// code list from the enum keeps the table current even before a schema sync
+// delivers the descriptions.
+//
+// `x-enum-descriptions` is not in the synced schema until the engine ships it,
+// so it is absent from the JSON-derived types and read via a cast (it becomes a
+// normal typed key once the sync bot lands it).
+//
+// The lookup is optional-chained through a loose cast so a future schema reshape
+// (renamed attribute or restructured `$defs`) degrades to an empty table rather
+// than throwing at module load and crashing the Astro build.
+const reasonProp: unknown = (
+  configSchema as {
+    $defs?: { PullRequestAttributes?: { properties?: Record<string, unknown> } };
+  }
+).$defs?.PullRequestAttributes?.properties?.['queue-dequeue-reason'];
+
+type EnumNode = { anyOf?: EnumNode[]; enum?: string[]; const?: string };
+
+function branchValues(node: EnumNode): string[] {
+  if (node.const !== undefined) {
+    return [node.const];
+  }
+  return node.enum ?? [];
+}
+
+// Collect the raw enum values the attribute accepts, tolerating the shapes the
+// engine might emit: an `anyOf` of `{const}` / `{enum}` branches (today), or a
+// flat `{enum}` / `{const}`. Returns [] for anything else (or a missing node),
+// so a future schema-shape change degrades to an empty table rather than
+// crashing the Astro build.
+function enumValues(prop: unknown): string[] {
+  if (!prop || typeof prop !== 'object') {
+    return [];
+  }
+  const node = prop as EnumNode;
+  return node.anyOf ? node.anyOf.flatMap(branchValues) : branchValues(node);
+}
+
+// The engine stores codes as `UPPER_SNAKE`; conditions are written in kebab-case
+// (the parser normalizes `upper().replace('-', '_')`), so that is what to show.
+function toKebab(code: string): string {
+  return code.toLowerCase().replace(/_/g, '-');
+}
+
+export default function QueueDequeueReasons() {
+  const descriptions =
+    (reasonProp as { 'x-enum-descriptions'?: Record<string, string> } | undefined)?.[
+      'x-enum-descriptions'
+    ] ?? {};
+
+  return (
+    <div className="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Reason</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {enumValues(reasonProp).map((code) => (
+            <tr key={code}>
+              <td>
+                <code>{toKebab(code)}</code>
+              </td>
+              <td dangerouslySetInnerHTML={{ __html: renderMarkdown(descriptions[code] ?? '') }} />
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/content/docs/configuration/data-types.mdx
+++ b/src/content/docs/configuration/data-types.mdx
@@ -4,6 +4,7 @@ description: The different data types you can find in Mergify configuration file
 ---
 
 import OptionsTable from '../../../components/Tables/OptionsTable';
+import QueueDequeueReasons from '../../../components/Tables/QueueDequeueReasons';
 import TemplateVariablesTable from '../../../components/Tables/TemplateVariablesTable';
 
 When using templates or conditions, data are made of different types. You will
@@ -419,141 +420,13 @@ Either `none`, `read`, `triage`, `write`, `maintain` or `admin`.
 
 ## Queue Dequeue Reason
 
-This describes the reason why a pull request has been removed from the queue.
+This describes the reason why a pull request's merge queue checks ended — either
+because the pull request left the queue, or because its checks were interrupted
+while it stayed in the queue.
 
-<table>
-  <thead>
-    <th>Reason</th>
-    <th>Description</th>
-  </thead>
+The following reasons can be reported:
 
-  <tbody>
-     <tr>
-      <td><code>none</code></td>
-      <td>Pull request was not and is not in any queue.</td>
-    </tr>
-
-    <tr>
-      <td><code>pr-merged</code></td>
-      <td>Pull request has been merged.</td>
-    </tr>
-
-    <tr>
-      <td><code>pr-dequeued</code></td>
-
-      <td>
-        Pull request has been removed from the queue by an
-        <a href="/commands/dequeue">dequeue command</a> or
-        by an <a href="/workflow">automation rule</a>
-      </td>
-    </tr>
-
-    <tr>
-      <td><code>checks-timeout</code></td>
-
-      <td>
-        The configured <a href="/configuration/file-format/#queue-rules">
-        <code>checks\_timeout</code></a> has been reached.
-      </td>
-    </tr>
-
-    <tr>
-      <td><code>checks-failed</code></td>
-      <td>The checks have failed.</td>
-    </tr>
-
-    <tr>
-      <td><code>queue-rule-missing</code></td>
-      <td>The queue rule has been removed from the configuration.</td>
-    </tr>
-
-    <tr>
-      <td><code>base-branch-missing</code></td>
-      <td>The pull request base branch is missing.</td>
-    </tr>
-
-    <tr>
-      <td><code>base-branch-changed</code></td>
-      <td>The pull request base branch has changed.</td>
-    </tr>
-
-    <tr>
-      <td><code>pr-unexpectedly-failed-to-merge</code></td>
-      <td>An unexpected error happened while merging the pull request.</td>
-    </tr>
-
-    <tr>
-      <td><code>batch-max-failure-resolution-attempts</code></td>
-      <td>The maximum number of resolution attempts set in <a href="/configuration/file-format/#queue-rules">
-      <code>batch\_max\_failure\_resolution\_attempts</code></a> has been reached.</td>
-    </tr>
-
-    <tr>
-      <td><code>conflict-with-base-branch</code></td>
-      <td>The pull request conflicts with its base branch.</td>
-    </tr>
-
-    <tr>
-      <td><code>conflict-with-pull-ahead</code></td>
-      <td>The pull request conflicts with a pull request ahead of it.</td>
-    </tr>
-
-    <tr>
-      <td><code>branch-update-failed</code></td>
-      <td>Updating the head branch of the pull request failed.</td>
-    </tr>
-
-    <tr>
-      <td><code>pr-ahead-dequeued</code></td>
-      <td>A pull request which is ahead has been removed from the queue.</td>
-    </tr>
-
-    <tr>
-        <td><code>pr-ahead-failed-to-merge</code></td>
-        <td>The pull request which is ahead could not be merged.</td>
-    </tr>
-
-    <tr>
-        <td><code>pr-with-higher-priority-queued</code></td>
-        <td>A higher priority pull request has been queued in the meantime.</td>
-    </tr>
-
-    <tr>
-        <td><code>pr-queued-twice</code></td>
-        <td>The pull request got queued twice.</td>
-    </tr>
-
-    <tr>
-        <td><code>pr-frozen-no-cascading</code></td>
-        <td>The pull request was frozen by a freeze with cascading effect disabled.</td>
-    </tr>
-
-    <tr>
-        <td><code>pr-checks-stopped-because-merge-queue-pause</code></td>
-        <td>The checks have been interrupted because the merge queue is paused on this repository.</td>
-    </tr>
-
-    <tr>
-        <td><code>draft-pull-request-changed</code></td>
-        <td>The draft pull request has been unexpectedly changed.</td>
-    </tr>
-
-    <tr>
-        <td><code>pull-request-updated</code></td>
-        <td>The pull request has been manually updated.</td>
-    </tr>
-
-    <tr>
-        <td><code>merge-queue-reset</code></td>
-        <td>The merge queue was reset.</td>
-    </tr>
-
-    <tr>
-        <td><code>incompatibility-with-branch-protections</code></td>
-        <td>The pull request cannot be checked because of an incompatibility with branch protections.</td>
-    </tr>
-  </tbody>
-</table>
+<QueueDequeueReasons />
 
 ## Report Modes
 


### PR DESCRIPTION
Replace the hand-written "Queue Dequeue Reason" table with a component that
renders from the synced config schema: the codes from the attribute's enum, and
the descriptions from the engine's `x-enum-descriptions`. The hand table had
drifted — missing 17 reasons and listing 3 that no longer exist. The component
degrades gracefully (codes with empty descriptions) until the schema sync
delivers the descriptions.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>