### PR TITLE
feat: link typed template variables to their data type section

### DIFF
--- a/public/mergify-configuration-schema.json
+++ b/public/mergify-configuration-schema.json
@@ -606,7 +606,8 @@
             },
             {
               "description": "Why the pull request left the merge queue; empty outside queue contexts.",
-              "name": "queue_dequeue_reason"
+              "name": "queue_dequeue_reason",
+              "type": "queue-dequeue-reason"
             }
           ]
         }
@@ -800,7 +801,8 @@
                 },
                 {
                   "description": "Why the pull request left the merge queue; empty outside queue contexts.",
-                  "name": "queue_dequeue_reason"
+                  "name": "queue_dequeue_reason",
+                  "type": "queue-dequeue-reason"
                 }
               ]
             },
@@ -4754,7 +4756,8 @@
                 },
                 {
                   "description": "Why the pull request left the merge queue; empty outside queue contexts.",
-                  "name": "queue_dequeue_reason"
+                  "name": "queue_dequeue_reason",
+                  "type": "queue-dequeue-reason"
                 }
               ]
             },

--- a/src/components/Tables/TemplateVariablesTable.tsx
+++ b/src/components/Tables/TemplateVariablesTable.tsx
@@ -8,6 +8,16 @@ interface TemplateVariablesTableProps extends Def {
   field: string;
 }
 
+// A template variable whose value is drawn from an enumerated data type carries a
+// `type` token in the schema (`x-mergify-template-variables[].type`). Map that token
+// to the data type section listing the accepted values, mirroring how option value
+// types link to their data type (see ConfigOptions `valueTypeFormatLinks`). Keying
+// off the schema-published token means a new typed variable needs only its engine
+// annotation plus one entry here — no per-variable-name special-casing.
+const variableTypeLinks: Record<string, string> = {
+  'queue-dequeue-reason': '/configuration/data-types#queue-dequeue-reason',
+};
+
 export default function TemplateVariablesTable({ def, field }: TemplateVariablesTableProps) {
   const schema = configSchema as unknown as ConfigSchema;
   const definition = schema.$defs[def]?.properties?.[field];
@@ -31,14 +41,23 @@ export default function TemplateVariablesTable({ def, field }: TemplateVariables
           </tr>
         </thead>
         <tbody>
-          {variables.map((variable) => (
-            <tr key={variable.name}>
-              <td>
-                <code>{`{{ ${variable.name} }}`}</code>
-              </td>
-              <td dangerouslySetInnerHTML={{ __html: renderMarkdown(variable.description) }} />
-            </tr>
-          ))}
+          {variables.map((variable) => {
+            const typeLink = variable.type ? variableTypeLinks[variable.type] : undefined;
+            return (
+              <tr key={variable.name}>
+                <td>
+                  {typeLink !== undefined ? (
+                    <a style={{ textDecoration: 'underline' }} href={typeLink}>
+                      <code>{`{{ ${variable.name} }}`}</code>
+                    </a>
+                  ) : (
+                    <code>{`{{ ${variable.name} }}`}</code>
+                  )}
+                </td>
+                <td dangerouslySetInnerHTML={{ __html: renderMarkdown(variable.description) }} />
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/src/util/templateVariables.test.ts
+++ b/src/util/templateVariables.test.ts
@@ -50,6 +50,29 @@ describe('extractTemplateVariables', () => {
     ]);
   });
 
+  it('carries the optional type token through for enumerated-value variables', () => {
+    const definition = {
+      type: 'string',
+      format: 'simple-template',
+      'x-mergify-template-variables': [
+        { name: 'author', description: 'PR author login' },
+        {
+          name: 'queue_dequeue_reason',
+          description: 'Why the PR left the queue',
+          type: 'queue-dequeue-reason',
+        },
+      ],
+    };
+    expect(extractTemplateVariables(definition)).toEqual([
+      { name: 'author', description: 'PR author login' },
+      {
+        name: 'queue_dequeue_reason',
+        description: 'Why the PR left the queue',
+        type: 'queue-dequeue-reason',
+      },
+    ]);
+  });
+
   it('returns [] when no template variables are present', () => {
     expect(extractTemplateVariables({ type: 'string' })).toEqual([]);
     expect(extractTemplateVariables(null)).toEqual([]);

--- a/src/util/templateVariables.ts
+++ b/src/util/templateVariables.ts
@@ -1,6 +1,11 @@
 export interface TemplateVariable {
   name: string;
   description: string;
+  // Some variables resolve to a value drawn from an enumerated data type rather than
+  // a free-form string. The schema tags those with a stable token (e.g.
+  // `queue-dequeue-reason`) that renderers map to the matching data type section.
+  // Absent for free-form string variables.
+  type?: string;
 }
 
 // Field definitions publish their allowlist under this custom JSON-schema key.


### PR DESCRIPTION
Template variables whose value is drawn from an enumerated data type now
render as a link to the matching data-types section instead of as a
free-form string. The engine tags such variables with a `type` token in
`x-mergify-template-variables`; the docs map the token to its section
(currently `queue_dequeue_reason` -> Queue Dequeue Reason).

Keying off the schema-published token replaces the earlier hardcoded
variable-name special-case, so a future typed variable needs only its
engine annotation plus one entry in the docs token map.

The bundled schema update pre-syncs the marker ahead of the automated
JSON Schema sync; the bot will reconcile it identically once the engine
change lands.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>