### PR TITLE
docs(test-insights): state that Detection reports on default-branch runs

### DIFF
--- a/src/content/docs/test-insights.mdx
+++ b/src/content/docs/test-insights.mdx
@@ -53,6 +53,11 @@ known flakiness.
   decisions. The test still runs and results are still collected, preserving
   full visibility.
 
+- **Default branch scope**: Test health across repositories comes from runs on
+  the default branch. Pull request runs feed
+  [Prevention](/test-insights/prevention) instead. See
+  [which runs Detection reports on](/test-insights/detection#which-runs-detection-reports-on).
+
 ## Setup
 
 Test Insights is powered by the same CI integration as

--- a/src/content/docs/test-insights/detection.mdx
+++ b/src/content/docs/test-insights/detection.mdx
@@ -12,6 +12,23 @@ see the full picture and prioritize what to fix.
 
 <Image src={DetectionScreenshot} alt="Detection dashboard: tests health donut and CI impact chart" />
 
+## Which runs Detection reports on
+
+Detection reports on tests that ran on your repository's default branch.
+Results uploaded from pull request branches are stored, but they do not
+contribute to the metrics shown here.
+
+A repository whose CI has only ever run on pull requests shows an empty
+Detection page, even though uploads are working. Merge to the default branch
+and the tests appear after that run completes.
+
+The same scope applies outside the dashboard: the
+[`mergify tests show`](/cli/tests) command and the
+[test search API](/api/test-insights) return default-branch results.
+
+[Prevention](/test-insights/prevention) covers the pull request side of Test
+Insights: it reports on tests running on pull request branches.
+
 ## How tests are classified
 
 Mergify classifies tests based on their results across multiple CI runs,


### PR DESCRIPTION
Detection, `mergify tests show`, and the test search API surface only runs
from the repository's default branch; pull request runs are stored but feed
Prevention instead. A repository whose CI has only ever run on pull requests
therefore sees an empty Detection page with working uploads.

MRGFY-8295

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CCCgUbY1KiEvFJdvfc81a4