### PR TITLE
docs(workflow): Mark the github_actions action as deprecated

### DIFF
--- a/src/content/docs/configuration/data-types.mdx
+++ b/src/content/docs/configuration/data-types.mdx
@@ -322,6 +322,11 @@ Used by the [`copy`](/workflow/actions/copy) and
 
 ### Workflow input template
 
+:::note
+  The [`github_actions`](/workflow/actions/github_actions) action is deprecated,
+  and so is this data type.
+:::
+
 Used by the [`github_actions`](/workflow/actions/github_actions) workflow input
 values.
 

--- a/src/content/docs/integrations.mdx
+++ b/src/content/docs/integrations.mdx
@@ -10,7 +10,7 @@ import DocsetGrid from '../../components/DocsetGrid/DocsetGrid.astro';
 
 <DocsetGrid>
   <Docset title="GitHub Actions" path="/integrations/gha" icon="simple-icons:githubactions">
-    CI Insights, Monorepo CI, and Merge Queue Scopes on GitHub Actions. Trigger workflows from Mergify rules.
+    CI Insights, Monorepo CI, and Merge Queue Scopes on GitHub Actions.
   </Docset>
   <Docset title="Buildkite" path="/integrations/buildkite" icon="simple-icons:buildkite">
     CI Insights, Monorepo CI, and Merge Queue Scopes on Buildkite.

--- a/src/content/docs/integrations/gha.mdx
+++ b/src/content/docs/integrations/gha.mdx
@@ -1,6 +1,6 @@
 ---
 title: Integrating GitHub Actions with Mergify
-description: Run CI Insights, Monorepo CI, and Merge Queue Scopes on GitHub Actions, and trigger workflows from Mergify rules.
+description: Run CI Insights, Monorepo CI, and Merge Queue Scopes on GitHub Actions.
 ---
 import ghaLogo from "../../images/integrations/gha/logo.png"
 import IntegrationLogo from "../../../components/IntegrationLogo.astro"
@@ -9,9 +9,9 @@ import IntegrationLogo from "../../../components/IntegrationLogo.astro"
 
 [GitHub Actions](https://github.com/features/actions) is the CI/CD platform
 provided by GitHub. Mergify has native integrations for GitHub Actions covering
-CI Insights, Monorepo CI, and Merge Queue Scopes, and can trigger workflows
-directly from a rule. Any GitHub Actions job status can also be referenced
-from your Mergify [conditions](/configuration/conditions) via `check-success`.
+CI Insights, Monorepo CI, and Merge Queue Scopes. Any GitHub Actions job status
+can also be referenced from your Mergify
+[conditions](/configuration/conditions) via `check-success`.
 
 ## Prerequisites
 
@@ -38,8 +38,8 @@ from your Mergify [conditions](/configuration/conditions) via `check-success`.
   [Nx](/merge-queue/scopes/nx), and
   [Turborepo](/merge-queue/scopes/turborepo) are available.
 
-- **[`github_actions` action](/workflow/actions/github_actions)**: trigger a
-  workflow directly from a Mergify rule.
+- **[`github_actions` action](/workflow/actions/github_actions)** (deprecated):
+  trigger a workflow directly from a Mergify rule.
 
 :::caution
   To match a GitHub Actions status check with `check-success`, use the job

--- a/src/content/docs/workflow/actions.mdx
+++ b/src/content/docs/workflow/actions.mdx
@@ -42,8 +42,8 @@ management.
   <Docset title="Edit" path="edit" icon="octicon:git-pull-request-draft-16">
     Convert a pull request to or from a draft.
   </Docset>
-  <Docset title="GitHub Actions" path="github_actions" icon="simple-icons:githubactions">
-    Dispatch an existing GitHub workflow in the repository.
+  <Docset title="GitHub Actions (Deprecated)" path="github_actions" icon="simple-icons:githubactions">
+    Deprecated — start your workflows from GitHub Actions events instead.
   </Docset>
   <Docset title="Label" path="label" icon="lucide:badge-check">
     Add, remove, or toggle labels on a pull request.

--- a/src/content/docs/workflow/actions/github_actions.mdx
+++ b/src/content/docs/workflow/actions/github_actions.mdx
@@ -1,10 +1,16 @@
 ---
-title: GitHub Actions
-description: Dispatch an existing GitHub workflow in the repository.
+title: GitHub Actions (Deprecated)
+description: Dispatch an existing GitHub workflow in the repository. Deprecated in favor of GitHub Actions events.
 ---
 
 import ActionOptionsTable from '../../../../components/Tables/ActionOptionsTable';
 import OptionsTable from '../../../../components/Tables/OptionsTable';
+
+:::danger
+  The `github_actions` action is **deprecated** and will be removed in a future
+  release. Start your workflows from [GitHub Actions events][gh-events]
+  instead.
+:::
 
 The `github_actions` action enables Mergify to seamlessly dispatch existing
 GitHub workflows within a repository when specified conditions are satisfied.
@@ -61,3 +67,5 @@ pull_request_rules:
               inputs:
                 author: "{{ author }}"
 ```
+
+[gh-events]: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows

--- a/src/content/navItems.tsx
+++ b/src/content/navItems.tsx
@@ -261,7 +261,7 @@ const navItems: NavItem[] = [
             icon: 'octicon:git-pull-request-draft-16',
           },
           {
-            title: 'GitHub Actions',
+            title: 'GitHub Actions (Deprecated)',
             path: '/workflow/actions/github_actions',
             icon: 'simple-icons:githubactions',
           },


### PR DESCRIPTION
Users hitting the deprecation notice in their pull request check run land on
this page, and it still presented the action as a supported choice. The
schema-driven option table cannot say so on its own: the deprecation is
declared on the parent ActionsModel field, and no page renders that model.

Four other surfaces sold the action as current -- the integrations hub card,
the GitHub Actions integration page in its description, intro and feature
list, and the workflow input template data type, whose only consumer is this
action. Marking one page and leaving those made the site contradict itself
depending on where a reader entered.

The removal date and the before/after migration deliberately stay out of the
prose, per AGENTS.md rule 7 -- the changelog owns those. delete_head_branch
shows why: its page still advertises a removal date three weeks past.

References: MRGFY-8147