### PR TITLE
docs(data-types): singularize the Report Mode section

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -16,6 +16,7 @@ import remarkSmartypants from 'remark-smartypants';
 import { asideAutoImport, astroAsides } from './integrations/astro-asides';
 import { astroYoutubeEmbeds, youtubeAutoImport } from './integrations/astro-youtube-embed';
 import { PagefindIndex } from './integrations/pagefind-index';
+import { validateDataTypeAnchors } from './integrations/validate-data-type-anchors';
 import { autolinkConfig } from './plugins/rehype-autolink-config';
 import { rehypeOptimizeStatic } from './plugins/rehype-optimize-static';
 import { rehypeTasklistEnhancer } from './plugins/rehype-tasklist-enhancer';
@@ -52,6 +53,7 @@ export default defineConfig({
         !page.includes('/merge-queue/migrate-partitions-to-scopes'),
     }),
     PagefindIndex(),
+    validateDataTypeAnchors(),
     icon({
       include: {
         lucide: ['*'],

--- a/integrations/validate-data-type-anchors.ts
+++ b/integrations/validate-data-type-anchors.ts
@@ -1,0 +1,32 @@
+import type { AstroIntegration } from 'astro';
+import rawConfigSchema from '../public/mergify-configuration-schema.json';
+import { missingDataTypeAnchors } from '../src/util/dataTypeAnchors';
+
+/**
+ * Fail the build when the config schema flags a documented data type whose
+ * derived anchor (slugified `title`) has no matching heading on the
+ * data-types page. This is the enforcement point that actually guards the
+ * drift path: schema syncs land as direct bot pushes to main (no PR, so no
+ * PR CI), and the deploy build is the only gate they pass through.
+ * dataType.test.ts runs the same check in PR CI for earlier feedback on
+ * docs-side edits.
+ */
+export function validateDataTypeAnchors(): AstroIntegration {
+  return {
+    name: 'validate-data-type-anchors',
+    hooks: {
+      'astro:build:start': () => {
+        const missing = missingDataTypeAnchors(rawConfigSchema);
+        if (missing.length > 0) {
+          throw new Error(
+            `Documented data type(s) in public/mergify-configuration-schema.json have no ` +
+              `matching heading anchor on src/content/docs/configuration/data-types.mdx: ` +
+              `${missing.join(', ')}. A marked node's slugified title must equal the anchor ` +
+              `of its section heading (add the missing section, or fix the title next to the ` +
+              `engine's DocsDataType annotation).`
+          );
+        }
+      },
+    },
+  };
+}

--- a/src/components/Tables/ConfigOptions.test.tsx
+++ b/src/components/Tables/ConfigOptions.test.tsx
@@ -1,0 +1,113 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { getValueTypeText } from '~/util/schemaToMarkdown';
+import { getValueType } from './ConfigOptions';
+
+// The x-has-data-type contract, render side: a node flagged as a documented data
+// type becomes a link to its data-types section instead of an expansion of
+// its shape, for both the HTML tables (getValueType) and the markdown/LLM
+// export (getValueTypeText). The node's `title` drives the label and the
+// anchor (slugified title). The flag may sit inline or beside a `$ref`
+// (pydantic's shape for types hoisted into $defs, where the title lives on
+// the $defs target). dataType.test.ts covers the page side (title↔anchor).
+
+const HREF = '/configuration/data-types#queue-dequeue-reason';
+
+const inlineMarked = {
+  title: 'Queue dequeue reason',
+  'x-has-data-type': true,
+  anyOf: [{ enum: ['PR_MERGED', 'PR_DEQUEUED'], type: 'string' }, { type: 'null' }],
+};
+
+function render(schema: object, definition: object): string {
+  const element = getValueType(schema, definition);
+  return element === null ? '' : renderToStaticMarkup(element);
+}
+
+describe('getValueType with x-has-data-type', () => {
+  it('links an inline-flagged node instead of expanding its enum', () => {
+    const html = render({}, inlineMarked);
+    expect(html).toContain(`href="${HREF}"`);
+    expect(html).toContain('Queue dequeue reason');
+    expect(html).not.toContain('PR_MERGED');
+  });
+
+  it('links a flag published as a $ref sibling, taking the title from the target', () => {
+    const schema = { $defs: { QueueCode: { title: 'Queue dequeue reason', type: 'string' } } };
+    const html = render(schema, { $ref: '#/$defs/QueueCode', 'x-has-data-type': true });
+    expect(html).toContain(`href="${HREF}"`);
+    expect(html).toContain('Queue dequeue reason');
+  });
+
+  it('links a flag on a $defs entry reached through a plain $ref', () => {
+    const schema = {
+      $defs: {
+        QueueCode: { 'x-has-data-type': true, title: 'Queue dequeue reason', type: 'string' },
+      },
+    };
+    const html = render(schema, { $ref: '#/$defs/QueueCode' });
+    expect(html).toContain(`href="${HREF}"`);
+  });
+
+  it('renders "list of" around $ref items pointing at a flagged $defs entry', () => {
+    const schema = {
+      $defs: {
+        ReportMode: {
+          'x-has-data-type': true,
+          title: 'Report Modes',
+          enum: ['check', 'comment'],
+          type: 'string',
+        },
+      },
+    };
+    const html = render(schema, { type: 'array', items: { $ref: '#/$defs/ReportMode' } });
+    expect(html).toContain('list of');
+    expect(html).toContain('href="/configuration/data-types#report-modes"');
+    expect(html).toContain('Report Modes');
+    expect(html).not.toContain('check');
+  });
+
+  it('falls back to the previous rendering when a flagged node has no title', () => {
+    const html = render({}, { 'x-has-data-type': true, enum: ['check', 'comment'] });
+    expect(html).not.toContain('href');
+    expect(html).toContain('check');
+  });
+
+  it('does not crash on a dangling $ref', () => {
+    expect(() => render({ $defs: {} }, { $ref: '#/$defs/Gone' })).not.toThrow();
+  });
+
+  it('still expands unmarked enums', () => {
+    const html = render({}, { enum: ['check', 'comment'] });
+    expect(html).toContain('check');
+    expect(html).toContain('comment');
+  });
+});
+
+describe('getValueTypeText with x-has-data-type', () => {
+  it('emits a markdown link instead of the enum dump', () => {
+    expect(getValueTypeText({} as never, inlineMarked)).toBe(`[Queue dequeue reason](${HREF})`);
+  });
+
+  it('emits "list of" around $ref items pointing at a flagged $defs entry', () => {
+    const schema = {
+      $defs: {
+        ReportMode: {
+          'x-has-data-type': true,
+          title: 'Report Modes',
+          enum: ['check', 'comment'],
+          type: 'string',
+        },
+      },
+    };
+    expect(
+      getValueTypeText(schema as never, { type: 'array', items: { $ref: '#/$defs/ReportMode' } })
+    ).toBe('list of [Report Modes](/configuration/data-types#report-modes)');
+  });
+
+  it('still expands unmarked enums', () => {
+    expect(getValueTypeText({} as never, { enum: ['check', 'comment'] })).toBe(
+      '`check` or `comment`'
+    );
+  });
+});

--- a/src/components/Tables/ConfigOptions.tsx
+++ b/src/components/Tables/ConfigOptions.tsx
@@ -1,6 +1,7 @@
 import jsonpointer from 'jsonpointer';
 import React, { ReactElement } from 'react';
-import configSchema from '../../util/sanitizedConfigSchema';
+import { getDataTypeHref, isDataType } from '~/util/dataType';
+import configSchema from '~/util/sanitizedConfigSchema';
 import { renderMarkdown } from './utils';
 
 const valueTypeLinks: { [key: string]: string } = {
@@ -112,9 +113,68 @@ function getTitle(schema: object, ref: OptionDefinitionRef): string {
   return item?.title || item?.name || '';
 }
 
+// A node flagged `x-has-data-type: true` is a documented data type: link to its
+// data-types section instead of expanding the node's shape — an enum such as
+// `queue-dequeue-reason` would otherwise dump its forty codes into the type
+// cell. The node's `title` drives both the label and the anchor (slugified
+// title == section heading anchor; the build gate enforces it). pydantic
+// publishes the flag inline for inlined types but as a *sibling of `$ref`*
+// for types hoisted into `$defs`, so check each node along the `$ref` chain,
+// starting with the raw node, and stop quietly on a dangling `$ref` rather
+// than crashing the build.
+function getDataTypeLink(schema: object, definition: unknown): ReactElement | null {
+  let node = definition;
+  let marked = isDataType(node);
+  for (let hops = 0; !marked && hops < 10; hops++) {
+    if (node === null || typeof node !== 'object') {
+      break;
+    }
+    const ref = (node as { $ref?: unknown }).$ref;
+    if (typeof ref !== 'string') {
+      break;
+    }
+    node = getItemFromSchema(schema, ref);
+    marked = isDataType(node);
+  }
+  if (!marked) {
+    return null;
+  }
+
+  // A `$ref`-sibling flag carries no title of its own — it lives on the
+  // `$defs` target — so follow one more hop for the title if needed.
+  let titled = node as { title?: string; $ref?: unknown };
+  if (titled.title === undefined && typeof titled.$ref === 'string') {
+    titled = getItemFromSchema(schema, titled.$ref) ?? titled;
+  }
+  const title = titled?.title;
+  if (!title) {
+    // Invalid marker (no title to derive from) — the anchor check reports
+    // it; render the node's shape as before instead of a broken link.
+    return null;
+  }
+
+  // Plain text, not renderMarkdown: markdown rendering emits a block-level
+  // <p> that would break inline composition ("list of <link>", "X or Y").
+  return (
+    <a style={{ textDecoration: 'underline' }} href={getDataTypeHref(title)}>
+      {title}
+    </a>
+  );
+}
+
 export function getValueType(schema: object, definition: any): React.ReactElement | null {
+  const dataTypeLink = getDataTypeLink(schema, definition);
+  if (dataTypeLink !== null) {
+    return dataTypeLink;
+  }
+
   let valueType: ReactElement | null = null;
   if (definition.type === 'array') {
+    const itemsDataTypeLink = getDataTypeLink(schema, definition.items);
+    if (itemsDataTypeLink !== null) {
+      return <>list of {itemsDataTypeLink}</>;
+    }
+
     let typeLink: string | undefined;
     let typeDescription: string | React.ReactElement | null;
 
@@ -168,10 +228,10 @@ export function getValueType(schema: object, definition: any): React.ReactElemen
           }
 
           return (
-            <>
+            <React.Fragment key={index}>
               {getValueType(schema, item)}
               {separator}
-            </>
+            </React.Fragment>
           );
         })}
       </>

--- a/src/content/docs/configuration/data-types.mdx
+++ b/src/content/docs/configuration/data-types.mdx
@@ -444,7 +444,7 @@ The following reasons can be reported:
 
 <QueueDequeueReasons />
 
-## Report Modes
+## Report Mode
 
 Report modes allow you to choose the type of report you want for your actions.
 Report mode values can be expressed in the configuration as a list of strings.

--- a/src/util/dataType.test.ts
+++ b/src/util/dataType.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import configSchema from '../../public/mergify-configuration-schema.json';
+import { collectDataTypeTitles, getDataTypeHref, isDataType } from './dataType';
+import { dataTypesHeadingAnchors, missingDataTypeAnchors } from './dataTypeAnchors';
+
+describe('isDataType', () => {
+  it('recognizes flagged nodes only', () => {
+    expect(isDataType({ 'x-has-data-type': true })).toBe(true);
+    expect(isDataType({ 'x-has-data-type': 'queue-dequeue-reason' })).toBe(false);
+    expect(isDataType({ type: 'string' })).toBe(false);
+    expect(isDataType(null)).toBe(false);
+    expect(isDataType('string')).toBe(false);
+  });
+});
+
+describe('getDataTypeHref', () => {
+  it('derives the anchor from the title, matching heading slugs regardless of case', () => {
+    expect(getDataTypeHref('Queue dequeue reason')).toBe(
+      '/configuration/data-types#queue-dequeue-reason'
+    );
+    expect(getDataTypeHref('Report Modes')).toBe('/configuration/data-types#report-modes');
+  });
+});
+
+describe('collectDataTypeTitles', () => {
+  it('finds flagged nodes wherever they appear in a schema', () => {
+    const schema = {
+      $defs: {
+        ReportMode: { 'x-has-data-type': true, title: 'Report Modes' },
+      },
+      properties: {
+        reason: {
+          anyOf: [{ 'x-has-data-type': true, title: 'Queue dequeue reason' }, { type: 'null' }],
+        },
+        report_mode: { type: 'array', items: { $ref: '#/$defs/ReportMode' } },
+        untitled: { 'x-has-data-type': true },
+      },
+    };
+    expect(collectDataTypeTitles(schema).sort()).toEqual([
+      'Queue dequeue reason',
+      'Report Modes',
+      undefined,
+    ]);
+  });
+});
+
+describe('data-types page anchors', () => {
+  // Every data-types anchor the site links to — the anchors derived from the
+  // engine's marked titles plus the anchors hardcoded in ConfigOptions'
+  // legacy link maps. Renaming one of these headings breaks live links even
+  // though the build still succeeds, so pin them here.
+  it('exposes every anchor the site links to', () => {
+    const anchors = dataTypesHeadingAnchors();
+    for (const expected of [
+      // derived from titles the engine marks with x-has-data-type
+      'queue-dequeue-reason',
+      'priority',
+      'report-modes',
+      'schedule',
+      // anchors hardcoded in ConfigOptions.tsx link maps
+      'commit',
+      'commit-author',
+      'github-repository-permissions',
+      'legacy-template',
+      'timestamp',
+      'duration',
+      'message-template',
+      'title-template',
+      'body-template',
+      'workflow-input-template',
+      'user',
+      'assignee',
+      'bot-account',
+    ]) {
+      expect(anchors).toContain(expected);
+    }
+  });
+
+  // The title-derived-anchor convention, checked against the synced schema.
+  // The same check gates the deploy build (integrations/validate-data-type-
+  // anchors.ts) because schema syncs land as direct pushes to main and never
+  // see PR CI; this test surfaces the failure earlier for docs-side edits.
+  it('covers every documented data type flagged in the config schema', () => {
+    expect(missingDataTypeAnchors(configSchema)).toEqual([]);
+  });
+});

--- a/src/util/dataType.test.ts
+++ b/src/util/dataType.test.ts
@@ -18,7 +18,7 @@ describe('getDataTypeHref', () => {
     expect(getDataTypeHref('Queue dequeue reason')).toBe(
       '/configuration/data-types#queue-dequeue-reason'
     );
-    expect(getDataTypeHref('Report Modes')).toBe('/configuration/data-types#report-modes');
+    expect(getDataTypeHref('Report Mode')).toBe('/configuration/data-types#report-mode');
   });
 });
 
@@ -26,7 +26,7 @@ describe('collectDataTypeTitles', () => {
   it('finds flagged nodes wherever they appear in a schema', () => {
     const schema = {
       $defs: {
-        ReportMode: { 'x-has-data-type': true, title: 'Report Modes' },
+        ReportMode: { 'x-has-data-type': true, title: 'Report Mode' },
       },
       properties: {
         reason: {
@@ -38,7 +38,7 @@ describe('collectDataTypeTitles', () => {
     };
     expect(collectDataTypeTitles(schema).sort()).toEqual([
       'Queue dequeue reason',
-      'Report Modes',
+      'Report Mode',
       undefined,
     ]);
   });
@@ -55,7 +55,7 @@ describe('data-types page anchors', () => {
       // derived from titles the engine marks with x-has-data-type
       'queue-dequeue-reason',
       'priority',
-      'report-modes',
+      'report-mode',
       'schedule',
       // anchors hardcoded in ConfigOptions.tsx link maps
       'commit',

--- a/src/util/dataType.ts
+++ b/src/util/dataType.ts
@@ -1,0 +1,57 @@
+import { slugify } from './slugify';
+
+// The engine flags a schema node that corresponds to a documented Mergify
+// data type with `x-has-data-type: true`. Everything else derives from the node's
+// standard `title`: the link label is the title, and the link target is the
+// slugified title, which by convention equals the section heading anchor on
+// /configuration/data-types. The convention is enforced where drift can
+// actually arrive: the Astro build fails when a marked title has no matching
+// heading anchor (schema syncs land as direct pushes to main, so the deploy
+// build is the gate), and dataType.test.ts gives the same signal earlier, in
+// PR CI.
+const DATA_TYPE_KEY = 'x-has-data-type';
+
+const DATA_TYPES_PAGE = '/configuration/data-types';
+
+export function isDataType(definition: unknown): boolean {
+  return (
+    !!definition &&
+    typeof definition === 'object' &&
+    (definition as Record<string, unknown>)[DATA_TYPE_KEY] === true
+  );
+}
+
+export function getDataTypeHref(title: string): string {
+  return `${DATA_TYPES_PAGE}#${slugify(title)}`;
+}
+
+/**
+ * Walk a JSON schema and return the `title` of every node flagged
+ * `x-has-data-type: true`, wherever the flag appears (inline property nodes,
+ * `$ref` siblings, `$defs` entries, array items, `anyOf` branches). A marked
+ * node without a title yields `undefined` — an invalid marker the anchor
+ * check reports.
+ */
+export function collectDataTypeTitles(
+  node: unknown,
+  titles: (string | undefined)[] = []
+): (string | undefined)[] {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectDataTypeTitles(item, titles);
+    }
+    return titles;
+  }
+
+  if (node && typeof node === 'object') {
+    if (isDataType(node)) {
+      const title = (node as { title?: unknown }).title;
+      titles.push(typeof title === 'string' ? title : undefined);
+    }
+    for (const value of Object.values(node)) {
+      collectDataTypeTitles(value, titles);
+    }
+  }
+
+  return titles;
+}

--- a/src/util/dataTypeAnchors.ts
+++ b/src/util/dataTypeAnchors.ts
@@ -1,0 +1,61 @@
+// Node-only helpers for the x-has-data-type title↔anchor convention (they read
+// the data-types page from disk). Kept separate from dataType.ts so
+// components can import the marker readers without dragging node:fs into a
+// client bundle.
+import { readFileSync } from 'node:fs';
+import type { Element, Root } from 'hast';
+import rehypeSlug from 'rehype-slug';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { unified } from 'unified';
+import { visit } from 'unist-util-visit';
+import { collectDataTypeTitles } from './dataType';
+import { slugify } from './slugify';
+
+const DATA_TYPES_MDX_URL = new URL('../content/docs/configuration/data-types.mdx', import.meta.url);
+
+/**
+ * The anchors rehype-slug will generate for the data-types page, computed by
+ * running the same `rehype-slug` the site pipeline uses (astro.config.ts) —
+ * same package, same version, so the anchor algorithm and its
+ * duplicate-heading `-1` suffixing can never drift from what deploys.
+ * MDX-specific syntax (imports, JSX tags, `{...}` expressions) parses as
+ * paragraphs or raw nodes here rather than components, which is fine for
+ * heading extraction: headings on the page are plain markdown.
+ */
+export function dataTypesHeadingAnchors(): Set<string> {
+  const mdx = readFileSync(DATA_TYPES_MDX_URL, 'utf8');
+  // Drop YAML frontmatter: its closing `---` would otherwise turn the
+  // preceding lines into a phantom setext heading.
+  const withoutFrontmatter = mdx.replace(/^---\n[\s\S]*?\n---\n/, '');
+
+  const processor = unified().use(remarkParse).use(remarkRehype).use(rehypeSlug);
+  const tree = processor.runSync(processor.parse(withoutFrontmatter)) as Root;
+
+  const anchors = new Set<string>();
+  visit(tree, 'element', (node: Element) => {
+    if (/^h[1-6]$/.test(node.tagName) && typeof node.properties.id === 'string') {
+      anchors.add(node.properties.id);
+    }
+  });
+  return anchors;
+}
+
+/**
+ * The documented-data-type markers in `schema` whose derived anchor
+ * (slugified title) has no matching heading on the data-types page — every
+ * entry is a dead link — plus any marked node missing the title the
+ * derivation needs. Empty when the convention holds.
+ */
+export function missingDataTypeAnchors(schema: unknown): string[] {
+  const anchors = dataTypesHeadingAnchors();
+  const problems = new Set<string>();
+  for (const title of collectDataTypeTitles(schema)) {
+    if (title === undefined) {
+      problems.add('(x-has-data-type node without a title)');
+    } else if (!anchors.has(slugify(title))) {
+      problems.add(`"${title}" → #${slugify(title)}`);
+    }
+  }
+  return [...problems].sort();
+}

--- a/src/util/schemaToMarkdown.ts
+++ b/src/util/schemaToMarkdown.ts
@@ -1,6 +1,7 @@
 import jsonpointer from 'jsonpointer';
 
 import { getAttributeDocumentationUrl, getAttributeSource } from './attributeMetadata';
+import { getDataTypeHref, isDataType } from './dataType';
 import configSchema from './sanitizedConfigSchema';
 
 type Schema = typeof configSchema;
@@ -15,12 +16,55 @@ function getTitle(schema: Schema, ref: string): string {
   return item?.title || item?.name || '';
 }
 
+// Markdown twin of ConfigOptions.getDataTypeLink: a node flagged
+// `x-has-data-type: true` links to its data-types section instead of expanding
+// its shape, with the node's `title` driving both label and anchor. The flag
+// may sit inline or beside a `$ref`, so check each node along the chain.
+function getDataTypeLinkText(schema: Schema, definition: unknown): string | undefined {
+  let node = definition;
+  let marked = isDataType(node);
+  for (let hops = 0; !marked && hops < 10; hops++) {
+    if (node === null || typeof node !== 'object') {
+      break;
+    }
+    const ref = (node as { $ref?: unknown }).$ref;
+    if (typeof ref !== 'string') {
+      break;
+    }
+    node = getItemFromSchema(schema, ref);
+    marked = isDataType(node);
+  }
+  if (!marked) {
+    return undefined;
+  }
+
+  let titled = node as { title?: string; $ref?: unknown };
+  if (titled.title === undefined && typeof titled.$ref === 'string') {
+    titled = getItemFromSchema(schema, titled.$ref) ?? titled;
+  }
+  const title = titled?.title;
+  if (!title) {
+    return undefined;
+  }
+
+  return `[${title}](${getDataTypeHref(title)})`;
+}
+
 /**
  * Plain-text equivalent of ConfigOptions.getValueType — returns a markdown
- * string instead of a React element.
+ * string instead of a React element. Exported for tests.
  */
-function getValueTypeText(schema: Schema, definition: any): string {
+export function getValueTypeText(schema: Schema, definition: any): string {
+  const dataTypeLink = getDataTypeLinkText(schema, definition);
+  if (dataTypeLink !== undefined) {
+    return dataTypeLink;
+  }
+
   if (definition.type === 'array') {
+    const itemsDataTypeLink = getDataTypeLinkText(schema, definition.items);
+    if (itemsDataTypeLink !== undefined) {
+      return `list of ${itemsDataTypeLink}`;
+    }
     if (definition.items?.$ref) {
       return `list of ${getTitle(schema, definition.items.$ref)}`;
     }


### PR DESCRIPTION
The page mixes singular and plural section names; singular is both the
dominant style and the one the config tables already render ("list of
Commit"). Rename the Report Modes section to Report Mode, moving its
anchor to #report-mode — the engine renames the data type's title in
lockstep in its own stacked PR, so the derived links keep matching.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Depends-On: #12159