### PR TITLE
docs: wire post_check check-run screenshot + drop dead import

### DIFF
--- a/src/content/docs/merge-protections.mdx
+++ b/src/content/docs/merge-protections.mdx
@@ -6,7 +6,6 @@ description: Go beyond GitHub's native branch protections and craft custom, adva
 ---
 
 import { Image } from "astro:assets"
-import mainScreen from "../images/merge-protections/main-screen.png"
 import commentScreen from "../images/merge-protections/comment.png"
 
 > Mergify Merge Protections extend GitHub's native Branch Protections & Rulesets with fine‑grained, dynamic rules.

--- a/src/content/docs/workflow/actions/post_check.mdx
+++ b/src/content/docs/workflow/actions/post_check.mdx
@@ -3,12 +3,14 @@ title: Post Check (Deprecated)
 description: Create a check-run on a pull request. Deprecated in favor of Merge Protections.
 ---
 
+import { Image } from 'astro:assets';
 import ActionOptionsTable from '../../../../components/Tables/ActionOptionsTable';
 import Button from '../../../../components/Button.astro';
+import PostCheckScreenshot from '../../../images/workflow/actions/post_check/post-check-actions.png';
 
 :::danger
-  The `post_check` action is **deprecated** and will be removed on September
-  30, 2026. Use [Merge Protections](/merge-protections) instead.
+  The `post_check` action is **deprecated** and will be removed in a future
+  release. Use [Merge Protections](/merge-protections) instead.
 
   Mergify will automatically migrate your configuration by removing
   `post_check` rules and opening a migration pull request that converts them
@@ -68,6 +70,11 @@ merge_protections:
 The `post_check` action allows Mergify to create a check-run on a pull request.
 This can be useful in situations where you want to add a custom check to the
 status of a pull request based on Mergify's evaluation.
+
+<Image
+  src={PostCheckScreenshot}
+  alt="A post_check check-run in a GitHub pull request's checks list, flagging a title that breaks Conventional Commit"
+/>
 
 ### Parameters
 


### PR DESCRIPTION
Wire the orphaned post-check-actions.png into the post_check Legacy
Reference (it depicts the exact check-run the action creates), and remove
the dead main-screen.png import from merge-protections.mdx (imported but
never rendered; the asset is still used by merge-protections/setup.mdx).

Also drop the dated "September 30, 2026" removal date from the post_check
deprecation callout, per repo policy against dated deprecation notices in
docs prose (the changelog is the single source of truth for removals).

Part of the docs screenshot refresh (MRGFY-8060). The audit flagged 5
"cheap win" orphaned assets to wire, but git history shows 4 of them were
intentionally removed by deliberate page rewrites and are stale, so
re-wiring them would regress the docs:

- ci-insights token.png / gh-secrets.png removed by #9238 (MRGFY-6011,
  moved from a dedicated CI Insights Token to application keys with ci
  scope) -- token.png shows the retired token UI
- merge-queue deploy bp-rule.png / bp-settings.png removed by #6531
  (branch protection -> GitHub rulesets)
- stacks stacked-gh-pr.png / stacked-mergify-pr.png removed by #10970
  (replaced by GitGraph components; stacked-gh-pr also misrepresents
  gh-stack's one-branch-per-PR model)

Those six assets are left for a separate orphan-asset deletion pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>