### PR TITLE
docs(merge-queue): show classic branch protection path for exclusive mode

### DIFF
--- a/src/content/docs/merge-queue/deploy.mdx
+++ b/src/content/docs/merge-queue/deploy.mdx
@@ -5,6 +5,8 @@ description: Deploy Mergify's merge queue with a hybrid approach or enforce excl
 
 import { Image } from "astro:assets";
 import bpDashboardScreenshot from "../../images/merge-queue/deploy/dashboard.png"
+import bpSettingsScreenshot from "../../images/merge-queue/deploy/bp-settings.png"
+import bpRuleScreenshot from "../../images/merge-queue/deploy/bp-rule.png"
 
 Once you've configured your merge queue, you can deploy it using one of two approaches:
 
@@ -76,3 +78,22 @@ GitHub rulesets and provides the most consistent, automated workflow.
 If you want Mergify to bypass the injection of the ruleset rules, see
 [GitHub Rulesets Compatibility](/merge-queue/github-rulesets) for details on
 bypass modes and known incompatibilities.
+
+### Enforcing Exclusive Mode with Classic Branch Protection
+
+Rulesets are the recommended way to enforce exclusive mode. If your repository
+still uses classic branch protection instead, you can achieve the same result
+by restricting who may push to your protected branch to Mergify only.
+
+1. In your repository, open **Settings > Branches** and click **Add branch
+   protection rule**.
+
+   <Image src={bpSettingsScreenshot} alt="GitHub branch protection settings"/>
+
+2. Enter your branch name, enable **Restrict who can push to matching
+   branches**, and add the **Mergify** app to the allowed list.
+
+   <Image src={bpRuleScreenshot} alt="Restrict push access to Mergify"/>
+
+With this rule in place, developers can no longer merge pull requests directly,
+so all merges flow through Mergify's queue.


### PR DESCRIPTION
Wire the two orphaned screenshots in deploy/ (bp-settings.png, bp-rule.png)
into the "Approach 2: Exclusive Mode" section of merge-queue/deploy.mdx.

The exclusive-mode steps previously said "follow the on-screen instructions"
and "click the verification button" without showing the GitHub UI. These two
screenshots document the classic branch-protection way to enforce exclusive
mode: restrict who can push to the protected branch to the Mergify app only.

They are added as a clearly-labeled "Enforcing Exclusive Mode with Classic
Branch Protection" alternative, NOT mixed into the recommended ruleset +
bypass-list flow (which the dashboard actively recommends and which the fresh
deploy/dashboard.png already illustrates). Classic branch protection is a
supported, already-documented path elsewhere in these docs (batches.mdx,
merge-strategies.mdx).

Judgment call for review: the orphaned bp-* assets document classic branch
protection while the current section documents the ruleset flow. If the intent
is for deploy.mdx to stay ruleset-only, drop this commit and the bp-* images
become deletion candidates.

Part 3 (Merge Queue) of the docs screenshot refresh. The other Part 3 items
resolved without a diff: all 7 freshness-verify pages (batches, lifecycle,
merge-strategies, monitoring, pause, setup, deploy) show the current dashboard
/ GitHub UI -> OK, no re-capture; and the github-rulesets.mdx bypass-actor
capture was declined (GitHub's own UI, already a clear textual click-through).

Proofreading: the mandated 4-agent proofread pipeline (style, technical,
structure, consistency) was run this session and passed clean; one precision
fix was applied to the closing sentence.

Refs: MRGFY-8060