### PR TITLE
docs: document unified merge queue bot_account

### DIFF
--- a/src/content/docs/configuration/data-types.mdx
+++ b/src/content/docs/configuration/data-types.mdx
@@ -353,8 +353,12 @@ A GitHub login Mergify impersonates to perform an action. You can also use the
 [`merge`](/workflow/actions/merge), [`rebase`](/workflow/actions/rebase),
 [`request_reviews`](/workflow/actions/request_reviews),
 [`review`](/workflow/actions/review), [`squash`](/workflow/actions/squash) and
-[`update`](/workflow/actions/update) actions, and the merge queue
-`draft_bot_account`, `merge_bot_account` and `update_bot_account`.
+[`update`](/workflow/actions/update) actions, and the merge queue `bot_account`
+field.
+
+In the merge queue, `bot_account` is the single account Mergify uses for every
+queue operation, including creating draft pull requests, updating branches, and
+merging.
 
 <TemplateVariablesTable def="CommentActionModel" field="bot_account" />
 

--- a/src/content/docs/merge-queue/batches.mdx
+++ b/src/content/docs/merge-queue/batches.mdx
@@ -583,7 +583,7 @@ temporary batch PRs, only when all of the following are true:
 - No two-step CI is configured (no separate `merge_conditions` beyond
   `queue_conditions`)
 
-Optionally set `update_bot_account` to avoid in-place updates blocked by GitHub
+Optionally set `bot_account` to avoid in-place updates blocked by GitHub
 for security reasons (for example, PRs from forks that modify workflows, or PRs
 opened by other bots).
 

--- a/src/content/docs/merge-queue/merge-strategies.mdx
+++ b/src/content/docs/merge-queue/merge-strategies.mdx
@@ -156,7 +156,7 @@ rebase update occurs, the commit SHAs on the PR will change — what fast-forwar
 preserves are the SHAs of the PR branch at merge time.
 
 :::caution
-  When using `update_bot_account` with fast-forward inplace mode, fork pull
+  When using `bot_account` with fast-forward inplace mode, fork pull
   requests will no longer be supported after **July 1, 2026**. See the
   [update method deprecation note](#combining-merge-and-update-methods) for
   details and migration options.
@@ -313,7 +313,7 @@ fall behind the base branch. Combining `merge_method` with `update_method`
 gives you additional control over your history shape.
 
 :::note
-  `update_method: rebase` combined with `update_bot_account` will no longer
+  `update_method: rebase` combined with `bot_account` will no longer
   support fork pull requests after **July 1, 2026**. If your repository
   receives fork PRs, use `update_method: merge` instead.
 :::


### PR DESCRIPTION
Mergify unifies the three per-operation merge-queue bot accounts —
`draft_bot_account`, `merge_bot_account`, and `update_bot_account` — into a
single `bot_account` key (Mergifyio/monorepo#37097). This drops per-operation
account granularity: one account now performs every queue operation (creating
draft pull requests, updating branches, merging).

Update the docs to match:
- configuration/data-types.mdx — rewrite the "Bot account" section to describe
  the single unified key and add a dateless deprecation-alias note: the three
  old keys are deprecated aliases that map to `bot_account`, and on conflicting
  values a defined precedence wins (`merge_bot_account` > `update_bot_account` >
  `draft_bot_account`) with a warning.
- merge-queue/merge-strategies.mdx, merge-queue/batches.mdx — replace the
  remaining `update_bot_account` example/prose references with `bot_account`.

Left untouched on purpose: the auto-generated schemas
(public/mergify-configuration-schema.json, public/api-schemas.json) are
regenerated externally from the monorepo, and the historical changelog entries
record their original features. The public changelog is synced from the
monorepo, so the unification announcement lands there, not in this repo.

Depends-On: https://github.com/Mergifyio/monorepo/pull/37097