### PR TITLE
docs(merge-protections): show where Depends-On surfaces in the queue

### DIFF
--- a/src/content/docs/merge-protections/builtin.mdx
+++ b/src/content/docs/merge-protections/builtin.mdx
@@ -33,6 +33,20 @@ Use cases:
 - Schema then implementation
 - Chained refactors
 
+### Seeing dependencies in the merge queue
+
+Because a pull request with a `Depends-On:` header merges after the ones it
+depends on, it can sit behind a lower-priority pull request for no visible
+reason. The [merge queue](/merge-queue) shows why: a queued pull request held
+back by a dependency carries a dependency icon in the list, and its side panel
+gains a **Depends On** section linking to each queued pull request it waits for.
+The merge queue status [API](/api/usage) reports the same list as
+`depends_on_pull_requests`.
+
+This display covers dependencies inside a [stack](/merge-queue/stacks) in the
+same repository. A dependency on a pull request in another repository still
+blocks the merge, but the queue does not show it.
+
 ## Merge-After
 
 Delay merging until a future time using a header in the PR description:


### PR DESCRIPTION
A queued pull request held back by a Depends-On can sit behind a lower-priority
one with nothing on the page explaining why. The merge queue now answers that: a
dependency icon in the list, a "Depends On" section in the side panel linking to
each pull request it waits for, and `depends_on_pull_requests` on the merge queue
status API.

The scope is narrower than it first looks, so the page says so. The engine
computes that list from the stack-predecessor walk, which engages only when the
pull request is genuinely stacked and declares a same-repository `Depends-On:`.
A cross-repository dependency still blocks the merge but is never displayed.

MRGFY-8213

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Depends-On: #12232