### PR TITLE
docs(enterprise,misc): fix inverted Redis TLS instructions and style

### DIFF
--- a/src/content/docs/billing.mdx
+++ b/src/content/docs/billing.mdx
@@ -9,9 +9,8 @@ import PlanScreenshot from "../images/billing/plan.png"
 import InvoicePreviousPeriod from "../images/billing/invoice-previous-period.png"
 import InvoiceNextPeriod from "../images/billing/invoice-next-period.png"
 
-At Mergify, our goal is to offer you a transparent and efficient billing system
-that meets your needs. Here's a comprehensive guide to help you grasp how our
-billing system functions:
+This page explains how Mergify's contributor-based billing works and how to
+read your invoice.
 
 ## Contributor-Based Billing
 
@@ -35,7 +34,7 @@ Here's how it works:
   active for billing purposes.
 
 - Usage is prorated to the day: if a contributor is seen active during 48 days,
-  the system only bills for precisely 48 days — not 2 entire months.
+  the system only bills for precisely 48 days, not 2 entire months.
 
 ### Estimating Contributors
 
@@ -86,14 +85,14 @@ number of active pull requests they have.
 ## Annual Subscription
 
 Mergify does not require an annual subscription (except for the Enterprise
-plan), but offer substantial discount if you buy users in advance for a
-12-months period.
+plan), but offers a large discount if you buy users in advance for a
+12-month period.
 
-An annual subscription allows you to buy a base of number of seats (users) per
+An annual subscription allows you to buy a base number of seats (users) per
 product at the start of the year. If your usage goes beyond the pre-purchased
 seats, additional seats are billed monthly, prorated to the exact day of use.
 
-For example, let's say you have purchased a annual license for 100 users. If
+For example, let's say you have purchased an annual license for 100 users. If
 your number of users increases to 110 users during 45 days, you will be
 invoiced for 10 extra users over 45 days.
 

--- a/src/content/docs/enterprise.mdx
+++ b/src/content/docs/enterprise.mdx
@@ -3,9 +3,8 @@ title: 'Mergify Enterprise'
 description: 'Self-hosted / on-premise documentation for Mergify Enterprise.'
 ---
 
-Welcome to the Mergify Enterprise resource center. Here you will find everything needed to deploy
-and run the on-premise edition—from requirements to installation, integrations, maintenance, and
-troubleshooting.
+This section covers everything needed to deploy and run the on-premise edition of Mergify
+Enterprise, from requirements to installation, integrations, maintenance, and troubleshooting.
 
 - Review the [Requirements](/enterprise/requirements) before provisioning infrastructure.
 
@@ -17,4 +16,4 @@ troubleshooting.
 - Keep your deployment healthy with the [Troubleshooting](/enterprise/troubleshooting) and
   [Maintenance](/enterprise/maintenance) guides.
 
-> 🚩 Need help? Contact Mergify support at [support@mergify.com](mailto:support@mergify.com).
+> Need help? Contact Mergify support at [support@mergify.com](mailto:support@mergify.com).

--- a/src/content/docs/enterprise/advanced-features.mdx
+++ b/src/content/docs/enterprise/advanced-features.mdx
@@ -163,7 +163,7 @@ AWS_REGION=us-west-2
 ## Slack Integration
 
 Mergify Enterprise 8.6.0+ can post notifications directly to Slack. These steps assume your
-self-hosted dashboard lives at `https://mergify.mycompany.com`—adjust URLs as needed.
+self-hosted dashboard lives at `https://mergify.mycompany.com`. Adjust URLs as needed.
 
 ### 1. Create a Slack App
 

--- a/src/content/docs/enterprise/architecture.mdx
+++ b/src/content/docs/enterprise/architecture.mdx
@@ -6,7 +6,7 @@ description: 'Understand the data flow and components that power the self-hosted
 Mergify Enterprise runs a dedicated automation engine that ingests repository
 events, evaluates your rules, and orchestrates merge actions from inside your
 infrastructure. GitHub supplies the event feed and API surface. The
-decision making, state handling, and workflow execution allß happen within your
+decision making, state handling, and workflow execution all happen within your
 environment (aside from the optional Subscription API lookup), so you maintain
 full control over data flows.
 

--- a/src/content/docs/enterprise/installation.mdx
+++ b/src/content/docs/enterprise/installation.mdx
@@ -17,9 +17,9 @@ import installSuccessScreen from "../../images/enterprise/install-success.png"
 
 The installation process is separated into two steps:
 
-1. First start the Mergify container without any configuration and the GitHub
-   App Installer started to create your Mergify GitHub App on GitHub. This will
-   generate a configuration file with the GitHub App credentials.
+1. First, start the Mergify container without any configuration and with the
+   GitHub App Installer enabled to create your Mergify GitHub App on GitHub.
+   This will generate a configuration file with the GitHub App credentials.
 
 2. Then restart the Mergify container with the downloaded configuration and the
    GitHub App Installer disabled.
@@ -28,16 +28,16 @@ You will run the installer mode first to generate a `mergify.env` file, then res
 normal mode with that configuration plus your subscription token.
 
 :::note
-Always pick the latest Enterprise image. Examples below use `@@ENTERPRISE_VERSION@@`; replace it with the newest
-tag from the releases page.
+  Always pick the latest Enterprise image. Examples below use `@@ENTERPRISE_VERSION@@`; replace it
+  with the newest tag from the releases page.
 :::
 
 ## Get the Docker Image
 
-First, ensure you have the mergify\_registry\_key.json file to get access to
-Mergify docker images.
+First, ensure you have the `mergify_registry_key.json` file to get access to
+Mergify Docker images.
 
-If you need help, ask your Mergify account representative or the Mergify
+If you need help, ask your Mergify account representative or Mergify
 customer support.
 
 Download the Docker image using `docker pull`:
@@ -61,11 +61,11 @@ docker run --rm -d \
 ```
 
 :::note\[Security Note]
-the installer can be safely exposed to the internet during this
-procedure. The installer is a static page that will post a form on the GitHub
-website. GitHub will then ask for confirmation about the creation of the
-resources. No data is stored on the server or the browser. The actual engine is
-not yet started.
+  The installer can be safely exposed to the internet during this
+  procedure. The installer is a static page that will post a form on the GitHub
+  website. GitHub will then ask for confirmation about the creation of the
+  resources. No data is stored on the server or the browser. The actual engine is
+  not yet started.
 :::
 
 ## Expose the Container
@@ -104,7 +104,7 @@ Click on **Install** on the following screen:
 
 <Image src={installAppScreen} alt="Mergify App Installation" />
 
-The GitHub App creation and installation is finished. 🥳
+The GitHub App creation and installation is finished.
 
 <Image src={installSuccessScreen} alt="Mergify App Installation Success" />
 
@@ -129,14 +129,14 @@ Make sure your Redis instance is ready and running at this stage.
 
 Redis server provides TLS termination. To connect to such an instance you need to:
 
-- Use `redis://` instead of `rediss://` in the `MERGIFYENGINE_REDIS_URL` environment variable.
+- Use `rediss://` instead of `redis://` in the `MERGIFYENGINE_REDIS_URL` environment variable.
 
 #### Optional: use Redis with self-signed TLS certificate
 
 Some Redis server providers set it up with self-signed certificates. In that case, to connect to
 such an instance you need to:
 
-- Use `redis://` instead of `rediss://` in the `MERGIFYENGINE_REDIS_URL` environment variable.
+- Use `rediss://` instead of `redis://` in the `MERGIFYENGINE_REDIS_URL` environment variable.
 
 - Set `MERGIFYENGINE_REDIS_SSL_VERIFY_MODE_CERT_NONE=1` in your environment variables. Mergify will
   connect to Redis using encryption but will not verify the server certificate.
@@ -168,8 +168,8 @@ each authentication mode.
 ## Start Mergify in Normal Mode
 
 :::note
-  🔑 You need a subscription token (`MERGIFYENGINE_SUBSCRIPTION_TOKEN`) to start using Mergify at this stage.
-  Contact support if you do not have one.
+  You need a subscription token (`MERGIFYENGINE_SUBSCRIPTION_TOKEN`) to start using Mergify at this
+  stage. Contact support if you do not have one.
 :::
 
 The example below includes the CI Insights and Test Insights environment variables. Omit them if you
@@ -211,10 +211,10 @@ GET / HTTP/1.1
 host: container:5000
 ```
 
-> ❤️‍🩹 The endpoint should respond with HTTP 307.
+> The endpoint should respond with HTTP 307.
 
 ## Testing the Installation
 
-1. Sign in to the dashboard at https://my-mergify.example.com/ and enable Workflow Automation for a repository.
+1. Sign in to the dashboard at `https://mergify.mycompany.com` and enable Workflow Automation for a repository.
 2. Commit an empty `.mergify.yml` to the default branch.
 3. Open a pull request; you should see a **Summary** check run.

--- a/src/content/docs/enterprise/maintenance.mdx
+++ b/src/content/docs/enterprise/maintenance.mdx
@@ -13,12 +13,9 @@ Backing up your Mergify Enterprise installation involves two main steps: noting
 your current Docker image version and backing up the PostgreSQL database.
 
 :::note
-Redis does not need regular backups because its content can be rebuilt from
-GitHub events.
+  Redis does not need regular backups because its content can be rebuilt from
+  GitHub events.
 :::
-
-This guide will walk you through backing up these components and restoring them
-when necessary.
 
 ## Backup strategy
 

--- a/src/content/docs/enterprise/manual-installation-legacy.mdx
+++ b/src/content/docs/enterprise/manual-installation-legacy.mdx
@@ -3,9 +3,9 @@ title: 'Manual Installation (Legacy)'
 description: 'Legacy process for provisioning the Mergify GitHub App and engine without the installer.'
 ---
 
-> ⚙️ These steps mirror the older manual workflow. Adapt them into infrastructure-as-code if needed.
+> These steps mirror the older manual workflow. Adapt them into infrastructure-as-code if needed.
 
-> 🔼 Replace the `@@ENTERPRISE_VERSION@@` tag with the latest Enterprise release.
+> Replace the `@@ENTERPRISE_VERSION@@` tag with the latest Enterprise release.
 
 ## 1. Create the GitHub App
 
@@ -121,9 +121,9 @@ docker pull registry.mergify.com/enterprise:@@ENTERPRISE_VERSION@@
 
 ## 5. Start Mergify
 
-> 🔑 A subscription token is required. Contact Mergify if you do not have one.
+> A subscription token is required. Contact Mergify if you do not have one.
 >
-> 💽 Ensure Redis (with persistence/TLS if needed) and Postgres are ready.
+> Ensure Redis (with persistence/TLS if needed) and Postgres are ready.
 
 ```sh
 docker run \

--- a/src/content/docs/enterprise/requirements.mdx
+++ b/src/content/docs/enterprise/requirements.mdx
@@ -53,7 +53,7 @@ docker run --name some-redis-with-tls -d \
 
 ## Mergify Requirements
 
-The Mergify container needs at leas:
+The Mergify container needs at least:
 
 - 4 GB of RAM
 - 2 vCPUs
@@ -64,7 +64,7 @@ The service listens on HTTP port 5000 for the dashboard/API and webhook intake,
 and it must sit behind a reverse proxy that:
 
 - Terminates TLS
-- Is exposed publicly through DNS over HTTPS
+- Is exposed publicly with a DNS name over HTTPS
 - Sets the `X-Forwarded-Proto` header
 
 Some features (copy, backport, rebase) write to `/tmp`, so ensure the host or node offers roughly

--- a/src/content/docs/enterprise/troubleshooting.mdx
+++ b/src/content/docs/enterprise/troubleshooting.mdx
@@ -132,4 +132,4 @@ cause silent failures.
 | Workflow run |
 
 You can find the purpose of these permissions in the
-[GitHub App required permissions guide](https://docs.mergify.com/security/#github-app-required-permissions).
+[GitHub App required permissions guide](/security#github-app-required-permissions).

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -22,7 +22,7 @@ import mergeQueueHero from './images/merge-queue-hero.jpg';
           Stop breaking <span class="home-hero-accent">main</span>
         </h1>
         <p class="text-subtitle home-hero-subtitle">
-          Mergify eliminates broken builds, tames flaky tests, and cuts CI waste — so your team
+          Mergify eliminates broken builds, tames flaky tests, and cuts CI waste, so your team
           ships with confidence.
         </p>
         <div class="home-hero-cta">

--- a/src/content/docs/security.mdx
+++ b/src/content/docs/security.mdx
@@ -1,6 +1,6 @@
 ---
 title: Security
-description: Mergify's security posture — compliance, data handling, access control, and the GitHub App permissions we request.
+description: "Mergify's security posture: compliance, data handling, access control, and the GitHub App permissions we request."
 ---
 
 import Button from '../../components/Button.astro';
@@ -44,7 +44,7 @@ roles](https://docs.github.com/en/organizations/managing-user-access-to-your-org
 A user with the `Read` role on a repository in GitHub also has the
 `Read` role in Mergify.
 
-Some operations additionally require the GitHub organization `Owner` role.
+Some operations also require the GitHub organization `Owner` role.
 See the [Features Permissions](#features-permissions) table below for the
 full mapping between GitHub roles and Mergify capabilities.
 
@@ -114,15 +114,15 @@ Each user can hold any combination of the following roles:
     <tr>
       <th scope="row">Billing Admin</th>
       <td>
-        Manage the Mergify subscription and billing details — invoices, plan
+        Manage the Mergify subscription and billing details: invoices, plan
         changes, and the Stripe customer portal.
       </td>
     </tr>
     <tr>
       <th scope="row">CI Admin</th>
       <td>
-        Configure CI Insights at the organization level — self-hosted runner
-        fleet — and manage CI-scoped application keys.
+        Configure CI Insights at the organization level (self-hosted runner
+        fleet) and manage CI-scoped application keys.
       </td>
     </tr>
     <tr>
@@ -135,7 +135,7 @@ Each user can hold any combination of the following roles:
     <tr>
       <th scope="row">Delegation Admin</th>
       <td>
-        Manage the delegated-role roster itself — grant or revoke any of the
+        Manage the delegated-role roster itself: grant or revoke any of the
         roles above (including this one) to other users.
       </td>
     </tr>
@@ -464,15 +464,15 @@ relevant account or resource. Permissions are inherited from GitHub roles.
   through Mergify's [delegated roles](#delegated-roles), without granting
   them the GitHub `Owner` role. The mapping is:
 
-  - **Billing Admin** — manage Mergify subscription.
+  - **Billing Admin**: manage Mergify subscription.
 
-  - **CI Admin** — manage API keys (CI scope only) and manage CI Insights
+  - **CI Admin**: manage API keys (CI scope only) and manage CI Insights
     self-hosted runners.
 
-  - **Integrations Admin** — configure default products for new repositories
+  - **Integrations Admin**: configure default products for new repositories
     and configure third-party integrations (Slack, Datadog, etc.).
 
-  - **Delegation Admin** — grant or revoke any of the roles above.
+  - **Delegation Admin**: grant or revoke any of the roles above.
 
   API keys with the `admin` scope still require the GitHub `Owner` role.
 :::

--- a/src/content/docs/support.mdx
+++ b/src/content/docs/support.mdx
@@ -3,10 +3,8 @@ title: Support
 description: Learn how to reach the Mergify support team, understand coverage, and explore enhanced support options.
 ---
 
-At Mergify, we treat support as a core part of the product experience. Our goal
-is to keep your merge automation running smoothly by making it simple to contact
-the right team, set expectations, and understand the additional services
-available to larger organizations.
+This page explains how to contact Mergify support and what to expect from a
+support request.
 
 ## Contact Support Immediately
 

--- a/src/content/docs/support/premium.mdx
+++ b/src/content/docs/support/premium.mdx
@@ -4,7 +4,7 @@ description: Escalation guide for Mergify's 24/7 Premium Support service.
 ---
 
 Mergify's 24/7 Premium Support gives your team a direct escalation path to our
-on-call engineers — around the clock, every day of the year. This service is
+on-call engineers, around the clock, every day of the year. This service is
 exclusively for critical incidents that block your ability to merge.
 
 For general support questions, configuration help, or feature requests, see the
@@ -37,13 +37,13 @@ Recent config changes: <any changes made before the issue>
 
 ## What Happens Next
 
-1. **Acknowledgment** — within 1 hour, an engineer confirms receipt and begins
+1. **Acknowledgment**: within 1 hour, an engineer confirms receipt and begins
    triage.
 
-2. **Investigation** — we analyze the incident using the details you provided
+2. **Investigation**: we analyze the incident using the details you provided
    alongside our own telemetry.
 
-3. **Resolution** — a fix or workaround is deployed. We confirm the outcome with
+3. **Resolution**: a fix or workaround is deployed. We confirm the outcome with
    you before closing the incident.
 
 Resolution time varies depending on incident complexity.
@@ -76,12 +76,12 @@ unavailable or actively blocking your workflow:
 
 To help us resolve your incident as fast as possible:
 
-- **Use the template above** — include repository, PR, and observed behavior.
+- **Use the template above**: include repository, PR, and observed behavior.
 
-- **Stay reachable** — ensure a technical contact is available for follow-up
+- **Stay reachable**: ensure a technical contact is available for follow-up
   during triage.
 
-- **Reserve escalation for blocking events** — this channel is for genuine
+- **Reserve escalation for blocking events**: this channel is for genuine
   service-blocking incidents that you cannot resolve using the product's
   available features.
 


### PR DESCRIPTION
First docs-health audit pass over the enterprise section and top-level
pages. The critical accuracy fix, verified against the engine:

- enterprise/installation: both Redis TLS bullets said "use `redis://`
  instead of `rediss://`", which is backwards; the engine only enables
  TLS (and the self-signed escape hatch) for the `rediss://` scheme.
  Anyone following the docs got a non-TLS connection.

Also fixed, verified: garbled installer step wording, "at leas"/stray-ß
typos, "DNS over HTTPS" misphrasing (reads as the DoH protocol),
inconsistent example domain, billing grammar ("a annual license",
"12-months period"), and a full-site URL converted to an internal link.
All MERGIFYENGINE_* env vars, endpoints, and admin commands on these
pages were verified against the monorepo.

Plus a conservative style pass per the proofread rubrics: emojis removed
from prose, em dashes, throat-clearing intros on enterprise/billing/
support, callout indentation, banned words. Compliance, pricing, and SLA
claims were deliberately left untouched (flagged in the audit report
instead).

Part of the first manual docs-health audit (MRGFY-8212).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Depends-On: #12210