### PR TITLE
docs(merge-queue): partition_rules are removed, not deprecated

### DIFF
--- a/src/content/docs/merge-queue/migrate-partitions-to-scopes.mdx
+++ b/src/content/docs/merge-queue/migrate-partitions-to-scopes.mdx
@@ -1,12 +1,16 @@
 ---
 title: Migrate from Partition Rules to Scopes
-description: Step-by-step guide to replace the deprecated partition_rules with scopes and scope-aware CI.
+description: Step-by-step guide to replace partition_rules, which Mergify no longer supports, with scopes and scope-aware CI.
 ---
 
-`partition_rules` are deprecated and will be removed in a future release. This
-guide walks you through replacing them with **scopes**, a more powerful system
-that integrates with your CI and unlocks smarter batching, parallel merge
-queues, and monorepo-aware workflows.
+`partition_rules` are no longer part of the Mergify configuration. A file that
+still declares them is not rejected, but Mergify ignores the section: the queue
+stops splitting into partition lanes, and Mergify opens an automatic migration
+pull request that strips it out.
+
+This guide walks you through replacing partitions with **scopes**, a system that
+integrates with your CI and unlocks smarter batching, parallel merge queues, and
+monorepo-aware workflows.
 
 ## Why Migrate?
 
@@ -175,6 +179,9 @@ jobs:
 Delete the entire `partition_rules` section from `.mergify.yml`. If you
 referenced `partition-name` or `current-partition-name` in your
 `pull_request_rules` conditions, remove those conditions. They no longer apply.
+
+If Mergify has already opened an automatic migration pull request for your
+repository, merging it does this step for you.
 
 ### 4. Enable parallel mode
 

--- a/src/content/docs/merge-queue/queue-modes.mdx
+++ b/src/content/docs/merge-queue/queue-modes.mdx
@@ -487,7 +487,8 @@ aren't available depending on the mode:
   independent, so a passing batch can't vouch for any other. It works in serial and parallel modes,
   where a passing batch vouches for the earlier changes it was tested on top of.
 
-- **`partition_rules` are not supported.** Partitions rely on serial ordering; use scopes instead.
+Independently of the mode, `partition_rules` are no longer part of the configuration: use scopes
+instead. See [Migrate from Partition Rules to Scopes](/merge-queue/migrate-partitions-to-scopes).
 
 ## Next Steps
 


### PR DESCRIPTION
The migration guide still told readers `partition_rules` were "deprecated and
will be removed in a future release". They are already gone: the key is absent
from `public/mergify-configuration-schema.json` and from the engine's
configuration model, having disappeared between the 2026-06-02 and 2026-06-12
schema syncs with no changelog entry.

Describe what actually happens now. The configuration model allows extra keys,
so a file still declaring `partition_rules` is not rejected: Mergify ignores the
section, the queue stops splitting into partition lanes, and the extra-keys
transformer opens a configuration migration pull request that strips it out.
Step 3 notes that merging that pull request does the work for you.

In queue-modes, `partition_rules` was listed as an isolated-mode limitation. It
is not mode-specific any more, so it moves out of the limitations list into a
sentence pointing at the migration guide.

MRGFY-8213

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>