### PR TITLE
docs(billing): explain the final invoice after cancellation

### DIFF
--- a/src/content/docs/billing.mdx
+++ b/src/content/docs/billing.mdx
@@ -124,11 +124,17 @@ href="mailto:support@mergify.com">please contact our customer
 support</a>. They'll guide you through the process and ensure a
 smooth transition.
 
+When you cancel, your subscription stays active until the end of the billing
+period you already paid for, and it does not renew. You may still receive one
+last invoice on that final day (see [Final Invoice After
+Cancellation](#3-final-invoice-after-cancellation) below).
+
 ## Understanding Your Invoice
 
 Our billing system aims for fairness, but its dynamic nature may result in
-invoices that can be complex to understand at first glance. Each invoice
-comprises two main sections:
+invoices that can be complex to understand at first glance. A regular invoice
+comprises two main sections. Cancelling your subscription produces one more
+invoice, which works differently and is covered last.
 
 ### 1. **Real-time User Adjustment**
 
@@ -165,5 +171,19 @@ adjustment mentioned earlier.
   <figcaption>Invoice lines for the upcoming billing period.</figcaption>
 </figure>
 
-By understanding these two sections, you can more easily interpret and
+### 3. **Final Invoice After Cancellation**
+
+When you cancel your subscription, it stays active until the end of the billing
+period you already paid for, then ends without renewing. You may still receive
+one last invoice dated on that final day.
+
+That last invoice covers your final billing period, not a renewal. It collects
+the [real-time user adjustments](#1-real-time-user-adjustment) described above:
+when your user count changes mid-period, the prorated difference is only settled
+on the next invoice, which for a cancelled subscription is the final one, issued
+when the period ends. So if your team grew during your last month, that growth
+is billed on the day your subscription ends. Once you pay it, you won't be
+charged again.
+
+By understanding how your invoices are built, you can more easily interpret and
 anticipate how changes in your contributors influence your Mergify charges.


### PR DESCRIPTION
Customers who cancel mid-period are told their subscription stays active
through the end of the period they already paid for. When their contributor
count grew during that last period, Stripe collects the accrued prorations on
the next invoice — which, for a cancelling subscription, is the final one,
dated on the very last day. Customers read that as "I cancelled and got billed
anyway" (see Plain T-4504).

The billing page documented the two invoice sections but nothing about
cancellation mechanics or this final true-up. This adds:

- a paragraph in "Switching or Cancelling Plans" stating the subscription ends
  at period end without renewing, and warning that one last invoice may arrive
  on that final day;
- a new "3. Final Invoice After Cancellation" subsection under "Understanding
  Your Invoice" explaining that this invoice is a proration true-up for the
  final period, not a renewal, and that nothing is charged after it.

The "Understanding Your Invoice" intro and closing sentence are adjusted since
the page no longer describes exactly two subsections.