### PR TITLE
docs(workflow): fix action reference accuracy and style drift

### DIFF
--- a/src/content/docs/workflow/actions.mdx
+++ b/src/content/docs/workflow/actions.mdx
@@ -9,13 +9,11 @@ import DocsetGrid from '../../../components/DocsetGrid/DocsetGrid.astro';
 Actions are the engine that powers Mergify. They define what Mergify should do
 when a set of conditions is met. This can range from merging a pull request,
 updating it with the latest changes, commenting on the pull request, assigning
-it to a user, adding labels, and so much more.
+it to a user, adding labels, and more.
 
-In essence, actions are the tasks that Mergify performs on your behalf to
-automate your pull request management workflow. By carefully crafting and
-combining actions, you can create a highly efficient and automated process
-that takes care of most of the routine tasks associated with pull request
-management.
+Actions are the tasks that Mergify performs on your behalf. By combining
+actions, you can automate most of the routine tasks associated with pull
+request management.
 
 <DocsetGrid>
   <Docset title="Assign" path="assign" icon="lucide:user-plus">
@@ -34,7 +32,7 @@ management.
     Post a comment on a pull request.
   </Docset>
   <Docset title="Delete Head Branch (Deprecated)" path="delete_head_branch" icon="lucide:scissors">
-    Deprecated — use GitHub's built-in "Automatically delete head branches" setting instead.
+    Deprecated. Use GitHub's built-in "Automatically delete head branches" setting instead.
   </Docset>
   <Docset title="Dismiss Reviews" path="dismiss_reviews" icon="lucide:message-square-x">
     Dismiss previous reviews on a pull request.
@@ -43,7 +41,7 @@ management.
     Convert a pull request to or from a draft.
   </Docset>
   <Docset title="GitHub Actions (Deprecated)" path="github_actions" icon="simple-icons:githubactions">
-    Deprecated — start your workflows from GitHub Actions events instead.
+    Deprecated. Start your workflows from GitHub Actions events instead.
   </Docset>
   <Docset title="Label" path="label" icon="lucide:badge-check">
     Add, remove, or toggle labels on a pull request.
@@ -52,7 +50,7 @@ management.
     Automate the merging of your pull requests.
   </Docset>
   <Docset title="Post Check (Deprecated)" path="post_check" icon="lucide:circle-check">
-    Deprecated — use Merge Protections instead.
+    Deprecated. Use Merge Protections instead.
   </Docset>
   <Docset title="Queue" path="queue" icon="mergify:merge-queue" neutral>
     Add the pull request to the merge queue.

--- a/src/content/docs/workflow/actions/assign.mdx
+++ b/src/content/docs/workflow/actions/assign.mdx
@@ -8,9 +8,7 @@ import ActionOptionsTable from '../../../../components/Tables/ActionOptionsTable
 The `assign` action allows you to assign one or more users to a pull request
 when the conditions you specify are met. This can help automate the process of
 designating the right people to handle specific pull requests, based on your
-conditions. This can significantly streamline your pull request management
-process and ensure that the right people are always aware of and working on the
-pull requests that require their attention.
+conditions.
 
 ## Parameters
 

--- a/src/content/docs/workflow/actions/backport.mdx
+++ b/src/content/docs/workflow/actions/backport.mdx
@@ -10,7 +10,7 @@ The `backport` action enables you to automatically create a backport of a
 merged pull request. When the conditions you specify are met, Mergify will
 create a new pull request to merge the changes into the specified base branch.
 
-The `backport` action is extremely useful for maintaining older versions of
+The `backport` action is useful for maintaining older versions of
 your project. It helps automate the process of applying bug fixes or other
 changes from the main branch to other branches.
 
@@ -123,6 +123,6 @@ defaults:
 ```
 
 :::note
-  Pull request author will need to log at least once in the Mergify dashboard
-  for a pull request to be created on their behalf.
+  The pull request author will need to log in to the Mergify dashboard at
+  least once for a pull request to be created on their behalf.
 :::

--- a/src/content/docs/workflow/actions/close.mdx
+++ b/src/content/docs/workflow/actions/close.mdx
@@ -15,10 +15,10 @@ want to ensure that certain types of pull requests are not merged.
 
 ## Examples
 
-### Automatically close pull request touching a file
+### Automatically close pull requests touching a file
 
-If you wanted to automatically close pull request that touches a certain file,
-let's say `do_not_touch.txt`, you could write a rule such as:
+If you want to automatically close any pull request that touches a certain
+file, let's say `do_not_touch.txt`, you could write a rule such as:
 
 ```yaml
 pull_request_rules:

--- a/src/content/docs/workflow/actions/comment.mdx
+++ b/src/content/docs/workflow/actions/comment.mdx
@@ -8,10 +8,8 @@ import ActionOptionsTable from '../../../../components/Tables/ActionOptionsTable
 The `comment` action allows Mergify to post a comment on your pull request when
 certain conditions are met.
 
-The comment action is a powerful tool that can provide automated responses to
-various events in your pull request workflow. By customizing the conditions and
-the message, you can create a more interactive and responsive experience for
-your contributors.
+The comment action can provide automated responses to events in your pull
+request workflow, based on the conditions and message you customize.
 
 ## Parameters
 
@@ -42,7 +40,7 @@ notified automatically by Mergify. You can do this using this rule:
 
 ```yaml
 pull_request_rules:
-  - name: comment when a pull request is merged
+  - name: comment when a pull request is in conflict
     conditions:
       - conflict
     actions:

--- a/src/content/docs/workflow/actions/delete_head_branch.mdx
+++ b/src/content/docs/workflow/actions/delete_head_branch.mdx
@@ -6,8 +6,8 @@ description: Delete pull request head branch. Deprecated in favor of GitHub's bu
 import ActionOptionsTable from '../../../../components/Tables/ActionOptionsTable';
 
 :::danger
-  The `delete_head_branch` action is **deprecated** and will be removed on
-  June 30, 2026. Use GitHub's built-in
+  The `delete_head_branch` action is **deprecated** and will be removed in a
+  future release. Use GitHub's built-in
   [automatically delete head branches][gh-auto-delete] setting instead.
 :::
 
@@ -37,8 +37,5 @@ pull_request_rules:
 In this example, Mergify will automatically delete the head branch of a pull
 request once it has been merged, but only if the pull request has been labeled
 with "cleanup".
-
-The `delete_head_branch` action is a simple yet powerful tool that can help
-maintain the cleanliness and organization of your repository.
 
 [gh-auto-delete]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches

--- a/src/content/docs/workflow/actions/dismiss_reviews.mdx
+++ b/src/content/docs/workflow/actions/dismiss_reviews.mdx
@@ -7,8 +7,6 @@ import ActionOptionsTable from '../../../../components/Tables/ActionOptionsTable
 
 The `dismiss_reviews` action allows Mergify to automatically dismiss approved
 or changes requested reviews when new commits are pushed to the pull request.
-It is a powerful tool that can help maintain the freshness and relevance of
-reviews in your pull request workflow.
 
 ## Parameters
 

--- a/src/content/docs/workflow/actions/github_actions.mdx
+++ b/src/content/docs/workflow/actions/github_actions.mdx
@@ -12,15 +12,13 @@ import OptionsTable from '../../../../components/Tables/OptionsTable';
   [migration guide](/workflow/actions/migrate-github-actions).
 :::
 
-The `github_actions` action enables Mergify to seamlessly dispatch existing
+The `github_actions` action enables Mergify to dispatch existing
 GitHub workflows within a repository when specified conditions are satisfied.
-By integrating this action, users can optimize their CI/CD pipeline, invoking
-specific GitHub Actions based on Mergify's conditions.
 
 :::note
   To use the `github_actions` action, ensure your workflow includes the
-  `workflow_dispatch` trigger. Additionally, Mergify requires write permissions
-  on Actions. Navigate to Mergify's UI to accept the permissions necessary for
+  `workflow_dispatch` trigger. Mergify also requires write permissions
+  on Actions. Go to Mergify's UI to accept the permissions necessary for
   this action.
 :::
 

--- a/src/content/docs/workflow/actions/label.mdx
+++ b/src/content/docs/workflow/actions/label.mdx
@@ -8,8 +8,7 @@ import { Image } from "astro:assets"
 import prConflictScreenshot from "../../../images/workflow/actions/label/conflict-pr-list.png"
 
 The `label` action allows Mergify to automatically add or remove labels from a
-pull request based on the conditions specified in your rules, making your
-workflow more organized and efficient.
+pull request based on the conditions specified in your rules.
 
 :::caution
   **Avoid rule pairs that flip the same label.** If one rule adds a label and
@@ -56,8 +55,8 @@ rule anymore, the label will be removed.
 
 ### Warn on Conflicts
 
-When browsing the list of pull request, GitHub does not give any indication on
-which pull requests might be in conflict. Mergify allows to do this easily by
+When browsing the list of pull requests, GitHub does not give any indication on
+which pull requests might be in conflict. Mergify lets you do this by
 adding a label.
 
 ```yaml
@@ -79,7 +78,7 @@ Then, your pull request list will look like this on conflict:
 
 ### Toggle A Label Based on CI Status
 
-This rule toggle a label based on the failure status of a CI system.
+This rule toggles a label based on the failure status of a CI system.
 
 ```yaml
 pull_request_rules:

--- a/src/content/docs/workflow/actions/merge.mdx
+++ b/src/content/docs/workflow/actions/merge.mdx
@@ -8,21 +8,20 @@ import { Image } from "astro:assets"
 import branchProtectionConditionsScreenshot from "../../../images/workflow/actions/merge/branch-protections-injection.png"
 
 The `merge` action allows Mergify to automatically merge pull requests when
-certain conditions are met. This can significantly streamline your workflow by
-reducing the need for manual intervention.
+certain conditions are met. This reduces the need for manual intervention.
 
 Whatever your conditions are, Mergify might inject extra conditions for the
 merge action to take place:
 
 - Mergify always respects the [branch protection settings](#branch-protection-conditions)
 
-- Mergify always respect [pull request dependencies](#pull-request-dependencies)
+- Mergify always respects [pull request dependencies](#pull-request-dependencies)
 
-- Mergify always respect the [merge date](#merge-date)
+- Mergify always respects the [merge date](#merge-date)
 
-- Mergify allows merging pull request modifying its configuration file by
+- Mergify allows merging pull requests that modify its configuration file by
   default. But Mergify will always check whether these changes are
-  valid or not, to avoid merging broken configurations.
+  valid, to avoid merging broken configurations.
 
 ## Branch Protection Conditions
 

--- a/src/content/docs/workflow/actions/post_check.mdx
+++ b/src/content/docs/workflow/actions/post_check.mdx
@@ -5,7 +5,6 @@ description: Create a check-run on a pull request. Deprecated in favor of Merge 
 
 import { Image } from 'astro:assets';
 import ActionOptionsTable from '../../../../components/Tables/ActionOptionsTable';
-import Button from '../../../../components/Button.astro';
 import PostCheckScreenshot from '../../../images/workflow/actions/post_check/post-check-actions.png';
 
 :::danger
@@ -54,7 +53,7 @@ merge_protections:
 ```
 
 :::note
-  The `title` and `summary` options have no equivalent in merge protections
+  The `title` and `summary` options have no equivalent in Merge Protections
   and will be dropped during the automatic migration.
 :::
 

--- a/src/content/docs/workflow/actions/queue.mdx
+++ b/src/content/docs/workflow/actions/queue.mdx
@@ -9,7 +9,7 @@ The `queue` action allows you to put a pull request into the [merge
 queue](/merge-queue). By placing pull requests in the queue, you can make sure
 they are up-to-date and control their processing based on their priority.
 
-If you have enabled [`auto_merge`](/merge-protections/auto-merge) in
+If you have enabled [`auto_merge_conditions`](/merge-protections/auto-merge) in
 `merge_protections_settings`, matching pull requests are added automatically
 and you usually do not need this action. Use the action when you want explicit,
 rule-driven or conditional enqueueing beyond what `queue_conditions` express.

--- a/src/content/docs/workflow/actions/rebase.mdx
+++ b/src/content/docs/workflow/actions/rebase.mdx
@@ -17,8 +17,9 @@ up-to-date with the latest changes from the base branch.
 :::
 
 :::caution
-  The `rebase` action with `bot_account` will no longer support fork pull
-  requests after **July 1, 2026**. If you use this configuration on
+  Support for the `rebase` action with `bot_account` on fork pull requests is
+  **deprecated** and will be removed in a future release. If you use this
+  configuration on
   repositories that receive PRs from forks, switch to the
   [`update` action](/workflow/actions/update) instead.
 :::

--- a/src/content/docs/workflow/actions/request_reviews.mdx
+++ b/src/content/docs/workflow/actions/request_reviews.mdx
@@ -10,7 +10,7 @@ or teams. This is useful when you want to ensure specific team members review
 certain pull requests.
 
 :::note
-  GitHub does not allow to request more than 15 users or teams for a review.
+  GitHub does not allow requesting more than 15 users or teams for a review.
 :::
 
 ## Parameters

--- a/src/content/docs/workflow/actions/review.mdx
+++ b/src/content/docs/workflow/actions/review.mdx
@@ -8,9 +8,7 @@ import ActionOptionsTable from '../../../../components/Tables/ActionOptionsTable
 The `review` action provides you with an automated way to review pull requests.
 This can be particularly useful in situations where you want to automatically
 approve pull requests that meet certain criteria, or to request changes on a
-pull request when a particular check fails. By automating this process, you can
-increase the efficiency of your workflow and ensure consistency in the way pull
-requests are reviewed in your repository.
+pull request when a particular check fails.
 
 ## Parameters
 
@@ -37,15 +35,15 @@ checks have passed successfully.
 ### Approve Dependabot Pull Requests
 
 You can use Mergify to review a pull request on your behalf. This can be handy
-if you require a minimum number of review to be present on a pull request
+if you require a minimum number of reviews to be present on a pull request
 (e.g., due to [branch
 protection](https://docs.github.com/en/github/administering-a-repository/about-protected-branches))
-but want to automate some merge.
+but want to automate some merges.
 
-[Dependabot](https://github.com/features/security) is the bot behind GitHub
-automatic security update. It sends automatic updates for your project's
+[Dependabot](https://github.com/features/security) is the bot behind GitHub's
+automatic security updates. It sends automatic updates for your project's
 dependencies, making sure they are secure. You can automate the approval of
-pull request created by `dependabot` with a rule such as:
+pull requests created by `dependabot` with a rule such as:
 
 ```yaml
 pull_request_rules:

--- a/src/content/docs/workflow/actions/update.mdx
+++ b/src/content/docs/workflow/actions/update.mdx
@@ -48,8 +48,8 @@ pull_request_rules:
 
 As GitHub supports linear history in pull request settings, it is very handy to
 use a rule to keep your pull requests up-to-date. As you do not want to trigger
-your CI too often by always re-running it on every pull request — especially
-when there is still work in progress — you can limit this action to labeled
+your CI too often by always re-running it on every pull request (especially
+when there is still work in progress), you can limit this action to labeled
 pull requests.
 
 ```yaml


### PR DESCRIPTION
First docs-health audit pass over the action reference pages. Accuracy fixes
verified against the config JSON schema and the engine source:

- queue: reference `auto_merge_conditions` instead of the deprecated
  `auto_merge`
- comment: fix the copy-pasted rule name in the conflict example (was
  "comment when a pull request is merged" on a `conflict` condition)
- delete_head_branch and rebase: convert dated deprecation notices to
  dateless markers per the repo rule (both dates had passed; the
  delete_head_branch date also disagreed with the engine's actual deadline,
  flagged separately in the audit report)
- post_check: drop the unused Button import; name Merge Protections as the
  feature in prose

Every documented option, default, and enum on all 21 action pages was
cross-checked against the schema; the rest were accurate.

Plus a conservative style pass per the proofread rubrics: banned words,
promotional filler sentences, em dashes, and a dozen grammar fixes across
15 pages.

Part of the first manual docs-health audit (MRGFY-8212).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Depends-On: #12205