### PR TITLE
docs(security): clarify first-trial self-service Billing Admin bootstrap

### DIFF
--- a/src/content/docs/security.mdx
+++ b/src/content/docs/security.mdx
@@ -86,6 +86,21 @@ Delegated roles are managed from **Settings → Roles** on the Mergify
 dashboard. Only GitHub `Owner`s and users holding the **Delegation Admin**
 role can grant or revoke them.
 
+:::note
+  **Onboarding exception: the first trial.** Starting your organization's
+  **first** trial is a self-service action. Any organization member can
+  start it, even without the GitHub `Owner` role, and Mergify automatically
+  grants them the **Billing Admin** role so they can manage the subscription
+  they create from it.
+
+  This is a one-time onboarding bootstrap. It cannot escalate privileges on
+  an established organization: it applies only while the organization has
+  never had a subscription, and once one exists (active or canceled),
+  starting another trial is rejected, so the automatic grant can no longer
+  be triggered. Billing Admin grants billing access only; it grants no
+  repository, queue, or configuration access.
+:::
+
 Each user can hold any combination of the following roles:
 
 <table>


### PR DESCRIPTION
The security page documents subscription management as Owner-only and says
only Owners or a Delegation Admin can grant delegated roles. It omitted the
onboarding bootstrap: any organization member can start the org's first
trial, and doing so auto-grants them the Billing Admin role. This gap read
as a privilege-escalation path (HackerOne #3873281) when it is intended
one-time behavior.

Add a note in the Delegated Roles section, right after the grant/revoke
rule it qualifies, making explicit that the first trial is a self-service
action any member can start, that it self-grants Billing Admin scoped to
billing only, and that it is a one-time bootstrap (rejected once any
subscription has existed), not an ongoing escalation path.

Scoped the auto-grant to the trial specifically: verified against the
engine source that a direct paid checkout does not auto-grant at
initiation, so only the trial path is stated. billing.mdx needs no change
(it never states who can start a trial).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>