### PR TITLE
docs(merge-queue): fix accuracy drift and style across the section

### DIFF
--- a/src/content/docs/merge-queue.mdx
+++ b/src/content/docs/merge-queue.mdx
@@ -146,7 +146,7 @@ Jump straight to the feature that matches your pain point:
 ### Broken Main Branch
 
 PRs that pass CI individually can break main when merged together. Mergify
-updates each PR against the latest main and re-runs CI before merging—catching
+updates each PR against the latest main and re-runs CI before merging, catching
 conflicts before they hit production.
 
 **→ [How the queue works](/merge-queue/lifecycle)**

--- a/src/content/docs/merge-queue/batches.mdx
+++ b/src/content/docs/merge-queue/batches.mdx
@@ -8,10 +8,8 @@ import Youtube from '../../../components/Youtube.astro'
 import batchesScreenshot from "../../images/merge-queue/batches/batches-dashboard.png"
 import requiredPRbypassScreenshot from "../../images/merge-queue/batches/mergify-required-pull-request-bypass.png"
 
-Mergify's batch merging feature is a powerful tool that enhances productivity
-and efficiency in your development workflow. Instead of merging pull requests
-one by one, which can be time-consuming, especially for larger projects, batch
-merging allows you to combine and merge multiple pull requests at once.
+Batch merging lets you combine and merge multiple pull requests at once,
+instead of merging them one by one.
 
 :::tip
   Learn the concepts behind batching and its trade-offs at the
@@ -30,14 +28,13 @@ to be processed as usual (see [Handling Batch
 Failures](#handling-batch-failure-or-timeout)).
 
 This feature is especially useful for large-scale projects with many pull
-requests to merge, as it can significantly reduce the time required to merge
-them all.
+requests to merge, as it can reduce the time required to merge them all.
 
 <Youtube video="2mVymDFMaMk" title="Using batch and two-step CI"/>
 
 ## Understanding Batch Merging
 
-Batch merging works by utilizing the `batch_size` option in your Mergify queue
+Batch merging works by using the `batch_size` option in your Mergify queue
 configuration. This option tells Mergify how many pull requests it should try
 to combine and validate at once. The `batch_size` can be adjusted according to
 the needs of your project, with a higher number indicating a larger batch size.
@@ -121,7 +118,7 @@ queue_rules:
     ...
 ```
 
-With the configuration above, Mergify waits up to 5 minutes for 5 PR to enter
+With the configuration above, Mergify waits up to 5 minutes for 5 PRs to enter
 the queue before creating a batch. This allows you to pick the right trade-off
 between latency and minimal CI usage.
 
@@ -293,8 +290,8 @@ However, there might be scenarios where you want to merge the temporary
 branches instead. One advantage of this is maintaining the same SHA1, which
 might be important for some workflows and for traceability.
 
-Also, if you are deploying after a merge, this can also make sure that you
-trigger only a single deployment once a batch of pull request is fully tested
+Also, if you are deploying after a merge, this can make sure that you
+trigger only a single deployment once a batch of pull requests is fully tested
 and passes the CI.
 
 There are two ways to merge the batch PR directly:
@@ -319,11 +316,11 @@ batch-PR modes.
 
 :::caution
   If GitHub branch protections are enabled, fast-forward requires some
-  additional configuration in branch protection settings, you also need to
+  additional configuration in branch protection settings: you also need to
   allow Mergify to "bypass the required pull requests" to merge.
 
   This is mandatory since Mergify pushes the temporary branch to the base
-  branch without going through a pull request in order to keep the same SHA1.
+  branch without going through a pull request to keep the same SHA1.
 
   <Image src={requiredPRbypassScreenshot} alt="Mergify bypass required pull requests" />
 :::
@@ -333,7 +330,7 @@ batch-PR modes.
 Set `merge_method: merge-batch` on your queue rule. This merge method requires
 `batch_size` to be greater than 1. Mergify creates the batch PR as usual, runs
 CI on it, and then merges the batch PR into the base branch using the GitHub
-Pull Request merge API with a merge commit. The merge commit message lists all
+pull request merge API with a merge commit. The merge commit message lists all
 the pull requests included in the batch.
 
 ```yaml
@@ -344,7 +341,7 @@ queue_rules:
 ```
 
 Unlike `fast-forward`, `merge-batch` uses the standard GitHub merge API, so it
-works with branch protection settings that require pull request merges — no
+works with branch protection settings that require pull request merges: no
 bypass configuration is needed.
 
 See [Merge Strategies: Merge Batch](/merge-queue/merge-strategies#merge-batch)
@@ -361,16 +358,14 @@ This is how it works:
 
 1. **Splitting the batch**: If a batch fails, all subsequent batches are deemed
    to fail as well, are canceled and put back into the queue. The system splits
-   the failed batch to isolate the problematic pull request. The size of these
-   new batches is determined by the `max_parallel_checks` parameter. By
-   default, the batch is split into two; however, if `max_parallel_checks` is
-   set to a value greater than 1, it dictates the number of batches the failed
-   batch should be divided into.
+   the failed batch to isolate the problematic pull request. The
+   `max_parallel_checks` parameter dictates the number of parts the failed
+   batch is divided into, with a minimum of two.
 
 2. **Testing the new batches**: After splitting, the first new batch is
    immediately retested, while others are queued. If `max_parallel_checks` is
-   greater than 1, the system will also test subsequent batch split at the same
-   time. This continues until the split is done.
+   greater than 1, the system will also test subsequent batch splits at the
+   same time. This continues until the split is done.
 
 3. **Handling the result**: If the first batch split succeeds, it is merged and
    the next split is scheduled for testing. If the batch fails, Mergify splits
@@ -754,9 +749,8 @@ and want to see all failures.
 
 ## Important Considerations
 
-While using batch merging and parallel checks together can significantly speed
-up your merge queue processing, it's crucial to consider the following points
-for an optimal setup:
+While using batch merging and parallel checks together can speed up your merge
+queue processing, consider the following points for an optimal setup:
 
 ### Branch Protection Settings
 

--- a/src/content/docs/merge-queue/deploy.mdx
+++ b/src/content/docs/merge-queue/deploy.mdx
@@ -8,17 +8,17 @@ import bpDashboardScreenshot from "../../images/merge-queue/deploy/dashboard.png
 
 Once you've configured your merge queue, you can deploy it using one of two approaches:
 
-**Approach 1: Hybrid Mode** — Mergify and manual merges coexist. This is the
+**Approach 1: Hybrid Mode.** Mergify and manual merges coexist. This is the
 simplest way to start and requires no additional setup.
 
-**Approach 2: Exclusive Mode** — Only Mergify can merge pull requests (enforced
-via GitHub rulesets). This provides the most streamlined workflow.
+**Approach 2: Exclusive Mode.** Only Mergify can merge pull requests (enforced
+via GitHub rulesets). This provides the most consistent workflow.
 
-Both approaches are optional—choose what works best for your team.
+Both approaches are optional: choose what works best for your team.
 
 ## Approach 1: Hybrid Mode
 
-In hybrid mode, developers can use the merge queue or merge manually—both work
+In hybrid mode, developers can use the merge queue or merge manually. Both work
 simultaneously. This is the default behavior and requires no setup.
 
 ### When to Use Hybrid Mode

--- a/src/content/docs/merge-queue/github-rulesets.mdx
+++ b/src/content/docs/merge-queue/github-rulesets.mdx
@@ -36,6 +36,10 @@ option on your queue rules:
 - **`merge`** -- rules are injected as merge conditions, checked after the
   queue has tested the pull request.
 
+- **`none`** -- rules are not injected at all. This mode requires a
+  `merge_bot_account` on the `queue` action, since Mergify must merge with
+  an account able to satisfy the protections itself.
+
 ### Bypass Actors and Injection
 
 If you are using GitHub rulesets (not classic branch protections), you can

--- a/src/content/docs/merge-queue/lifecycle.mdx
+++ b/src/content/docs/merge-queue/lifecycle.mdx
@@ -7,18 +7,10 @@ import { Image } from "astro:assets"
 import queueCheckScreenshot from "../../images/merge-queue/lifecycle/mergify-check.png"
 import queueStatusScreenshot from "../../images/merge-queue/setup/queue-status.png"
 
-The merge queue in Mergify is a powerful tool for maintaining the integrity of
-your codebase, ensuring that every Pull Request (PR) is up-to-date and passes
-all necessary checks before being merged. But once a PR is added to a merge
-queue, what exactly happens? Understanding the lifecycle of a PR in the merge
-queue is essential for managing your PRs effectively and ensuring a smooth,
-efficient workflow.
-
-In this guide, we will walk you through the journey of a PR once it enters the
-merge queue, from the moment it's added until it's either successfully merged
-or removed from the queue. We'll also explain how to monitor and manage your
-merge queue effectively, and share some best practices for handling common
-scenarios such as requeueing and dequeueing PRs.
+This page explains what happens to a pull request (PR) once it enters the
+merge queue, from the moment it's added until it's either merged or removed
+from the queue. It also covers how to monitor and manage your merge queue, and
+how to handle common scenarios such as requeueing and dequeueing PRs.
 
 ## Adding a Pull Request to the Merge Queue
 
@@ -30,8 +22,8 @@ automatically. Here's an overview of the process:
    [merge queue status comment checkbox](/commands/queue#queueing-with-a-checkbox).
 
 - **Automated addition:** A pull request can be automatically added to the
-   merge queue using [`auto_merge`](/merge-protections/auto-merge) in
-   `merge_protections_settings`.
+   merge queue using [`auto_merge_conditions`](/merge-protections/auto-merge)
+   in `merge_protections_settings`.
 
 Before a pull request can be added to the merge queue, it must meet certain
 conditions, specified under `queue_conditions` in your
@@ -163,7 +155,7 @@ A pull request can be removed from the merge queue in a couple of ways:
    request from being merged, such as when a critical issue is discovered.
 
 Please note, a pull request removed from the queue with the `dequeue` command
-will not rejoin the queue automatically — it will need to be manually re-added
+will not rejoin the queue automatically; it will need to be manually re-added
 to the queue by re-applying the `queue` command and by re-satisfying the
 `queue_conditions`.
 
@@ -340,7 +332,7 @@ queue, Mergify provides multiple tools and indicators. Here's how you can use
 them:
 
 1. **Check the Mergify dashboard:** The [Mergify
-   dashboard](https://dashboard.mergify.com) provides a comprehensive view of
+   dashboard](https://dashboard.mergify.com) provides a full view of
    your queue. You can see the number of pull requests in each queue and their
    position.
 
@@ -353,8 +345,7 @@ them:
 <Image src={queueCheckScreenshot} alt="Mergify check status" />
 
 Monitoring your pull requests' status helps you understand their position in
-the queue and estimate when they might be merged, making the entire process
-more transparent and manageable.
+the queue and estimate when they might be merged.
 
 ## The Mergify Merge Queue Check Run
 

--- a/src/content/docs/merge-queue/merge-strategies.mdx
+++ b/src/content/docs/merge-queue/merge-strategies.mdx
@@ -50,12 +50,12 @@ default GitHub merge behavior.
   branch={{ label: "main", node: "M" }}
 />
 
-- **History:** non-linear — the PR branch and base branch are visible as
+- **History:** non-linear; the PR branch and base branch are visible as
   separate lines in `git log --graph`
 
-- **Merge commits:** yes — each PR produces a merge commit on the base branch
+- **Merge commits:** yes; each PR produces a merge commit on the base branch
 
-- **SHAs preserved:** yes — original PR commits keep their SHAs
+- **SHAs preserved:** yes; original PR commits keep their SHAs
 
 - **Use case:** most teams; simplest setup with no constraints on parallelism
   or batching
@@ -88,9 +88,9 @@ Squashes all PR commits into a single commit on the base branch.
   branch={{ label: "main", node: "S" }}
 />
 
-- **History:** linear — one commit per PR on the base branch
+- **History:** linear; one commit per PR on the base branch
 - **Merge commits:** no
-- **SHAs preserved:** no — a new commit is created
+- **SHAs preserved:** no; a new commit is created
 - **Use case:** teams that want a clean `git log` where one commit = one PR
 
 ## Rebase
@@ -123,11 +123,11 @@ SHAs.
   branch={{ label: "main", node: "Dp" }}
 />
 
-- **History:** linear — no merge commits, individual commits are preserved
+- **History:** linear; no merge commits, individual commits are preserved
 
 - **Merge commits:** no
 
-- **SHAs preserved:** no — commits are recreated with new SHAs, so the PR
+- **SHAs preserved:** no; commits are recreated with new SHAs, so the PR
   branch ref won't match the base branch
 
 - **Use case:** teams that want linear history with individual commits visible,
@@ -152,12 +152,12 @@ The PR is rebased on top of the base branch, CI runs on the PR itself, and
 the base branch ref is fast-forwarded to the PR's head commit.
 
 In this mode, `update_method` must be set to `rebase` (the default). If a
-rebase update occurs, the commit SHAs on the PR will change — what fast-forward
+rebase update occurs, the commit SHAs on the PR will change; what fast-forward
 preserves are the SHAs of the PR branch at merge time.
 
 :::caution
-  When using `update_bot_account` with fast-forward inplace mode, fork pull
-  requests will no longer be supported after **July 1, 2026**. See the
+  When using `update_bot_account` with fast-forward inplace mode, support for
+  fork pull requests is deprecated. See the
   [update method deprecation note](#combining-merge-and-update-methods) for
   details and migration options.
 :::
@@ -177,11 +177,11 @@ preserves are the SHAs of the PR branch at merge time.
   branch={{ label: "main", node: "D" }}
 />
 
-- **History:** strictly linear — commits sit directly on the base branch
+- **History:** strictly linear; commits sit directly on the base branch
 
 - **Merge commits:** none
 
-- **SHAs preserved:** yes — the exact same commit SHAs from the PR appear on
+- **SHAs preserved:** yes; the exact same commit SHAs from the PR appear on
   the base branch
 
 ### Batch-PR Mode
@@ -196,16 +196,16 @@ commits** from folding each PR into the batch branch.
 - **History:** linear at the base-branch level, but individual merge commits
   from combining PRs may appear
 
-- **Merge commits:** possible — from combining PRs in the batch branch
+- **Merge commits:** possible (from combining PRs in the batch branch)
 
 - **SHAs preserved:** the final merged result is the exact SHA tested by CI
 
 ### Constraints
 
-- **`commit_message_format` has no effect** — fast-forward preserves
+- **`commit_message_format` has no effect**: fast-forward preserves
   the original commits, so custom commit messages are not applicable
 
-- **[Parallel mode](/merge-queue/queue-modes) is not supported** — fast-forward
+- **[Parallel mode](/merge-queue/queue-modes) is not supported**: fast-forward
   is not compatible with scope-based parallel queues
 
 - **Use case:** teams and OSS projects that care about commit identity and want
@@ -223,7 +223,7 @@ commits** from folding each PR into the batch branch.
 
 ### Examples
 
-Inplace mode — strictly linear history with preserved commit SHAs:
+Inplace mode, with strictly linear history and preserved commit SHAs:
 
 ```yaml
 merge_queue:
@@ -237,7 +237,7 @@ queue_rules:
       - check-success = ci
 ```
 
-Batch-PR mode — batching with fast-forward merge:
+Batch-PR mode, combining batching with fast-forward merge:
 
 ```yaml
 queue_rules:
@@ -261,10 +261,10 @@ queue_rules:
 
 When `merge_method` is set to `merge-batch`, Mergify merges the batch pull
 request it creates for batching directly into the base branch using a merge
-commit — instead of merging the original pull requests individually.
+commit, instead of merging the original pull requests individually.
 
 This is similar to `fast-forward` in that the batch PR itself is merged, but
-uses the GitHub Pull Request merge API rather than advancing the git ref
+uses the GitHub pull request merge API rather than advancing the git ref
 directly. The resulting merge commit message identifies which pull requests
 were included in the batch (e.g., "Merge queue: merged #42, #43, #44").
 
@@ -286,22 +286,22 @@ were included in the batch (e.g., "Merge queue: merged #42, #43, #44").
   branch={{ label: "main", node: "M" }}
 />
 
-- **History:** non-linear — a single merge commit per batch appears on the base
+- **History:** non-linear; a single merge commit per batch appears on the base
   branch
 
-- **Merge commits:** yes — one merge commit per batch, not per PR
+- **Merge commits:** yes; one merge commit per batch, not per PR
 
-- **SHAs preserved:** no — the batch merge commit is new, and the original PR
+- **SHAs preserved:** no; the batch merge commit is new, and the original PR
   commit SHAs are not preserved because the batch PR contains recreated commits
 
-- **Requires `batch_size > 1`** — this method is designed for batch merging and
+- **Requires `batch_size > 1`**: this method is designed for batch merging and
   cannot be used with single PRs
 
 - **Use case:** teams that use batch merging and want a single merge commit per
   batch on the base branch, triggering only one deployment per batch
 
 :::note
-  Unlike `fast-forward`, `merge-batch` uses the standard GitHub Pull Request
+  Unlike `fast-forward`, `merge-batch` uses the standard GitHub pull request
   merge API, so it works with branch protection settings that require pull
   request merges. No bypass configuration is needed.
 :::
@@ -313,8 +313,8 @@ fall behind the base branch. Combining `merge_method` with `update_method`
 gives you additional control over your history shape.
 
 :::note
-  `update_method: rebase` combined with `update_bot_account` will no longer
-  support fork pull requests after **July 1, 2026**. If your repository
+  Support for fork pull requests with `update_method: rebase` combined with
+  `update_bot_account` is deprecated. If your repository
   receives fork PRs, use `update_method: merge` instead.
 :::
 

--- a/src/content/docs/merge-queue/migrate-partitions-to-scopes.mdx
+++ b/src/content/docs/merge-queue/migrate-partitions-to-scopes.mdx
@@ -4,7 +4,7 @@ description: Step-by-step guide to replace the deprecated partition_rules with s
 ---
 
 `partition_rules` are deprecated and will be removed in a future release. This
-guide walks you through replacing them with **scopes** — a more powerful system
+guide walks you through replacing them with **scopes**, a more powerful system
 that integrates with your CI and unlocks smarter batching, parallel merge
 queues, and monorepo-aware workflows.
 
@@ -15,13 +15,13 @@ conditions evaluated by Mergify. Scopes improve on this in several ways:
 
 | | Partition Rules | Scopes |
 |---|---|---|
-| **CI awareness** | None — CI runs everything | Jobs can be skipped when their scope is not affected |
+| **CI awareness** | None: CI runs everything | Jobs can be skipped when their scope is not affected |
 | **Build tool support** | None | Native support for Nx, Bazel, Turborepo, and custom tooling |
-| **Batching** | Fixed lanes — PRs routed to one partition | Overlap-aware — PRs sharing scopes batch together |
-| **Parallel mode** | Not compatible | Fully supported — non-overlapping scopes merge simultaneously |
+| **Batching** | Fixed lanes: PRs routed to one partition | Overlap-aware: PRs sharing scopes batch together |
+| **Parallel mode** | Not compatible | Fully supported: non-overlapping scopes merge simultaneously |
 | **Merge queue scope** | Not available | Special `merge-queue` scope lets you gate expensive tests to queue-only runs |
 
-In short, scopes give you **faster CI, smarter batching, and less wasted
+In short, scopes give you **faster CI and smarter batching with less wasted
 compute**.
 
 ## Requirements
@@ -56,7 +56,7 @@ each build tool.
 Each partition condition becomes a scope with file patterns. The syntax changes
 from Mergify conditions to glob patterns.
 
-**Before — partition_rules:**
+**Before (partition_rules):**
 
 {/* validate-config-examples: skip — deprecated partition_rules syntax, shown for migration */}
 
@@ -89,7 +89,7 @@ pull_request_rules:
       queue:
 ```
 
-**After — scopes with file patterns:**
+**After (scopes with file patterns):**
 
 ```yaml
 scopes:
@@ -121,7 +121,7 @@ pull_request_rules:
 :::note
   The fallback partition has no equivalent in scopes. If a PR matches no scope,
   it is treated as having no scope and will be batched with other unscoped PRs.
-  This is usually the desired behavior — files outside any scope boundary don't
+  This is usually the desired behavior: files outside any scope boundary don't
   need special routing.
 :::
 
@@ -174,7 +174,7 @@ jobs:
 
 Delete the entire `partition_rules` section from `.mergify.yml`. If you
 referenced `partition-name` or `current-partition-name` in your
-`pull_request_rules` conditions, remove those conditions — they no longer apply.
+`pull_request_rules` conditions, remove those conditions. They no longer apply.
 
 ### 4. Enable parallel mode
 
@@ -205,7 +205,7 @@ queue_rules:
 ```
 
 In parallel mode, PRs touching different scopes are tested and merged
-simultaneously — just like partition lanes, but with smarter dependency tracking
+simultaneously, just like partition lanes, but with smarter dependency tracking
 when scopes overlap.
 
 See [Queue Modes](/merge-queue/queue-modes) for details.
@@ -352,5 +352,5 @@ pull_request_rules:
 ```
 
 The key improvements:
-- **Scopes enable smarter batching** — PRs touching the same scope are grouped together
-- **Non-overlapping scopes merge simultaneously** — just like partition lanes, but with smarter dependency tracking when scopes overlap
+- **Scopes enable smarter batching**: PRs touching the same scope are grouped together
+- **Non-overlapping scopes merge simultaneously**: just like partition lanes, but with smarter dependency tracking when scopes overlap

--- a/src/content/docs/merge-queue/monitoring.mdx
+++ b/src/content/docs/merge-queue/monitoring.mdx
@@ -1,6 +1,6 @@
 ---
 title: Monitoring your Merge Queue
-description: Monitor key metrics of your merge queue to optimize throughput and reduce latency, ensuring a streamlined development cycle.
+description: Monitor key metrics of your merge queue to improve throughput and reduce latency.
 ---
 
 import { Image } from "astro:assets"
@@ -47,7 +47,7 @@ View these metrics on the merge queue page of your
 <Image src={dashboardStatsScreenshot} alt="Statistics page on mergify's dashboard"/>
 
 Use the date picker to select the time range you want to review. Presets go up to
-"Past 3 Months", and data is retained for 90 days so every preset returns complete
+"Past 3 months", and data is retained for 90 days so every preset returns complete
 data.
 
 ## Monitoring the Queue with the CLI
@@ -61,12 +61,12 @@ mergify queue status
 
 This displays:
 
-- **Pause status** — whether the queue is paused, with reason and elapsed time
+- **Pause status**: whether the queue is paused, with reason and elapsed time
 
-- **Batches** — batches organized by scope with status indicators and their
+- **Batches**: batches organized by scope with status indicators and their
   pull requests
 
-- **Waiting PRs** — queued pull requests with priority, queue time, and
+- **Waiting PRs**: queued pull requests with priority, queue time, and
   estimated merge time
 
 To filter results to a specific branch:

--- a/src/content/docs/merge-queue/monorepo.mdx
+++ b/src/content/docs/merge-queue/monorepo.mdx
@@ -5,16 +5,15 @@ description: Optimize merge queue batching for monorepos with scopes.
 
 In monorepo environments, not every pull request affects the entire codebase. Running the full
 validation matrix for each change quickly becomes wasteful, yet batching unrelated pull requests
-still makes the queue churn through work that doesn't matter. This page explains the pain points
-first and then shows how Mergify's monorepo capabilities keep batching efficient without
-sacrificing safety.
+still makes the queue churn through work that doesn't matter. This page shows how Mergify's
+monorepo capabilities keep batching efficient without sacrificing safety.
 
 :::tip
   Learn about merge queue strategies for monorepos at the
   [Merge Queue Academy](https://merge-queue.academy/use-cases/monorepos/).
 :::
 
-To solve this, Mergify introduces **scopes**—named regions of your repository that describe which
+To solve this, Mergify introduces **scopes**, named regions of your repository that describe which
 services, packages, or domains a change touches. The rest of this guide shows how scopes pair with
 monorepo-aware tooling to batch compatible pull requests, keep unrelated work apart, and drive only
 the CI jobs that matter. For the full schema and advanced strategies, see
@@ -67,7 +66,7 @@ request is created, Mergify automatically determines which scopes are affected a
 information to optimize batching. The [Scopes reference](/merge-queue/scopes) covers the schema plus
 all tooling-specific guides, including file-pattern detection and integrations with Bazel, Nx, and
 Turborepo. If you already run Nx, Bazel, Turborepo, or another orchestrator, point it at
-`gha-mergify-ci` to upload those scope names—**scopes are the feature Merge Queue consumes**, regardless
+`gha-mergify-ci` to upload those scope names: **scopes are the feature Merge Queue consumes**, regardless
 of how you compute them.
 
 ## Next steps
@@ -76,7 +75,7 @@ of how you compute them.
   Turborepo, custom uploaders).
 
 - [Queue Modes](/merge-queue/queue-modes): once scopes are configured, enable parallel mode to
-  test and merge pull requests that touch different scopes simultaneously — significantly reducing
-  merge times in monorepos.
+  test and merge pull requests that touch different scopes simultaneously, reducing merge times
+  in monorepos.
 
 - [Monorepo CI](/monorepo-ci): opinionated GitHub Actions workflows if you need turnkey automation.

--- a/src/content/docs/merge-queue/pause.mdx
+++ b/src/content/docs/merge-queue/pause.mdx
@@ -1,14 +1,14 @@
 ---
 title: Pausing the Merge Queue
-description: Understand the pause feature and how it can be utilized during CI incidents.
+description: Understand the pause feature and how to use it during CI incidents.
 ---
 
 import screenshotButtonPause from '../../images/merge-queue/pause/dashboard-button-pause-mq.png';
 import { Image } from "astro:assets";
 
-Mergify's Merge Queue offers a feature known as "pausing" that grants users
-increased control over the automation process during special circumstances.
-Let's explore what pausing involves, its impacts, and its typical use cases.
+Pausing Mergify's Merge Queue suspends its automation, typically during a CI
+incident. This page explains what pausing does, its impacts, and when to use
+it.
 
 ## What Does Pausing Do?
 
@@ -48,7 +48,7 @@ the queue.
 
 ### Using the CLI
 
-Pause the queue from the terminal with an optional reason:
+Pause the queue from the terminal with a reason (required):
 
 ```bash
 mergify queue pause --reason "deploying hotfix"
@@ -72,16 +72,15 @@ API](/api/usage).
 
 ### CI Incidents
 
-During a major incident with the Continuous Integration (CI) system, the pause
-feature can be invaluable. If there's a likelihood that checks will fail and
-consequently eject the pull request from the queue, it's beneficial to pause
-the merge queue.
+During a major incident with the CI system, if checks are likely to fail and
+eject pull requests from the queue, pause the merge queue until the incident
+is resolved.
 
 ### Non-CI Incidents
 
 If an incident is unrelated to the CI, like a production issue, but you wish to
 halt merging while allowing checks to run, then the [scheduled freeze
-feature](/merge-protections/#scheduling-freezes) is a more suitable choice.
+feature](/merge-protections/freeze) is a more suitable choice.
 
 ## Benefits of Using the Pause Feature
 
@@ -93,8 +92,3 @@ feature](/merge-protections/#scheduling-freezes) is a more suitable choice.
 
 3. **Reduce Noise**: Constantly failing checks during a CI incident can create
    unnecessary notifications. Pausing the queue mitigates this.
-
-The pause feature of the Mergify merge queue offers users an enhanced layer of
-control and adaptability during special situations. Familiarizing yourself with
-when and how to pause your merge queue can optimize your workflow and reduce
-disruptions.

--- a/src/content/docs/merge-queue/priority.mdx
+++ b/src/content/docs/merge-queue/priority.mdx
@@ -5,20 +5,19 @@ description: Learn how to order your pull requests in the queue by priority.
 
 import OptionsTable from '../../../components/Tables/OptionsTable';
 
-Priority rules are an optional but highly useful feature in Mergify's arsenal.
-They offer you a more refined control over how your pull requests are ordered
+Priority rules give you finer control over how your pull requests are ordered
 within a queue. By applying these rules, you can assign priorities to pull
 requests based on the conditions you define. This makes it possible to
-influence the position in which a pull request is added to the queue, thereby
-helping you handle urgent tasks more promptly.
+influence the position in which a pull request is added to the queue, so
+urgent tasks merge sooner.
 
 ## Understanding Priority Rules
 
 Priority rules in Mergify are a set of guidelines that determine the order of
-pull requests within a merge queue. They apply a priority — which could be a
-keyword such as `low`, `medium`, `high` or a numerical value — to a pull
-request based on conditions you've defined. When using numerical value, the
-value can be between 1 and 10,000.
+pull requests within a merge queue. They apply a priority (a keyword such as
+`low`, `medium`, or `high`, or a numerical value) to a pull request based on
+conditions you've defined. When using a numerical value, it can be between 1
+and 10,000.
 
 When a pull request is added to a queue, each priority rule is evaluated
 against its conditions. This assessment determines where the pull request will
@@ -27,7 +26,7 @@ one will be used.
 
 :::note
 
-  If no priority rules matches, Mergify assigns the `medium` priority to a
+  If no priority rule matches, Mergify assigns the `medium` priority to a
   pull request. This is not configurable.
 
 :::
@@ -58,10 +57,8 @@ In the above configuration:
 - The name under each rule is just an identifier and doesn't impact the
   functioning of the rule.
 
-The power of priority rules lies in their flexibility. You can set up as many
-rules as you need, tailored to your specific workflow. Whether it's to
-prioritize bug fixes or to push feature updates to the back, priority rules
-offer you the control you need over your merge queue.
+You can set up as many rules as you need, tailored to your specific workflow,
+whether that's prioritizing bug fixes or pushing feature updates to the back.
 
 ## How to Define Priority Rules
 
@@ -111,11 +108,11 @@ The textual priorities have the following numerical values:
 
 :::note
 
-    Priority is always the first criterion when selecting pull requests for batching.
-    Mergify picks PRs strictly in priority order and only after that may look ahead to 
-    find additional PRs with the same queue rule to complete the batch.
-    This ensures that higher-priority pull requests are never delayed, while still 
-    allowing the system to optimize CI usage and reduce merge time.
+  Priority is always the first criterion when selecting pull requests for
+  batching. Mergify picks PRs strictly in priority order and only after that
+  may look ahead to find additional PRs with the same queue rule to complete
+  the batch. This ensures that higher-priority pull requests are never delayed,
+  while still allowing the system to optimize CI usage and reduce merge time.
 
 :::
 
@@ -158,7 +155,7 @@ running on a `normal` pull request and gets tested first.
 
 ## Advanced Priority Rule Usage
 
-Beyond the basic use of priority rules, you can leverage advanced features to
+Beyond the basic use of priority rules, you can use advanced features to
 fine-tune how your pull requests are prioritized in the queue.
 
 ### Using Numerical Values
@@ -223,7 +220,7 @@ priority_rules:
 ```
 
 These are just a few ways to get the most out of Mergify's priority rules. By
-thinking about your team's needs and workflow, you can leverage these advanced
+thinking about your team's needs and workflow, you can use these advanced
 usage scenarios to create a priority system that best serves your project.
 
 ## Troubleshooting Priority Rules

--- a/src/content/docs/merge-queue/queue-modes.mdx
+++ b/src/content/docs/merge-queue/queue-modes.mdx
@@ -1,18 +1,18 @@
 ---
 title: Queue Modes
-description: Choose how the merge queue schedules pull requests — serial, parallel, or isolated.
+description: "Choose how the merge queue schedules pull requests: serial, parallel, or isolated."
 ---
 
 The `merge_queue.mode` option controls how the merge queue schedules pull requests. There are three
 modes:
 
-- **`serial`** (default) — every pull request is tested on top of the previous one, in a single
+- **`serial`** (default): every pull request is tested on top of the previous one, in a single
   ordered pipeline.
 
-- **`parallel`** — pull requests that touch different [scopes](/merge-queue/scopes) are tested and
+- **`parallel`**: pull requests that touch different [scopes](/merge-queue/scopes) are tested and
   merged at the same time.
 
-- **`isolated`** — every batch runs as a fully independent unit, with no dependency on any other
+- **`isolated`**: every batch runs as a fully independent unit, with no dependency on any other
   batch.
 
 All three honor your [queue rules](/merge-queue/rules) and [batch sizing](/merge-queue/batches).
@@ -31,7 +31,7 @@ are already using it.
 
 ## Serial Mode
 
-Serial mode is the **default** — you don't need to configure anything to use it. Every pull request
+Serial mode is the **default**: you don't need to configure anything to use it. Every pull request
 is tested on top of the one before it, forming a single ordered pipeline. This guarantees
 correctness: each pull request is validated against the exact state it will merge into. The
 trade-off is that unrelated changes still wait for each other.
@@ -72,8 +72,8 @@ choice.
 
 ## Parallel Mode
 
-Parallel mode tests and merges pull requests that touch different areas of the codebase — different
-[scopes](/merge-queue/scopes) — at the same time. Pull requests that share a scope are still queued
+Parallel mode tests and merges pull requests that touch different areas of the codebase (different
+[scopes](/merge-queue/scopes)) at the same time. Pull requests that share a scope are still queued
 together so they are tested as a group, preventing semantic conflicts.
 
 :::tip
@@ -142,7 +142,7 @@ strict digraph {
 }
 ```
 
-Here PR #4 touches the `api` scope, just like PR #1 — so it must wait for PR #1 to merge first.
+Here PR #4 touches the `api` scope, just like PR #1, so it must wait for PR #1 to merge first.
 Meanwhile PR #3 (docs) proceeds independently.
 
 ### Set up parallel mode
@@ -220,7 +220,7 @@ requests:
 3. **Dependency tracking.** Batches that share at least one scope are linked as parent → child in a
    dependency graph. A child batch cannot merge until all its parents have merged.
 
-4. **Parallel execution.** Batches with no shared scopes — and therefore no dependency — are tested
+4. **Parallel execution.** Batches with no shared scopes (and therefore no dependency) are tested
    by CI at the same time, up to `max_parallel_checks`.
 
 5. **Merge.** As soon as a batch's CI passes and all its parent batches are merged, Mergify merges
@@ -228,7 +228,7 @@ requests:
 
 When a batch fails, Mergify splits it and retests the parts to isolate the problematic pull request
 (see [Handling Batch Failures](/merge-queue/batches#handling-batch-failure-or-timeout)). Because
-batches are scoped, a failure in one scope queue does **not** block unrelated scope queues — only
+batches are scoped, a failure in one scope queue does **not** block unrelated scope queues: only
 batches that depend on the failed one (via a shared scope) are affected.
 
 ### Limiting concurrency per scope
@@ -378,7 +378,7 @@ do interact.
 
 | Scenario | What happens | Benefit |
 |----------|-------------|---------|
-| PRs touch **different** scopes | Tested and merged in parallel | Faster merge times — no waiting for unrelated work |
+| PRs touch **different** scopes | Tested and merged in parallel | Faster merge times, no waiting for unrelated work |
 | PRs touch **the same** scope | Ordered within that scope queue and tested together | Conflicts caught before merge |
 | A PR touches **multiple** scopes | Linked to all relevant scope queues | Correctness preserved across scopes |
 
@@ -420,7 +420,7 @@ strict digraph {
 ```
 
 Use isolated mode when your pull requests are genuinely independent and you want maximum throughput
-without maintaining a scope map — for example when each pull request targets its own service or
+without maintaining a scope map, for example when each pull request targets its own service or
 package and you don't need Mergify to serialize overlapping changes.
 
 :::caution
@@ -457,14 +457,17 @@ queue_rules:
 
 How Mergify fills a batch depends on whether you configure [scopes](/merge-queue/scopes):
 
-- **With scopes.** Mergify groups the most similar pull requests — those sharing the most scopes —
+- **With scopes.** Mergify groups the most similar pull requests (those sharing the most scopes)
   into the same batch, using the same [scope-aware batching](/merge-queue/scopes) as the other
   modes. This keeps related changes tested together and maximizes CI reuse.
 
-- **Without scopes.** Mergify fills batches by queue priority and arrival order, up to `batch_size`.
+- **Without scopes.** Mergify seeds each batch by queue priority and arrival order, then fills the
+  remaining slots with the pull requests that change similar directories, as described in
+  [How Pull Requests Are Grouped Into a
+  Batch](/merge-queue/batches#how-pull-requests-are-grouped-into-a-batch).
 
 Either way, the resulting batches are fully independent. They run concurrently up to
-`max_parallel_checks`, and Mergify merges each one as soon as its own CI passes — there is never a
+`max_parallel_checks`, and Mergify merges each one as soon as its own CI passes; there is never a
 parent batch to wait for. Batch failures are handled the same way as in the other modes (see
 [Handling Batch Failures](/merge-queue/batches#handling-batch-failure-or-timeout)).
 
@@ -478,7 +481,7 @@ aren't available depending on the mode:
   not require scopes.
 
 - **`fast-forward` merge is not supported.** Because batches merge independently, Mergify needs to
-  rebase them. Use `merge` or `rebase` as your `merge_method`.
+  rebase them. Use `merge`, `squash`, or `rebase` as your `merge_method`.
 
 - **`skip_intermediate_results` is not supported in isolated mode.** Isolated batches are fully
   independent, so a passing batch can't vouch for any other. It works in serial and parallel modes,

--- a/src/content/docs/merge-queue/rules.mdx
+++ b/src/content/docs/merge-queue/rules.mdx
@@ -5,9 +5,7 @@ description: Learn how to implement queue rules and route your pull requests.
 
 import OptionsTable from '../../../components/Tables/OptionsTable';
 
-In larger projects with a high volume of pull requests, managing merges can
-become complex. This is where **Mergify's multiple queue rules** feature
-becomes a game-changer: it enables you to have finer control over the merge
+**Mergify's multiple queue rules** give you finer control over the merge
 process by categorizing pull requests based on any criteria you define.
 
 Queue rules let you organize your PR merge process into separate templates,
@@ -49,7 +47,7 @@ queue_rules:
 
 ## Configuration Options
 
-The top-level key `queue_rules` allows you to define the rules that reign over
+The top-level key `queue_rules` allows you to define the rules that govern
 your [merge queue](/merge-queue).
 
 Here are all the available fields you can configure for a queue rule:
@@ -94,13 +92,13 @@ This separation lets you schedule PRs early (e.g. based on labels) while still
 enforcing stricter checks before merge. This can be used to implement [two-step
 CI](/merge-queue/two-step).
 
-You can find more details about the [lifecycle of pull request in the
+You can find more details about the [lifecycle of a pull request in the
 documentation](/merge-queue/lifecycle#lifecycle-of-a-pull-request-in-the-merge-queue).
 
 ## Auto‑Queueing Pull Requests
 
 :::caution
-  `autoqueue` is deprecated and will stop working on 2026-07-16. Use
+  `autoqueue` is deprecated. Use
   [`auto_merge_conditions`](/merge-protections/auto-merge) in
   `merge_protections_settings` instead.
 

--- a/src/content/docs/merge-queue/scopes.mdx
+++ b/src/content/docs/merge-queue/scopes.mdx
@@ -135,7 +135,7 @@ queue_rules:
   - `null`: disables scopes entirely.
 
 - `scopes.merge_queue_scope`: optional name automatically applied to temporary merge queue pull
-  requests (defaults to `merge-queue`). Set it to `null` to disable.
+  requests (defaults to `merge-queue`).
 
 - `scopes.capacities`: optional map of scope name to the number of speculative checks that scope may
   run at the same time, used to limit per-scope concurrency in parallel mode. See [Limiting
@@ -157,7 +157,7 @@ queue_rules:
     batch_size: 5
 ```
 
-With the configuration above you must push scopes yourself—typically from a CI job that analyses the
+With the configuration above you must push scopes yourself, typically from a CI job that analyses the
 pull request and calls `gha-mergify-ci` with the `scopes-upload` action. This is the recommended
 approach when build systems such as Bazel, Nx, or Turborepo already know which projects are affected.
 
@@ -275,7 +275,7 @@ description created by the queue.
 
 - Keep scope names stable and small in number so batches stay meaningful.
 
-- Prefer scopes that align with your CI topology—if a test suite covers a specific service or
+- Prefer scopes that align with your CI topology: if a test suite covers a specific service or
   package, create a scope with the same boundary.
 
 - Still configure sane `batch_max_wait_time` values: scopes help Mergify pick the right pull

--- a/src/content/docs/merge-queue/scopes/bazel.mdx
+++ b/src/content/docs/merge-queue/scopes/bazel.mdx
@@ -6,7 +6,7 @@ description: Configure merge queue scopes using Bazel's dependency graph for pre
 import ScopesDetection from '~/components/ScopesDetection.astro';
 
 If you're using monorepo tools like Bazel that have built-in dependency graph analysis,
-you can leverage their affected project detection instead of using file patterns.
+you can use their affected project detection instead of file patterns.
 This approach is often more accurate because these tools understand your project's
 dependency relationships.
 

--- a/src/content/docs/merge-queue/scopes/nx.mdx
+++ b/src/content/docs/merge-queue/scopes/nx.mdx
@@ -6,7 +6,7 @@ description: Configure merge queue scopes using Nx's dependency graph to drive b
 import ScopesDetection from '~/components/ScopesDetection.astro';
 
 If you're using tools like the Nx build system that have built-in dependency graph analysis,
-you can leverage their affected project detection instead of using file patterns.
+you can use their affected project detection instead of file patterns.
 This approach is often more accurate because these tools understand your project's
 dependency relationships.
 

--- a/src/content/docs/merge-queue/scopes/others.mdx
+++ b/src/content/docs/merge-queue/scopes/others.mdx
@@ -6,7 +6,7 @@ description: Configure merge queue scopes using your preferred monorepo tooling.
 import ScopesDetection from '~/components/ScopesDetection.astro';
 
 If you're using monorepo tools that have built-in
-dependency graph analysis, you can leverage their affected project detection instead of using file
+dependency graph analysis, you can use their affected project detection instead of file
 patterns. This approach is often more accurate because these tools understand your project's
 dependency relationships.
 

--- a/src/content/docs/merge-queue/scopes/turborepo.mdx
+++ b/src/content/docs/merge-queue/scopes/turborepo.mdx
@@ -6,7 +6,7 @@ description: Configure merge queue scopes using Turborepo's dependency graph awa
 import ScopesDetection from '~/components/ScopesDetection.astro';
 
 If you're using monorepo tools like Turborepo that have built-in
-dependency graph analysis, you can leverage their affected project detection instead of using file
+dependency graph analysis, you can use their affected project detection instead of file
 patterns. This approach is often more accurate because these tools understand your project's
 dependency relationships.
 

--- a/src/content/docs/merge-queue/setup.mdx
+++ b/src/content/docs/merge-queue/setup.mdx
@@ -21,7 +21,7 @@ required.
 ### 1. Install Mergify
 
 [Install the Mergify GitHub App](https://github.com/apps/mergify/installations/new)
-on your repository. That's it — you now have a working merge queue.
+on your repository. That's it: you now have a working merge queue.
 
 ### 2. Queue Your First PR
 

--- a/src/content/docs/merge-queue/stacks.mdx
+++ b/src/content/docs/merge-queue/stacks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Stacked Pull Requests
-description: How the merge queue handles stacks created by mergify stack push — auto-propagation, stack-aware batching, and cascade dequeue.
+description: "How the merge queue handles stacks created by mergify stack push: auto-propagation, stack-aware batching, and cascade dequeue."
 ---
 
 import GitGraph from '~/components/GitGraph.astro';


### PR DESCRIPTION
First docs-health audit pass over all merge-queue pages. Accuracy fixes
verified against the config JSON schema, the CLI schema, and the engine:

- github-rulesets: add the missing `none` value of
  `branch_protection_injection_mode` (schema enum queue|merge|none)
- scopes: remove the wrong "set `merge_queue_scope` to `null` to
  disable" claim (schema types it non-nullable)
- batches: "split into two by default" was stale; the engine splits a
  failed batch into max(2, max_parallel_checks) parts
- queue-modes: isolated-mode batching without scopes fills by
  changed-directory similarity, not pure arrival order; fast-forward
  restriction list was missing `squash` as an allowed method
- lifecycle: reference `auto_merge_conditions` instead of the deprecated
  `auto_merge`
- pause: `--reason` is required, not optional (CLI schema); fix the broken
  freeze anchor to /merge-protections/freeze
- monitoring: match the dashboard UI text ("Past 3 months")
- rules and merge-strategies: convert expired dated deprecation notices
  (autoqueue, fork-rebase) to dateless markers per the repo rule

Plus a conservative style pass per the proofread rubrics: banned words,
~50 prose em dashes, throat-clearing intros, promotional filler, and
grammar fixes. Frontmatter descriptions with banned words or em dashes
were also cleaned (quoted where a colon required it).

Part of the first manual docs-health audit (MRGFY-8212).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Depends-On: #12206