### PR TITLE
docs(commands,merge-protections,migrate): fix broken examples and style

### DIFF
--- a/src/content/docs/commands.mdx
+++ b/src/content/docs/commands.mdx
@@ -7,19 +7,17 @@ import DocsetGrid from '../../components/DocsetGrid/DocsetGrid.astro';
 import { Image } from "astro:assets"
 import commandExample from "../images/commands/command-example.png"
 
-Mergify commands are powerful, user-friendly directives that you can invoke
-directly from your repository's comments. Designed to streamline the
-interaction with the Mergify bot, these commands empower users to execute
-specific actions on pull requests without leaving the GitHub interface. Whether
-you wish to rebase a branch, refresh checks, or perform any other
-Mergify-supported action, a simple command can save you time and clicks.
+Mergify commands are directives that you can invoke directly from your
+repository's comments. They let you run specific actions on pull requests
+without leaving the GitHub interface. Whether you wish to rebase a branch,
+refresh checks, or perform any other Mergify-supported action, a simple
+command can save you time and clicks.
 
 ## Getting Started with Commands
 
-Using Mergify commands is straightforward and intuitive. These commands are
-designed to be invoked directly within the comments section of your pull
-requests, ensuring seamless integration with your regular GitHub workflow.
-Here's a step-by-step guide to getting started:
+Commands are invoked directly within the comments section of your pull
+requests, as part of your regular GitHub workflow. Here's a step-by-step
+guide to getting started:
 
 1. **Navigate to Your Pull Request**: Head over to the pull request where you
    want to execute a Mergify action.
@@ -46,10 +44,9 @@ Here's a step-by-step guide to getting started:
 
 <Image src={commandExample} alt="Example command comment in GitHub"/>
 
-Remember, while Mergify commands are powerful and offer great convenience,
-always ensure you understand the impact of a command, especially in a
-collaborative environment. Misused commands can potentially disrupt the
-workflow of other contributors.
+Always make sure you understand the impact of a command, especially in a
+collaborative environment. Misused commands can disrupt the workflow of other
+contributors.
 
 ## Command List
 

--- a/src/content/docs/commands/backport.mdx
+++ b/src/content/docs/commands/backport.mdx
@@ -5,16 +5,11 @@ description: Copy a pull request to another branch after merge.
 
 import BackportLimitations from '../workflow/actions/_backport_limitations.mdx';
 
-The `backport` command is one of Mergify's most useful features, especially for
-projects that maintain multiple branches simultaneously. This command automates
-the process of creating a new pull request to apply changes from a merged pull
-request onto another branch. Whether you're maintaining different versions of a
-software or need to ensure that bug fixes are propagated to all active
-branches, `backport` has got you covered.
-
-With the `backport` command, managing changes across multiple branches becomes
-a breeze. Say goodbye to the tedious manual cherry-picking and let Mergify
-streamline your workflow.
+The `backport` command is especially useful for projects that maintain
+multiple branches simultaneously. It automates the process of creating a new
+pull request to apply changes from a merged pull request onto another branch,
+whether you're maintaining different versions of your software or need to ensure
+that bug fixes are propagated to all active branches.
 
 Once the backport is initiated, Mergify will provide feedback directly in the
 comments. If the backport is successful, you'll receive a link to the newly

--- a/src/content/docs/commands/copy.mdx
+++ b/src/content/docs/commands/copy.mdx
@@ -5,15 +5,13 @@ description: Copy a pull request to another branch.
 
 import CopyLimitations from '../workflow/actions/_copy_limitations.mdx';
 
-The `copy` command is a convenient tool in Mergify's suite, allowing users to
-replicate changes from a pull request to another branch within the same
-repository. This is particularly useful for teams working with multiple
-branches, such as feature branches, and wanting to propagate changes without
-manually creating multiple pull requests.
+The `copy` command replicates changes from a pull request to another branch
+within the same repository. This is particularly useful for teams working with
+multiple branches, such as feature branches, and wanting to propagate changes
+without manually creating multiple pull requests.
 
-Utilizing the `copy` command with Mergify can streamline your branching
-strategy and development flow by quickly mirroring changes where needed within
-the same repository.
+The `copy` command can simplify your branching strategy and development flow
+by quickly mirroring changes where needed.
 
 After initiating the copy process, Mergify will provide feedback via comments.
 If the copy is successful, a link to the new pull request will be provided. In

--- a/src/content/docs/commands/dequeue.mdx
+++ b/src/content/docs/commands/dequeue.mdx
@@ -3,8 +3,7 @@ title: Mergify Dequeue Command
 description: Remove a pull request from a merge queue.
 ---
 
-The `dequeue` command is a pivotal utility in Mergify's suite, intended for
-users wishing to remove a pull request from the merge queue promptly. This
+The `dequeue` command removes a pull request from the merge queue. This
 command is ideal for situations where you realize a pull request either
 shouldn't be merged or needs further revision before merging.
 

--- a/src/content/docs/commands/queue.mdx
+++ b/src/content/docs/commands/queue.mdx
@@ -8,7 +8,7 @@ import queueControlCheckbox from "../../images/commands/queue-control-checkbox.p
 
 The `queue` command in Mergify offers users a direct way to interact with the
 [Mergify merge queue](/merge-queue), right from their pull request
-comments. By utilizing this command, users can add a pull request to a merge
+comments. With this command, users can add a pull request to a merge
 queue or re-add it after it has been dequeued.
 
 To enter a queue, a pull request must match the `queue_conditions` of the
@@ -60,9 +60,9 @@ it passes its `queue_conditions`.
 
 ### Re-queuing a Previously Dequeued Pull Request
 
-If a pull request was removed from the merge queue — whether due to a failed
-check, a flaky test, or a manual `dequeue` — you can re-add it using the same
-`queue` command:
+If a pull request was removed from the merge queue (due to a failed check, a
+flaky test, or a manual `dequeue`), you can re-add it using the same `queue`
+command:
 
 ```text
 @mergifyio queue

--- a/src/content/docs/commands/rebase.mdx
+++ b/src/content/docs/commands/rebase.mdx
@@ -11,9 +11,8 @@ to rebase a pull request against its base branch. It's a handy way to ensure
 that the pull request is updated with the latest changes from the base branch
 without manually triggering a rebase.
 
-By leveraging the `rebase` command, developers can keep their pull requests
-up-to-date and maintain a clean commit history, enhancing the clarity and
-quality of the project's development.
+The `rebase` command lets developers keep their pull requests up-to-date and
+maintain a clean commit history.
 
 import RebaseAdvantage from './_rebase_advantages.mdx';
 
@@ -21,8 +20,8 @@ import RebaseAdvantage from './_rebase_advantages.mdx';
 
 :::caution
   Rebasing fork pull requests using `bot_account` impersonation is
-  deprecated and will stop working on **July 1, 2026**. Use the
-  [`update` command](/commands/update) instead for fork PRs.
+  deprecated. Use the [`update` command](/commands/update) instead for fork
+  PRs.
 :::
 
 ## Syntax

--- a/src/content/docs/commands/restrictions.mdx
+++ b/src/content/docs/commands/restrictions.mdx
@@ -5,21 +5,20 @@ description: Set limitations on who can execute specific Mergify commands.
 
 import OptionsTable from '../../../components/Tables/OptionsTable';
 
-Mergify commands can be a powerful tool to control and manage pull requests.
-However, in some scenarios, you might want to restrict who can use these
-commands to ensure they're executed only by authorized individuals. The command
+In some scenarios, you might want to restrict who can use Mergify commands to
+ensure they're executed only by authorized individuals. The command
 restrictions feature allows you to define a set of users or teams who are
 permitted to use specific Mergify commands.
 
 ## How Restrictions Work
 
-With command restrictions, you can leverage
-[conditions](/configuration/conditions) to define the valid context that are
+With command restrictions, you can use
+[conditions](/configuration/conditions) to define the valid context that is
 authorized to run a specific command. This could be a list of allowed users or
 teams, or even attributes related to the pull request itself.
 
 The restrictions are configured with the top-level key `commands_restrictions`
-which can specify restrictions for each commands.
+which can specify restrictions for each command.
 
 ### Examples
 
@@ -42,7 +41,7 @@ commands_restrictions:
 ```
 
 To limit backport commands for users with a specific permission on the
-repository.
+repository:
 
 ```yaml
 commands_restrictions:

--- a/src/content/docs/commands/squash.mdx
+++ b/src/content/docs/commands/squash.mdx
@@ -3,16 +3,12 @@ title: Mergify Squash Command
 description: Squash the commits of a pull request into one.
 ---
 
-The `squash` command is an integral tool in Mergify's arsenal, empowering users
-to condense all the changes from a pull request into a single commit. For PRs
-that come with a myriad of incremental commits, this command serves as a boon
-for those desiring a neat and concise commit history.
+The `squash` command condenses all the changes from a pull request into a
+single commit. For PRs that come with many incremental commits, it keeps the
+commit history neat and concise, especially when you wish to merge a pull
+request without the clutter of multiple individual commits.
 
-Implementing the `squash` command with Mergify is a stride towards a cleaner
-commit history, especially when you wish to merge a pull request without the
-clutter of multiple individual commits.
-
-The `squash` command proves to be invaluable for:
+The `squash` command is useful for:
 
 - **Clarity and Neatness**: Maintaining a clean commit history, especially when
   numerous commits have only minor changes.

--- a/src/content/docs/commands/update.mdx
+++ b/src/content/docs/commands/update.mdx
@@ -3,13 +3,12 @@ title: Mergify Update Command
 description: Update a pull request by merging its base branch into it.
 ---
 
-The `update` command is a powerful tool in Mergify's toolkit, designed to
-simplify the process of keeping pull requests current with their base branch.
-For teams working in rapidly evolving codebases where the main or base branch
-sees frequent changes, it's not uncommon for pull requests to become outdated.
+The `update` command keeps pull requests current with their base branch. When
+the base branch sees frequent changes, it's not uncommon for pull requests to
+become outdated.
 
-Instead of manually merging the base branch Mergify’s `update` command takes
-care of this seamlessly.
+Instead of manually merging the base branch, you can let the `update` command
+take care of it.
 
 ## Syntax
 

--- a/src/content/docs/merge-protections.mdx
+++ b/src/content/docs/merge-protections.mdx
@@ -29,10 +29,10 @@ Merge Protections let you:
 | Capability | GitHub Native | Mergify Merge Protections |
 | ---------- | ------------- | ------------------------- |
 | Conditional logic (complex AND/OR on PR metadata) | No | Extensive |
-| Depends‑On relationships | ❌ | ✅ |
-| Time / schedule based merge windows | ❌ | ✅ |
-| Repository freeze (manual or scheduled) | ❌ | ✅ |
-| Single composite check gate | Partial | ✅ |
+| Depends‑On relationships | No | Yes |
+| Time / schedule based merge windows | No | Yes |
+| Repository freeze (manual or scheduled) | No | Yes |
+| Single composite check gate | Partial | Yes |
 
 ## How They Work
 

--- a/src/content/docs/merge-protections/auto-merge.mdx
+++ b/src/content/docs/merge-protections/auto-merge.mdx
@@ -97,9 +97,8 @@ merge_protections_settings:
 
 ## Migrating from `autoqueue`
 
-`queue_rules[].autoqueue` is deprecated and will stop working on
-**2026-07-16**. The replacement is `auto_merge_conditions` in
-`merge_protections_settings`.
+`queue_rules[].autoqueue` is deprecated. The replacement is
+`auto_merge_conditions` in `merge_protections_settings`.
 
 Mergify opens an automatic migration pull request that rewrites the
 configuration. The translation depends on the shape of the original

--- a/src/content/docs/merge-protections/builtin.mdx
+++ b/src/content/docs/merge-protections/builtin.mdx
@@ -7,7 +7,7 @@ import { Image } from "astro:assets"
 import dependsOnBody from "../../images/merge-protections/depends-on.png"
 import mergeAfterBody from "../../images/merge-protections/merge-after.png"
 
-These protections are automatically interpreted — no configuration required.
+These protections are automatically interpreted, no configuration required.
 
 ## Depends-On
 
@@ -15,7 +15,7 @@ Block merging until specified pull requests are merged.
 
 Declare dependencies in the PR body:
 
-```yaml
+```text
 Depends-On: #123
 Depends-On: https://github.com/org/repo/pull/123
 Depends-On: org/repo#123
@@ -37,7 +37,7 @@ Use cases:
 
 Delay merging until a future time using a header in the PR description:
 
-```yaml
+```text
 Merge-After: 2025-09-01T09:00:00Z
 ```
 

--- a/src/content/docs/merge-protections/custom-rules.mdx
+++ b/src/content/docs/merge-protections/custom-rules.mdx
@@ -34,7 +34,7 @@ Common condition patterns:
 | Goal | Example Condition |
 | ---- | ----------------- |
 | Target specific branch | `base = main` |
-| Enforce title prefix | `title ~= ^^feat:` |
+| Enforce title prefix | `title ~= ^feat:` |
 | Require label | `label = security-reviewed` |
 | Match file changes | `files ~= ^src/` |
 | Require author team | `author = @security-team` |

--- a/src/content/docs/merge-protections/examples.mdx
+++ b/src/content/docs/merge-protections/examples.mdx
@@ -18,7 +18,7 @@ name: Issue Linked
 if:
   - label = feature
 success_conditions:
-  - title ~= #[0-9]+
+  - "title ~= #[0-9]+"
 ```
 
 ## Disallow WIP in Title

--- a/src/content/docs/merge-protections/setup.mdx
+++ b/src/content/docs/merge-protections/setup.mdx
@@ -38,11 +38,11 @@ protection status appears as a GitHub Check Run or as a Deployment.
 Example configuration:
 ```yaml
 merge_protections_settings:
-    reporting_method: check-runs  # or deployments
-    # Post a comment with details about required rules
-    post_comment: true
-    # Automatically merge or queue PRs when all protections pass
-    auto_merge_conditions: true
+  reporting_method: check-runs  # or deployments
+  # Post a comment with details about required rules
+  post_comment: true
+  # Automatically merge or queue PRs when all protections pass
+  auto_merge_conditions: true
 ```
 
 Choose the method that best fits your integration and compliance needs.
@@ -60,7 +60,7 @@ reference and configuration examples.
 ## Make the Check Required
 
 Enabling inserts a check named `Mergify Merge Protections` on each pull
-request. Mark it as required, either as a checks or deployment:
+request. Mark it as required, either as a check or a deployment:
 
 - GitHub Branch Protection: Settings → Branches → Add/Edit rule → Require
   status checks / deployment to succeed → select `Mergify Merge Protections`
@@ -71,7 +71,7 @@ request. Mark it as required, either as a checks or deployment:
 <Image src={bpScreen} alt="GitHub Branch Protection" />
 
 Once required, the check blocks merges whenever any active protection fails and
-explains why in its output & a summary comment.
+explains why in its output and a summary comment.
 
 ## Updating Rules
 

--- a/src/content/docs/migrate/bors-ng.mdx
+++ b/src/content/docs/migrate/bors-ng.mdx
@@ -8,8 +8,8 @@ import IntegrationLogo from "../../../components/IntegrationLogo.astro"
 <IntegrationLogo src={borsLogo} alt="Bors logo"/>
 
 Bors‑NG orchestrates a “try → staging → master” flow with batch testing and
-ordered merges. Mergify offers a production‑grade Merge Queue with similar
-guarantees plus flexible rules.
+ordered merges. Mergify offers a Merge Queue with similar guarantees plus
+flexible rules.
 
 :::tip[Need help?]
 
@@ -52,7 +52,7 @@ Use `batch_size > 1` to emulate Bors batches.
 ## Emulating “try” builds
 
 If you relied on `bors try` to validate speculative changes, you can keep a
-lightweight CI workflow triggered by a label or comment
+lightweight CI workflow triggered by a label or comment.
 
 ## Batches and priorities
 

--- a/src/content/docs/migrate/bulldozer.mdx
+++ b/src/content/docs/migrate/bulldozer.mdx
@@ -43,7 +43,7 @@ Equivalent Mergify configuration:
 
 ```yaml title=.mergify.yml
 merge_protections_settings:
-  auto_merge: true
+  auto_merge_conditions: true
 
 merge_protections:
   - name: bulldozer-equivalent
@@ -60,8 +60,9 @@ queue_rules:
 ```
 
 Notes:
-- [`auto_merge`](/merge-protections/auto-merge) automatically queues PRs when
-  all [merge protection](/merge-protections) `success_conditions` pass
+- [`auto_merge_conditions`](/merge-protections/auto-merge) automatically
+  queues PRs when all [merge protection](/merge-protections)
+  `success_conditions` pass
 
 - Checks map to `check-success = <name>` (or `check-skipped`, `check-neutral`)
 
@@ -69,19 +70,20 @@ Notes:
 
 - Approvals map to review count or specific reviewers
 
-- The merge queue keeps PRs updated automatically — no manual rebases needed
+- The merge queue keeps PRs updated automatically, so no manual rebases are
+  needed
 
 ## Going Further with Merge Queue
 
 Once you have basic automerge working, you can take advantage of features
 Bulldozer doesn't offer:
 
-- [Priorities](/merge-queue/priority) — urgent PRs jump ahead in the queue
+- [Priorities](/merge-queue/priority): urgent PRs jump ahead in the queue
 
-- [Batches](/merge-queue/batches) — merge multiple PRs at once to reduce CI
+- [Batches](/merge-queue/batches): merge multiple PRs at once to reduce CI
   load
 
-- [Parallel checks](/merge-queue/performance#parallel-checks) — test multiple queue
+- [Parallel checks](/merge-queue/performance#parallel-checks): test multiple queue
   entries simultaneously
 
 ## Feature parity quick table

--- a/src/content/docs/migrate/github-merge-queue.mdx
+++ b/src/content/docs/migrate/github-merge-queue.mdx
@@ -12,8 +12,8 @@ before merging. Migrating to Mergify keeps that guarantee while adding
 fine‑grained policies, batching strategies, real CI efficiency insights, and
 queue observability (latency, throughput, bottlenecks) in one system.
 
-This guide shows a minimal, incremental migration—no rewrites, keep your branch
-protections and required checks exactly as they are.
+This guide shows a minimal, incremental migration: no rewrites, and you keep
+your branch protections and required checks exactly as they are.
 
 :::tip[Need help?]
 
@@ -59,8 +59,8 @@ Queue features:
 
 ## Minimal equivalent configuration
 
-If today you rely on a protected `main` with a GitHub Merge Queue, there is no
-needed configuration. Mergify automatically injects your ruleset or branch
+If today you rely on a protected `main` with a GitHub Merge Queue, no
+configuration is needed. Mergify automatically injects your ruleset or branch
 protections into the queue system. Simply type [`@mergify
 queue`](/commands/queue) to queue a pull request.
 
@@ -125,8 +125,8 @@ Rollback is trivial: toggle GitHub’s native queue back on; no destructive stat
 ## FAQ
 
 **Does Mergify require removing branch protections?** No. Keep them; Mergify
-works with them. Just avoid duplicate required contexts (same check listed in
-both branch protection and queue conditions is fine—no double run).
+works with them. Just avoid duplicate required contexts (the same check listed
+in both branch protection and queue conditions is fine; it doesn't run twice).
 
 **Do I lose the merge squash/rebase options?** No. Configure `merge_method` per
 rule; you can still vary merge strategies across PR subsets.


### PR DESCRIPTION
First docs-health audit pass over the commands, merge-protections, and
migration pages. Accuracy fixes verified against the schema and engine:

- migrate/bulldozer: example used the deprecated `auto_merge: true`; now
  `auto_merge_conditions: true`
- merge-protections/custom-rules: fix regex typo `^^feat:`
- merge-protections/examples: quote `"title ~= #[0-9]+"` (the unquoted
  `#` made YAML parse the condition as empty)
- merge-protections/builtin: Depends-On/Merge-After PR-body snippets are
  now `text` fences, not `yaml` (`#123` would be a YAML comment)
- merge-protections/setup: normalize example YAML to 2-space indentation
- commands/rebase and merge-protections/auto-merge: expired dated
  deprecation notices converted to dateless markers per the repo rule
- merge-protections comparison table: emoji cells replaced with No/Yes

All command names, arguments, and default restrictions were verified
against the engine; the roster is accurate.

Plus a conservative style pass per the proofread rubrics: promotional
openers and filler paragraphs, banned words, em dashes, grammar.

Part of the first manual docs-health audit (MRGFY-8212).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Depends-On: #12207