### PR TITLE
feat(screenshot-scenarios): drive the sandbox via the sandbox-org skill

### DIFF
--- a/.claude/skills/screenshot-scenarios/SKILL.md
+++ b/.claude/skills/screenshot-scenarios/SKILL.md
@@ -2,11 +2,11 @@
 name: screenshot-scenarios
 description: >-
   Produce meaningful Mergify dashboard screenshots for the docs by staging a real
-  product state in the Mergifyio/sandbox repo, capturing it, then cleaning up. Use
+  product state in the mergify-sandbox org, capturing it, then cleaning up. Use
   when a docs page needs a screenshot that shows an actual state (a queue with PRs,
   a batch, a freeze, priority ordering), when auditing which pages are missing or
   have stale screenshots, or when asked to build a scenario and screenshot it. Sets
-  up state via gh + the mergify CLI, captures via the capture-screenshots skill,
+  up state via the sandbox-org skill, captures via the capture-screenshots skill,
   and tears the scenario down. Defers CI/Test Insights shots (they need real CI
   data). Composes with capture-screenshots, document-a-feature, docs-gap-analysis.
 ---
@@ -17,16 +17,22 @@ A dashboard screenshot is only useful if the UI shows something worth seeing. An
 empty queue view teaches nothing. This skill **stages a real state** in a sandbox
 repo, captures it with `capture-screenshots`, and tears it back down.
 
-`capture-screenshots` is the mechanical primitive (navigate → capture → save →
-emit `<Image>`). This skill is the layer above it: *what state to produce, how to
-produce it, and where the shot belongs*.
+Two skills do the heavy lifting; this one is the layer above them — *what state
+to produce, and where the shot belongs*:
+
+- **sandbox-org** (mergify-internal plugin) drives the sandbox: it creates the
+  repo, pushes config, opens PRs, queues, freezes, waits for the queue to settle,
+  and cleans up. See `references/sandbox.md` for how this skill uses it.
+- **capture-screenshots** is the mechanical capture (navigate → capture → save →
+  emit `<Image>`).
 
 ## Prerequisites
 
 - Logged into `app.mergify.com` in Chrome (for capture — see `capture-screenshots`).
-- `gh` authenticated with write access to `Mergifyio/sandbox`.
-- The `mergify` CLI available.
-- Mergify enabled on the sandbox. See `references/sandbox.md` for first-run setup.
+- The **sandbox-org** skill available (mergify-internal plugin) — it provides the
+  `sandbox.sh` commands used throughout — and `gh` + the `mergify` CLI it uses,
+  authenticated as an admin of the `mergify-sandbox` org.
+- The scenario repo created and Mergify-enabled. See `references/sandbox.md`.
 
 ## Two entry points
 
@@ -41,17 +47,15 @@ Create a todo per step.
 
 1. **Pick the recipe.** Read `references/scenario-recipes.md`. If a recipe fits,
    use it. If not, build a custom one following [Building a scenario](#building-a-custom-scenario).
-2. **Stage the state** in the sandbox. Follow the recipe using the driver in
-   `references/sandbox.md` (push config, open PRs, queue/freeze, then **poll**
-   until the target state is reached). The `mergify:mergify-merge-queue`,
-   `mergify:mergify-config`, and `mergify:mergify-merge-protections` plugin skills
-   help with the mechanics when installed; the sandbox driver's raw CLI works
-   without them.
+2. **Stage the state** with the **sandbox-org** skill's staging verbs
+   (`push-config` → `open-pr` → `queue` → optionally `freeze`, then `wait-queued`
+   to poll until the target state settles). `references/sandbox.md` maps each
+   recipe step to the exact `sandbox.sh` command.
 3. **Capture.** Invoke the **capture-screenshots** skill with the recipe's
    dashboard URL and framing. It saves to the right `images/` dir and emits the
    `<Image>` snippet.
-4. **Clean up** (always). Run the light teardown in `references/sandbox.md`:
-   close the PRs, delete the branches, lift any freeze, revert the config. Leave
+4. **Clean up** (always). `sandbox.sh cleanup <repo>` closes the scenario PRs and
+   deletes their branches; `sandbox.sh unfreeze <repo>` lifts any freeze. Leave
    the sandbox at baseline.
 5. **Wire it in.** Drop the snippet into the page, or hand off to
    `document-a-feature` if this is part of a new feature page.
@@ -88,13 +92,13 @@ and captures it → `capture-screenshots` does the mechanical capture →
 
 ## Guardrails
 
-- **Sandbox only.** Only ever mutate `Mergifyio/sandbox`. Confirm the repo before
-  any write. Never open PRs, push config, or create freezes anywhere else, and
-  never screenshot another customer's data.
+- **Sandbox only.** All staging goes through the sandbox-org skill, which refuses
+  any repo outside the `mergify-sandbox` org — so a scenario can never mutate a
+  real repo. Never screenshot another customer's data.
 - **Always clean up**, even on failure — leave the sandbox at baseline so the next
   run starts clean.
-- **Poll, don't guess** — wait for the state to settle before capturing; a
-  half-formed queue makes a misleading shot.
+- **Poll, don't guess** — `wait-queued` before capturing; a half-formed queue
+  makes a misleading shot.
 - **Defer CI / Test Insights** shots for now: they need real CI runs and test
   results, which this sandbox flow does not stage. Focus on merge-queue,
   merge-protections, freeze, and priority states.

--- a/.claude/skills/screenshot-scenarios/references/sandbox.md
+++ b/.claude/skills/screenshot-scenarios/references/sandbox.md
@@ -1,101 +1,49 @@
-# Sandbox Driver
+# Sandbox
 
-How to drive `Mergifyio/sandbox` to stage a state, then tear it down. All writes
-target **only** this repo — confirm before every mutating command.
+Scenarios are staged on a repo in the **mergify-sandbox** org, driven entirely
+through the **sandbox-org** skill (mergify-internal plugin). That skill owns the
+mechanics — repo lifecycle, config, PRs, queue, freeze, polling, teardown — and
+confines every write to the org. This file only records how *this* skill uses it.
 
-## Table of contents
+## Scenario repo
 
-- [First-run setup](#first-run-setup)
-- [Primitives](#primitives)
-- [Polling for state](#polling-for-state)
-- [Cleanup (always)](#cleanup-always)
-- [Safety](#safety)
-
-## First-run setup
-
-The sandbox may be empty. Ensure once (idempotent):
-
-1. **Mergify enabled** — the Mergify GitHub App must be installed on
-   `Mergifyio/sandbox`. If the queue never reacts, this is the first thing to
-   check (stop and ask the user to enable it; you cannot install the app).
-2. **A base branch with content** — `main` needs at least a `README.md` so
-   branches can diverge and PRs can be opened.
-   ```bash
-   gh api repos/Mergifyio/sandbox/contents/README.md >/dev/null 2>&1 \
-     || gh api -X PUT repos/Mergifyio/sandbox/contents/README.md \
-        -f message="init" -f content="$(printf 'sandbox' | base64)"
-   ```
-3. **Baseline config** — keep a minimal known-good `.mergify.yml` on `main` as the
-   baseline that cleanup restores to.
-
-## Primitives
-
-Set `REPO=Mergifyio/sandbox`. The `mergify:mergify-merge-queue`,
-`mergify:mergify-config`, and `mergify:mergify-merge-protections` skills (from the
-mergify plugin, when it is installed) give the higher-level semantics; the raw
-`gh` / `mergify` CLI calls below are the mechanics and work without the plugin.
-
-**Push a scenario config** (Mergify reads config from the default branch):
-```bash
-# Validate first with the mergify CLI, then commit .mergify.yml to main
-mergify config validate --config-file /tmp/scenario.mergify.yml
-# commit it to main via gh api contents (PUT) or a short-lived branch + merge
+```
+mergify-sandbox/dashboard-scenarios
 ```
 
-**Open a PR** (repeat N times for multi-PR scenarios). Keep the file path
-slash-free — the `/` belongs in the branch name, not the Contents API path:
-```bash
-BR="scenario/pr-1"; FILE="scenario-1.txt"
-gh api -X PUT "repos/$REPO/contents/$FILE" -f message="scenario pr 1" \
-  -f branch="$BR" -f content="$(printf 'x' | base64)"
-gh pr create --repo "$REPO" --head "$BR" --base main \
-  --title "Scenario PR 1" --body "screenshot scenario"
-```
-
-**Queue a PR** — either auto-queue via the pushed config, or explicitly:
-```bash
-gh pr comment <num> --repo "$REPO" --body "@mergifyio queue"
-```
-
-**Freeze** (for freeze shots) — `mergify freeze create …` against the sandbox
-(or the `mergify:mergify-merge-protections` skill).
-
-**Labels / priority** — `gh pr edit <num> --repo "$REPO" --add-label <label>` to
-drive priority-rule scenarios.
-
-## Polling for state
-
-Never capture before the state has settled. Poll until the target is reached:
+First run, create and enable it (once):
 
 ```bash
-mergify stack list        # or the mergify:mergify-merge-queue status view
-gh pr checks <num> --repo "$REPO"
+sandbox.sh create dashboard-scenarios --private --description "Staged states for docs dashboard screenshots"
+sandbox.sh enable dashboard-scenarios
 ```
 
-For a queue shot, wait until the expected PRs actually appear in the queue (and,
-for batches, share a batch). Give it a bounded number of tries; if it never
-settles, stop and ask (usually a config or app-enablement problem).
+Keep a minimal known-good baseline config as `baseline.mergify.yml` next to your
+scenario files: each scenario overwrites it on `main`, and cleanup pushes it back.
+
+## Recipe step → sandbox-org command
+
+Set `REPO=dashboard-scenarios` (the `mergify-sandbox/` prefix is implied).
+
+| recipe step | command |
+| -- | -- |
+| push the scenario config | `sandbox.sh push-config $REPO ./scenario.mergify.yml` |
+| open a scenario PR (repeat N×) | `sandbox.sh open-pr $REPO scenario/pr-1` |
+| queue a PR | `sandbox.sh queue $REPO <num>` |
+| freeze (for freeze shots) | `sandbox.sh freeze $REPO --reason "docs freeze shot"` |
+| labels / priority | `gh pr edit <num> --repo mergify-sandbox/$REPO --add-label <label>` |
+| wait until settled | `sandbox.sh wait-queued $REPO <num>` |
+
+For queue status while polling a specific state, `sandbox.sh queue-status $REPO`.
 
 ## Cleanup (always)
 
-Light teardown — return the sandbox to baseline, even if the run failed:
-
 ```bash
-# Close only the scenario PRs this run created (scenario/ branch prefix)
-for n in $(gh pr list --repo "$REPO" --state open --json number,headRefName \
-  --jq '.[] | select(.headRefName | startswith("scenario/")) | .number'); do
-  gh pr close "$n" --repo "$REPO" --delete-branch
-done
-# Lift any freeze created for the shot (mergify CLI)
-# Restore .mergify.yml on main to the baseline config
+sandbox.sh cleanup $REPO      # close every scenario/ PR, delete its branch
+sandbox.sh unfreeze $REPO     # lift any freeze the scenario created
+sandbox.sh push-config $REPO ./baseline.mergify.yml   # restore the baseline config on main
 ```
 
-Only close PRs / delete branches that this run created (they use the
-`scenario/` branch prefix and "Scenario" titles) — don't touch unrelated ones.
-
-## Safety
-
-- **Repo allowlist of one:** every write must target `Mergifyio/sandbox`. Before
-  any mutating `gh`/`mergify` call, confirm the repo string is exactly that.
-- Use the `scenario/` branch prefix so cleanup can identify what to remove.
-- If a command would target any other repo, stop — that is a bug.
+`cleanup` only touches PRs whose branch starts with `scenario/`, so it never
+removes unrelated work. Always tear down — even on failure — so the next scenario
+starts from baseline.

--- a/.claude/skills/screenshot-scenarios/references/scenario-recipes.md
+++ b/.claude/skills/screenshot-scenarios/references/scenario-recipes.md
@@ -1,13 +1,14 @@
 # Scenario Recipes
 
-A library of repeatable states to stage in `Mergifyio/sandbox`, capture, and tear
-down. Each recipe names the config, the PRs/actions, the wait condition, and the
-capture view. Drive them with `references/sandbox.md`; capture with the
+A library of repeatable states to stage in the `mergify-sandbox` scenario repo,
+capture, and tear down. Each recipe names the config, the PRs/actions, the wait
+condition, and the capture view. Drive them via the sandbox-org skill (see
+`references/sandbox.md` for the step → command mapping); capture with the
 `capture-screenshots` skill; always run the standard cleanup afterward.
 
 Dashboard URLs follow the pattern
-`https://app.mergify.com/github/Mergifyio/sandbox/<view>` — confirm the exact
-path from the app (see `capture-screenshots`' conventions).
+`https://app.mergify.com/github/mergify-sandbox/dashboard-scenarios/<view>` —
+confirm the exact path from the app (see `capture-screenshots`' conventions).
 
 ## Table of contents
 
@@ -40,7 +41,7 @@ Cleanup is always the standard teardown (`references/sandbox.md`).
     - name: default
       merge_conditions: []
   ```
-- **Stage** — open 3 PRs, comment `@mergifyio queue` on each.
+- **Stage** — open 3 PRs, queue each one with `sandbox.sh queue`.
 - **Wait** — the queue view lists all 3 PRs.
 - **Capture** — `…/queues`, frame the queue list.
 
@@ -83,8 +84,8 @@ Cleanup is always the standard teardown (`references/sandbox.md`).
 - **Goal** — the dashboard showing an active queue freeze.
 - **Serves** — `merge-protections/freeze.mdx`.
 - **Config** — baseline queue config is enough; the freeze is created via CLI.
-- **Stage** — create a freeze on the sandbox with `mergify freeze create` (or the
-  `mergify:mergify-merge-protections` skill), optionally with one PR queued behind it.
+- **Stage** — create a freeze on the sandbox with `sandbox.sh freeze`, optionally
+  with one PR queued behind it.
 - **Wait** — the freeze shows as active.
 - **Capture** — the freeze view.
 


### PR DESCRIPTION
Retire the bespoke Mergifyio/sandbox driver: staging now goes through the
sandbox-org skill (mergify-internal plugin) against the mergify-sandbox org,
which owns the repo/queue/freeze mechanics and confines every write to the org.
references/sandbox.md shrinks to the scenario repo choice and a recipe-step →
sandbox.sh command mapping.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>