### PR TITLE
ci: require two approvals on docs-agent pull requests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -44,7 +44,11 @@ merge_protections:
       - or: &DefaultReviewCond
           - "#approved-reviews-by >= 2"
           - author = dependabot[bot]
-          - author = mergify-ci-bot
+          # mergify-ci-bot needs no approval for the deterministic syncers, but
+          # the docs agent writes prose under docs-agent/* and gets no free pass.
+          - and:
+              - author = mergify-ci-bot
+              - "-head ~= ^docs-agent/"
 
   - name: 🧑‍🚒 Hotfix Review Requirements
     if:
@@ -81,8 +85,13 @@ queue_rules:
   - name: default
     <<: *DefaultQueueOptions
     queue_conditions:
-      - author != mergify-ci-bot
-      - author != dependabot[bot]
+      # docs-agent branches are excluded from the automated updates lane below,
+      # so they have to land here or they would match no queue at all.
+      - or:
+          - and:
+              - author != mergify-ci-bot
+              - author != dependabot[bot]
+          - head ~= ^docs-agent/
     merge_conditions:
       - schedule=Mon-Fri 09:00-17:30[Europe/Paris]
 
@@ -93,6 +102,7 @@ queue_rules:
       - or:
           - author = mergify-ci-bot
           - author = dependabot[bot]
+      - "-head ~= ^docs-agent/"
     batch_size: 10
     batch_max_wait_time: 5min
 
@@ -100,7 +110,14 @@ pull_request_rules:
   - name: request review
     conditions:
       - -author=dependabot[bot]
-      - -author=mergify-ci-bot
+      # Bots are not routed for review, except the docs agent, which now needs
+      # two approvals like anyone else. Gated on -draft so the ten drafts a
+      # Monday audit opens do not each ping the team before a human wants them.
+      - or:
+          - -author=mergify-ci-bot
+          - and:
+              - head ~= ^docs-agent/
+              - -draft
       - -merged
       - -closed
       - and: *CheckRuns


### PR DESCRIPTION
`mergify-ci-bot` satisfies the "👀 Review Requirements" merge protection with
**zero** approvals and is auto-queued through the `automated updates` lane.
That is right for the deterministic syncers in `Mergifyio/ci-bot` — a changelog
copy or a JSON-schema sync needs no reviewers — and wrong for the scheduled
docs agent, which opens pull requests full of prose a model wrote.

Nothing but the draft flag holds that line today. The agent opens drafts only
(`draft: always-true`, not overridable at runtime), so a human must act before
anything lands; but the moment someone marks one ready, it can merge with no
approval on it at all. ci-bot#282 merged today, which armed the Monday 06:00
Europe/Paris health audit, so this wants to land first.

Both bots push from the same fork (`mergify-ci-bot/docs`), so `author` and
`head-repo-full-name` cannot tell them apart. The branch prefix can: the
runner's `scope.py` names every branch `docs-agent/health-audit-<section>` or
`docs-agent/change-watch`, and it is the only place a branch name is minted.

Four rules change, keyed on that prefix so the syncers keep their fast path:

- **`👀 Review Requirements`** — the `mergify-ci-bot` free pass is now
  conditional on the head *not* being a `docs-agent/` branch. Agent pull
  requests fall through to `#approved-reviews-by >= 2`, the same bar as anyone
  else. The `&DefaultReviewCond` anchor is shared, so the hotfix rule tightens
  identically.
- **`automated updates` queue rule** — agent branches are kept out of the
  fast-forward, batch-of-10 lane.
- **`default` queue rule** — and therefore have to be let in here, or they
  would match no queue at all and could not be merged even once approved
  (`auto_merge_conditions: true` auto-queues, then the queue rules route).
  They inherit `squash` and the weekday merge window, like human pull requests.
- **`request review`** — routes agent pull requests to `@devs`, since they now
  need approvals and nothing else would ask for them. Gated on `-draft`, so the
  ten drafts a Monday audit opens do not each ping the team before a human has
  decided one is worth merging.

Not changed: the `automated updates` *priority* rule still matches the agent,
so its pull requests sit at `low` behind human work in the `default` queue.
That reads as correct; say so if it isn't.

## Note on the snippet in the ticket

MRGFY-8340 and `docs-agent/README.md` both propose `-head-ref ~= ^docs-agent/`.
There is no `head-ref` attribute — the 75 condition attributes in
`public/mergify-configuration-schema.json` have `head` ("the name of the branch
where the pull request changes are implemented"). Using `head` here. The
snippet also stopped at two rules; the `default` queue and review routing above
are the rest of the change.

## Validation

- `mergify config validate` on a merge-key-expanded copy of this file: valid.
  (Run against the file as written it reports three pre-existing
  `'<<' was unexpected` errors — the CLI's loader does not resolve YAML merge
  keys. Same three before and after this change.)
- `mergify config simulate https://github.com/Mergifyio/docs/pull/12272` (a real
  `mergify-ci-bot` schema-sync pull request, from the fork) with this config:
  `-head ~= ^docs-agent/` evaluates true, the free pass holds, and `request
  review` stays not-applicable. The syncers are unaffected.
- Same simulation with the regex swapped to `^json-schema-` so that it matches
  #12272's actual head: the free pass collapses, `#approved-reviews-by >= 2`
  becomes the operative condition, and `request review` activates. That is the
  docs-agent path, demonstrated on a real pull request rather than read by eye.
- `pnpm check`: green.

No `docs-agent/` pull request exists yet to simulate against directly — the
first one arrives with the first scheduled run.

MRGFY-8340