### PR TITLE
docs(capture-screenshots): update conventions to dashboard.mergify.com + 2x DPR

### DIFF
--- a/.claude/skills/capture-screenshots/SKILL.md
+++ b/.claude/skills/capture-screenshots/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Capture consistent Mergify dashboard screenshots for the docs site using
   Chrome browser automation, save them to the correct images/ directory, and
   emit the ready-to-paste astro:assets import and <Image> tag with alt text. Use
-  when adding or refreshing a dashboard/app screenshot in docs, when a docs page
-  needs a UI image, or when asked to screenshot app.mergify.com for
+  when adding or refreshing a dashboard screenshot in docs, when a docs page
+  needs a UI image, or when asked to screenshot dashboard.mergify.com for
   documentation. Drives the claude-in-chrome MCP tools against the user's
   existing logged-in Chrome session.
 ---
@@ -13,14 +13,29 @@ description: >-
 # Capture Dashboard Screenshots
 
 Produce clean, consistent screenshots of the Mergify dashboard
-(`app.mergify.com`) and wire them into a docs page.
+(`dashboard.mergify.com`) and wire them into a docs page.
 
-## Prerequisite
+## Two ways to capture
 
-The user must already be **logged into app.mergify.com in Chrome**. This skill
-reuses the existing browser session through the claude-in-chrome MCP tools; it
-never handles credentials. If navigation lands on a login page, stop and ask the
-user to log in (`! open https://app.mergify.com`), then continue.
+**Prefer the internal Playwright tool for batch or unattended captures.** The
+capture tool in the **`Mergifyio/skills`** repo runs headless Chromium at
+`deviceScaleFactor: 2` and writes PNG bytes straight to disk. It owns the
+session/auth handling, which is intentionally kept out of this public repo.
+
+**Use the interactive Chrome path below when you are working alongside the user**
+— exploring the dashboard, framing a one-off shot, or capturing a state that is
+easier to reach by clicking than by URL. It drives the claude-in-chrome MCP
+against the user's own logged-in session.
+
+Either way, the docs-side conventions are the same: framing, directory/naming,
+and the `<Image>` wiring snippet — see `references/conventions.md`.
+
+## Prerequisite (interactive path)
+
+The user must already be **logged into dashboard.mergify.com in Chrome**. This
+skill reuses the existing browser session through the claude-in-chrome MCP tools;
+it never handles credentials. If navigation lands on a login page, stop and ask
+the user to log in (`! open https://dashboard.mergify.com`), then continue.
 
 ## Load the browser tools first
 

--- a/.claude/skills/capture-screenshots/references/conventions.md
+++ b/.claude/skills/capture-screenshots/references/conventions.md
@@ -26,6 +26,17 @@ Default to **1440 × 900** unless the content needs more width. Astro + Sharp
 optimize and downscale on the site, so capture at the full standard size rather
 than a cramped window — never upscale a small capture.
 
+Capture at **2× (retina)**. The existing docs screenshots are all 2× — a 1×
+capture renders visibly softer next to them. How you get 2× depends on the path:
+
+- **Internal Playwright tool** (`Mergifyio/skills`) — sets
+  `deviceScaleFactor: 2` explicitly alongside `viewport 1440×900` and writes
+  `page.screenshot()` bytes straight to disk, so 2× is captured natively.
+- **Interactive claude-in-chrome capture** — there is no `deviceScaleFactor`
+  knob. Capture on a **2×/retina display at 100% browser zoom**; anything else
+  yields a soft 1× shot. Check the PNG's pixel dimensions against its CSS region
+  before wiring it in.
+
 ## Theme
 
 Capture in **light theme by default** (the docs render on a light surface and the
@@ -74,18 +85,23 @@ debugging and read it back with `read_console_messages`.
 
 ## Common dashboard URLs
 
-`app.mergify.com` (confirm against the live app; paths evolve):
+`dashboard.mergify.com` (confirm against the live app; paths evolve). To target a
+specific org/repo you can optionally append `?login=<org>&repository=<repo>`
+(e.g. `?login=Mergifyio&repository=monorepo`); it is not required — many docs
+links omit it and the dashboard resolves org/repo from the active session:
 
 | Area | Path |
 | --- | --- |
-| Org dashboard | `/github/<org>` |
-| Merge queues | `/github/<org>/queues` |
-| CI Insights | `/github/<org>/ci-insights` |
-| Test Insights | `/github/<org>/tests` |
-| Settings | `/github/<org>/settings` |
+| Home | `/home` |
+| Merge queues | `/merge-queue` |
+| CI Insights | `/ci-insights` |
+| Test Insights → Prevention | `/test-insights/prevention` |
+| Test Insights → Detection | `/test-insights/detection` |
+| Test Insights → Mitigation | `/test-insights/mitigation` |
 
-If a path 404s, navigate from the dashboard UI and read the resulting URL with
-`read_page` rather than guessing.
+`app.mergify.com` is retired and no longer resolves — always use
+`dashboard.mergify.com`. If a path 404s, navigate from the dashboard UI and read
+the resulting URL with `read_page` rather than guessing.
 
 ## Stable framing tips
 


### PR DESCRIPTION
Refresh the public-safe capture-screenshots skill: app.mergify.com -> dashboard.mergify.com throughout, add deviceScaleFactor: 2 to the viewport conventions, and point to the internal Playwright capture tool in Mergifyio/skills (no auth internals).

Per review: frame the ?login&repository query context as optional (docs links omit it) and drop '/app' from the frontmatter description.

Split out of #12127 (Test Insights screenshots) at Julien's request.

Refs MRGFY-8060

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>