### PR TITLE
feat(docs): accept the namespaced documented-data-type marker

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "rehype-autolink-headings": "^7.1.0",
     "rehype-format": "^5.0.1",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark-lint": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       rehype-slug:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3256,6 +3259,9 @@ packages:
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-select@6.0.4:
     resolution: {integrity: sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==}
 
@@ -4427,6 +4433,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
@@ -9112,6 +9121,12 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@ungap/structured-clone': 1.3.1
+      unist-util-position: 5.0.0
+
   hast-util-select@6.0.4:
     dependencies:
       '@types/hast': 3.0.5
@@ -10644,6 +10659,11 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-sanitize: 5.0.2
 
   rehype-slug@6.0.0:
     dependencies:

--- a/src/components/Tables/QueueDequeueReasons.tsx
+++ b/src/components/Tables/QueueDequeueReasons.tsx
@@ -1,17 +1,17 @@
+import { readEnumChoices } from '../../util/enumChoices';
 import configSchema from '../../util/sanitizedConfigSchema';
 
 import { renderMarkdown } from './utils';
 
 // The `queue-dequeue-reason` condition attribute accepts one of the merge queue
-// dequeue codes. The engine is the single source of truth: the codes come from
-// the attribute's enum, and a one-line description for each is published
-// alongside it under `x-enum-descriptions` (keyed by the raw code). Driving the
-// code list from the enum keeps the table current even before a schema sync
-// delivers the descriptions.
+// dequeue codes. The engine is the single source of truth: the codes and their
+// one-line descriptions are published on the attribute itself, so this table
+// stays current without being hand-maintained.
 //
-// `x-enum-descriptions` is not in the synced schema until the engine ships it,
-// so it is absent from the JSON-derived types and read via a cast (it becomes a
-// normal typed key once the sync bot lands it).
+// `readEnumChoices` handles every shape the engine can publish here — a flat
+// `enum`, the `anyOf` of `const`/`enum` branches a composed `Literal` produces
+// today, or a `$ref` to a shared component — and reads the documentation from
+// either `x-mergify-enum` or the older `x-enum-descriptions` map.
 //
 // The lookup is optional-chained through a loose cast so a future schema reshape
 // (renamed attribute or restructured `$defs`) degrades to an empty table rather
@@ -22,28 +22,6 @@ const reasonProp: unknown = (
   }
 ).$defs?.PullRequestAttributes?.properties?.['queue-dequeue-reason'];
 
-type EnumNode = { anyOf?: EnumNode[]; enum?: string[]; const?: string };
-
-function branchValues(node: EnumNode): string[] {
-  if (node.const !== undefined) {
-    return [node.const];
-  }
-  return node.enum ?? [];
-}
-
-// Collect the raw enum values the attribute accepts, tolerating the shapes the
-// engine might emit: an `anyOf` of `{const}` / `{enum}` branches (today), or a
-// flat `{enum}` / `{const}`. Returns [] for anything else (or a missing node),
-// so a future schema-shape change degrades to an empty table rather than
-// crashing the Astro build.
-function enumValues(prop: unknown): string[] {
-  if (!prop || typeof prop !== 'object') {
-    return [];
-  }
-  const node = prop as EnumNode;
-  return node.anyOf ? node.anyOf.flatMap(branchValues) : branchValues(node);
-}
-
 // The engine stores codes as `UPPER_SNAKE`; conditions are written in kebab-case
 // (the parser normalizes `upper().replace('-', '_')`), so that is what to show.
 function toKebab(code: string): string {
@@ -51,10 +29,7 @@ function toKebab(code: string): string {
 }
 
 export default function QueueDequeueReasons() {
-  const descriptions =
-    (reasonProp as { 'x-enum-descriptions'?: Record<string, string> } | undefined)?.[
-      'x-enum-descriptions'
-    ] ?? {};
+  const choices = readEnumChoices(configSchema, reasonProp);
 
   return (
     <div className="table-wrap">
@@ -66,12 +41,12 @@ export default function QueueDequeueReasons() {
           </tr>
         </thead>
         <tbody>
-          {enumValues(reasonProp).map((code) => (
-            <tr key={code}>
+          {choices.map((choice) => (
+            <tr key={choice.value}>
               <td>
-                <code>{toKebab(code)}</code>
+                <code>{toKebab(choice.value)}</code>
               </td>
-              <td dangerouslySetInnerHTML={{ __html: renderMarkdown(descriptions[code] ?? '') }} />
+              <td dangerouslySetInnerHTML={{ __html: renderMarkdown(choice.description) }} />
             </tr>
           ))}
         </tbody>

--- a/src/components/Tables/utils.test.ts
+++ b/src/components/Tables/utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { renderMarkdown } from './utils';
+
+// `renderMarkdown` output is injected with `dangerouslySetInnerHTML` by every
+// schema-driven table, so what it lets through is a security property.
+//
+// Two different layers provide that, and it is worth keeping them apart: raw
+// HTML never survives because `remark-rehype` runs without
+// `allowDangerousHtml`, which is true with or without the sanitizer. Only the
+// URL-protocol filtering below actually exercises `rehype-sanitize` — those
+// are the assertions that fail if it is removed.
+describe('renderMarkdown', () => {
+  it('renders the markdown the schema descriptions actually use', () => {
+    const html = renderMarkdown('A [real link](https://example.com) and `code`.');
+    expect(html).toContain('<a href="https://example.com">real link</a>');
+    expect(html).toContain('<code>code</code>');
+  });
+
+  it('keeps relative links, anchors and mailto', () => {
+    expect(renderMarkdown('[a](/merge-queue/batches)')).toContain('href="/merge-queue/batches"');
+    expect(renderMarkdown('[a](#batch-status)')).toContain('href="#batch-status"');
+    expect(renderMarkdown('[a](mailto:x@example.com)')).toContain('href="mailto:x@example.com"');
+  });
+
+  // These are the sanitizer's own guarantee: `remark-rehype` emits an <a> for
+  // any link target, whatever its protocol, so without `rehype-sanitize` each
+  // of these renders as a live link.
+  describe('URL protocol filtering (rehype-sanitize)', () => {
+    it('strips a javascript: link rather than emitting a live one', () => {
+      const html = renderMarkdown('[click](javascript:alert(1))');
+      expect(html).toContain('click');
+      expect(html).not.toContain('javascript:');
+    });
+
+    it('strips a case-obfuscated javascript: link', () => {
+      expect(renderMarkdown('[click](JaVaScRiPt:alert(1))')).not.toContain('alert(1)');
+    });
+
+    it('strips a data: URL on an image', () => {
+      expect(renderMarkdown('![x](data:text/html;base64,PHNjcmlwdD4=)')).not.toContain(
+        'data:text/html'
+      );
+    });
+  });
+
+  // Kept as a regression pin on the pipeline as a whole, not on the sanitizer:
+  // these pass because raw HTML is discarded before it becomes a node. If a
+  // caller ever enables `allowDangerousHtml`, `rehype-raw` parses it and the
+  // sanitizer becomes what keeps these green.
+  describe('raw HTML never reaches the output', () => {
+    it('drops an event handler', () => {
+      expect(renderMarkdown('<img src=x onerror="alert(1)">')).not.toContain('onerror');
+    });
+
+    it('drops a script tag', () => {
+      expect(renderMarkdown('<script>alert(1)</script>')).not.toContain('<script');
+    });
+  });
+});

--- a/src/components/Tables/utils.ts
+++ b/src/components/Tables/utils.ts
@@ -1,17 +1,35 @@
 import rehypeFormat from 'rehype-format';
 import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
 import { unified } from 'unified';
 
+/**
+ * Render a short markdown string (a schema description, a template variable
+ * blurb) to HTML for injection via `dangerouslySetInnerHTML`.
+ *
+ * Sanitized on the way out. The input is always first-party — descriptions
+ * synced from the engine's schemas — so this is defence in depth rather than a
+ * response to untrusted input, but the output goes straight into the DOM and
+ * several tables share this helper, so the guarantee belongs here and not in
+ * each caller. Without it, `[x](javascript:...)` in a description would render
+ * as a live `javascript:` link: `remark-rehype` does not filter URL protocols,
+ * and being first-party is a property of today's callers, not of this function.
+ *
+ * `rehype-raw` is kept ahead of the sanitizer so that if a caller ever enables
+ * `allowDangerousHtml`, the embedded HTML is parsed and then sanitized rather
+ * than passed through as an opaque raw node.
+ */
 export function renderMarkdown(markdown: string) {
   const file = unified()
     .use(remarkParse)
     .use(remarkRehype)
+    .use(rehypeRaw)
+    .use(rehypeSanitize)
     .use(rehypeFormat)
     .use(rehypeStringify)
-    .use(rehypeRaw)
     .processSync(markdown);
 
   return file.toString();

--- a/src/util/dataType.test.ts
+++ b/src/util/dataType.test.ts
@@ -4,9 +4,20 @@ import { collectDataTypeTitles, getDataTypeHref, isDataType } from './dataType';
 import { dataTypesHeadingAnchors, missingDataTypeAnchors } from './dataTypeAnchors';
 
 describe('isDataType', () => {
-  it('recognizes flagged nodes only', () => {
+  it('recognizes the namespaced marker', () => {
+    expect(isDataType({ 'x-mergify-has-data-type': true })).toBe(true);
+    expect(isDataType({ 'x-mergify-has-data-type': 'queue-dequeue-reason' })).toBe(false);
+  });
+
+  // The engine is renaming the key, and syncs land as direct pushes to main,
+  // so a schema carrying either spelling has to keep working until no synced
+  // schema publishes the old one.
+  it('still recognizes the legacy marker', () => {
     expect(isDataType({ 'x-has-data-type': true })).toBe(true);
     expect(isDataType({ 'x-has-data-type': 'queue-dequeue-reason' })).toBe(false);
+  });
+
+  it('rejects everything else', () => {
     expect(isDataType({ type: 'string' })).toBe(false);
     expect(isDataType(null)).toBe(false);
     expect(isDataType('string')).toBe(false);
@@ -23,17 +34,17 @@ describe('getDataTypeHref', () => {
 });
 
 describe('collectDataTypeTitles', () => {
-  it('finds flagged nodes wherever they appear in a schema', () => {
+  it('finds flagged nodes wherever they appear, in either spelling', () => {
     const schema = {
       $defs: {
-        ReportMode: { 'x-has-data-type': true, title: 'Report Mode' },
+        ReportMode: { 'x-mergify-has-data-type': true, title: 'Report Mode' },
       },
       properties: {
         reason: {
           anyOf: [{ 'x-has-data-type': true, title: 'Queue dequeue reason' }, { type: 'null' }],
         },
         report_mode: { type: 'array', items: { $ref: '#/$defs/ReportMode' } },
-        untitled: { 'x-has-data-type': true },
+        untitled: { 'x-mergify-has-data-type': true },
       },
     };
     expect(collectDataTypeTitles(schema).sort()).toEqual([

--- a/src/util/dataType.ts
+++ b/src/util/dataType.ts
@@ -1,24 +1,30 @@
 import { slugify } from './slugify';
 
 // The engine flags a schema node that corresponds to a documented Mergify
-// data type with `x-has-data-type: true`. Everything else derives from the node's
-// standard `title`: the link label is the title, and the link target is the
-// slugified title, which by convention equals the section heading anchor on
-// /configuration/data-types. The convention is enforced where drift can
+// data type with `x-mergify-has-data-type: true`. Everything else derives from
+// the node's standard `title`: the link label is the title, and the link target
+// is the slugified title, which by convention equals the section heading anchor
+// on /configuration/data-types. The convention is enforced where drift can
 // actually arrive: the Astro build fails when a marked title has no matching
 // heading anchor (schema syncs land as direct pushes to main, so the deploy
 // build is the gate), and dataType.test.ts gives the same signal earlier, in
 // PR CI.
-const DATA_TYPE_KEY = 'x-has-data-type';
+//
+// `x-has-data-type` is the legacy spelling, still accepted because a synced
+// schema can carry either during the engine-side rename: syncs land as direct
+// pushes to main, so the docs repo cannot assume both sides move together.
+// Reading both keeps the marker working in whichever direction the two repos
+// merge, and this fallback can go once no synced schema publishes the old key.
+const DATA_TYPE_KEYS = ['x-mergify-has-data-type', 'x-has-data-type'] as const;
 
 const DATA_TYPES_PAGE = '/configuration/data-types';
 
 export function isDataType(definition: unknown): boolean {
-  return (
-    !!definition &&
-    typeof definition === 'object' &&
-    (definition as Record<string, unknown>)[DATA_TYPE_KEY] === true
-  );
+  if (!definition || typeof definition !== 'object') {
+    return false;
+  }
+  const node = definition as Record<string, unknown>;
+  return DATA_TYPE_KEYS.some((key) => node[key] === true);
 }
 
 export function getDataTypeHref(title: string): string {
@@ -26,11 +32,11 @@ export function getDataTypeHref(title: string): string {
 }
 
 /**
- * Walk a JSON schema and return the `title` of every node flagged
- * `x-has-data-type: true`, wherever the flag appears (inline property nodes,
- * `$ref` siblings, `$defs` entries, array items, `anyOf` branches). A marked
- * node without a title yields `undefined` — an invalid marker the anchor
- * check reports.
+ * Walk a JSON schema and return the `title` of every node flagged as a
+ * documented data type, in either spelling, wherever the flag appears (inline
+ * property nodes, `$ref` siblings, `$defs` entries, array items, `anyOf`
+ * branches). A marked node without a title yields `undefined` — an invalid
+ * marker the anchor check reports.
  */
 export function collectDataTypeTitles(
   node: unknown,

--- a/src/util/enumChoices.test.ts
+++ b/src/util/enumChoices.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { readEnumChoices, resolveRef } from './enumChoices';
+
+// This reader spans an engine-side migration, so each shape it has to survive
+// is pinned here. Every failure mode below is silent by nature — a shape it
+// mishandles renders a header with an empty or subtly wrong table rather than
+// failing the build — which is why they are tested rather than left to review.
+describe('readEnumChoices', () => {
+  it('reads the target shape: x-mergify-enum aligned with enum', () => {
+    expect(
+      readEnumChoices(
+        {},
+        {
+          enum: ['running', 'failed'],
+          'x-mergify-enum': [
+            { title: 'CI Running', description: 'Checks are running.' },
+            { title: 'Failed', description: 'Checks failed.', deprecated: true },
+          ],
+        }
+      )
+    ).toEqual([
+      {
+        value: 'running',
+        title: 'CI Running',
+        description: 'Checks are running.',
+        deprecated: false,
+      },
+      { value: 'failed', title: 'Failed', description: 'Checks failed.', deprecated: true },
+    ]);
+  });
+
+  it('falls back to the x-enum-descriptions map while the engine migrates', () => {
+    expect(
+      readEnumChoices(
+        {},
+        { enum: ['a', 'b'], 'x-enum-descriptions': { a: 'First.', b: 'Second.' } }
+      )
+    ).toEqual([
+      { value: 'a', title: undefined, description: 'First.', deprecated: false },
+      { value: 'b', title: undefined, description: 'Second.', deprecated: false },
+    ]);
+  });
+
+  it('merges the two shapes so a half-migrated node keeps every description', () => {
+    // Both shapes can coexist on one node mid-migration; treating them as
+    // alternatives would blank values the schema still documents.
+    const choices = readEnumChoices(
+      {},
+      {
+        enum: ['a', 'b', 'c'],
+        'x-mergify-enum': [{ description: 'A new' }, {}, {}],
+        'x-enum-descriptions': { a: 'A old', b: 'B old', c: 'C old' },
+      }
+    );
+    expect(choices.map((c) => c.description)).toEqual(['A new', 'B old', 'C old']);
+  });
+
+  it('flattens a composed Literal published as anyOf of const/enum branches', () => {
+    expect(
+      readEnumChoices(
+        {},
+        {
+          anyOf: [{ const: 'NONE' }, { enum: ['MERGED', 'DEQUEUED'] }],
+          'x-enum-descriptions': { NONE: 'Not queued.' },
+        }
+      ).map((c) => c.value)
+    ).toEqual(['NONE', 'MERGED', 'DEQUEUED']);
+  });
+
+  it('resolves a $ref to a hoisted component', () => {
+    const root = {
+      components: {
+        schemas: {
+          Outcome: {
+            enum: ['success'],
+            'x-mergify-enum': [{ title: 'Success', description: 'It passed.' }],
+          },
+        },
+      },
+    };
+    expect(readEnumChoices(root, { $ref: '#/components/schemas/Outcome' })).toEqual([
+      { value: 'success', title: 'Success', description: 'It passed.', deprecated: false },
+    ]);
+  });
+
+  it('resolves a $ref sitting inside an anyOf branch', () => {
+    // What an optional hoisted enum looks like: {anyOf: [{$ref}, {type: null}]}.
+    // Resolving only the top node would yield nothing at all.
+    const root = {
+      $defs: {
+        Reason: {
+          enum: ['A', 'B'],
+          'x-mergify-enum': [{ description: 'a' }, { description: 'b' }],
+        },
+      },
+    };
+    const choices = readEnumChoices(root, {
+      anyOf: [{ $ref: '#/$defs/Reason' }, { type: 'null' }],
+    });
+    expect(choices.map((c) => c.value)).toEqual(['A', 'B']);
+    expect(choices.map((c) => c.description)).toEqual(['a', 'b']);
+  });
+
+  it('reads metadata published as a $ref sibling, not only on the target', () => {
+    // Pydantic publishes an annotation inline for an inlined type but as a
+    // sibling of `$ref` once the type is hoisted into `$defs`.
+    const root = { $defs: { Reason: { enum: ['A', 'B'] } } };
+    const choices = readEnumChoices(root, {
+      $ref: '#/$defs/Reason',
+      'x-mergify-enum': [{ description: 'first' }, { description: 'second' }],
+    });
+    expect(choices.map((c) => c.description)).toEqual(['first', 'second']);
+  });
+
+  it('ignores a misaligned x-mergify-enum rather than shifting every description', () => {
+    // Positional metadata whose length disagrees with `enum` describes the
+    // wrong values from the first divergence onward. Publishing nothing beats
+    // publishing confidently wrong sentences.
+    const choices = readEnumChoices(
+      {},
+      {
+        enum: ['b', 'c'],
+        'x-mergify-enum': [
+          { description: 'desc for a' },
+          { description: 'desc for b' },
+          { description: 'desc for c' },
+        ],
+      }
+    );
+    expect(choices.map((c) => c.description)).toEqual(['', '']);
+  });
+
+  it('leaves values undocumented rather than dropping them', () => {
+    const choices = readEnumChoices(
+      {},
+      { enum: ['a', 'b'], 'x-mergify-enum': [{ title: 'A' }, {}] }
+    );
+    expect(choices.map((c) => c.value)).toEqual(['a', 'b']);
+    expect(choices.map((c) => c.description)).toEqual(['', '']);
+  });
+
+  it('reads a single-value choice set published as a non-string const', () => {
+    // A one-value literal publishes `{const: 1}` where a two-value one
+    // publishes `{enum: [1, 2]}`; accepting only string consts would render
+    // the second and silently drop the first.
+    expect(readEnumChoices({}, { const: 1, 'x-mergify-enum': [{ description: 'one' }] })).toEqual([
+      { value: '1', title: undefined, description: 'one', deprecated: false },
+    ]);
+  });
+
+  it('degrades to an empty list instead of throwing on unusable input', () => {
+    expect(readEnumChoices({}, undefined)).toEqual([]);
+    expect(readEnumChoices({}, { type: 'string' })).toEqual([]);
+    expect(readEnumChoices({}, { $ref: '#/nope/missing' })).toEqual([]);
+  });
+});
+
+describe('resolveRef', () => {
+  it('stops on a dangling ref rather than looping or throwing', () => {
+    expect(resolveRef({}, { $ref: '#/a/b' })).toEqual({ $ref: '#/a/b' });
+  });
+
+  it('does not throw on a pointer containing a stray percent sign', () => {
+    // Hand-rolled `decodeURIComponent` on each segment raises URIError here,
+    // which would break the never-throws contract during SSR.
+    const root = { components: { schemas: { 'A%B': { enum: ['x'] } } } };
+    expect(() => resolveRef(root, { $ref: '#/components/schemas/A%B' })).not.toThrow();
+  });
+
+  it('returns non-ref nodes untouched', () => {
+    expect(resolveRef({}, { enum: ['x'] })).toEqual({ enum: ['x'] });
+  });
+});

--- a/src/util/enumChoices.ts
+++ b/src/util/enumChoices.ts
@@ -1,0 +1,207 @@
+import jsonpointer from 'jsonpointer';
+
+// Reading the documented values of a schema "choice set" (an enum and its
+// per-value documentation).
+//
+// The engine is migrating how it publishes that documentation, so this reader
+// deliberately understands every shape a synced schema can currently be in.
+// Schema syncs land as direct pushes to main, so the docs repo cannot assume
+// the engine side has migrated yet — and both shapes may coexist across the
+// configuration schema and the OpenAPI spec for a while.
+//
+// Metadata shapes, which are *merged* rather than treated as alternatives so a
+// half-migrated node keeps rendering every description it publishes:
+//   - `x-mergify-enum`: a positional array of `{title, description, deprecated}`
+//     aligned with `enum`. The target shape.
+//   - `x-enum-descriptions`: a map of raw value -> description sentence. The
+//     previous shape; carries no per-value title or deprecation.
+//
+// The values come from `enum`, from a `const`, or from an `anyOf`/`oneOf` of
+// such branches — the shape a composed `Literal` (`Literal["A"] | OtherT`)
+// produces. Branches are `$ref`-resolved too: hoisting a repeated enum into a
+// shared component leaves `{anyOf: [{$ref: ...}, {type: "null"}]}`, and a
+// reader that only resolved the top node would silently render nothing.
+
+export interface EnumChoice {
+  value: string;
+  /** Display label, when the schema publishes one. */
+  title?: string;
+  /** May be empty: a value can be published before it is documented. */
+  description: string;
+  deprecated: boolean;
+}
+
+interface SchemaNode {
+  $ref?: unknown;
+  enum?: unknown;
+  const?: unknown;
+  anyOf?: unknown;
+  oneOf?: unknown;
+  'x-mergify-enum'?: unknown;
+  'x-enum-descriptions'?: unknown;
+}
+
+const MAX_REF_HOPS = 10;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Follow a `$ref` chain from `node` within `root`, returning the node reached.
+ * Stops on a dangling, malformed or cyclic ref and returns what it has, so a
+ * schema reshape degrades to an empty table rather than throwing during the
+ * Astro build.
+ *
+ * Uses the same `jsonpointer` the other schema readers use (ConfigOptions,
+ * schemaToMarkdown) rather than splitting and decoding by hand: a pointer
+ * containing a stray `%` makes `decodeURIComponent` raise, which would break
+ * the never-throws contract this function advertises.
+ */
+export function resolveRef(root: unknown, node: unknown): unknown {
+  let current = node;
+  for (let hop = 0; hop < MAX_REF_HOPS; hop++) {
+    if (!isObject(current)) {
+      return current;
+    }
+    const ref = (current as SchemaNode).$ref;
+    if (typeof ref !== 'string' || !ref.startsWith('#/')) {
+      return current;
+    }
+    let target: unknown;
+    try {
+      target = jsonpointer.get(root as object, ref.slice(1));
+    } catch {
+      return current;
+    }
+    if (target === undefined || target === null) {
+      return current;
+    }
+    current = target;
+  }
+  return current;
+}
+
+/**
+ * The raw values a resolved node accepts directly (no branch recursion).
+ *
+ * `const` is stringified the same way `enum` entries are: a single-value
+ * choice set publishes `{const: 1}` where a multi-value one publishes
+ * `{enum: [1, 2]}`, and accepting only strings would silently drop the
+ * former while rendering the latter.
+ */
+function ownValues(node: SchemaNode): string[] {
+  if (Array.isArray(node.enum)) {
+    return node.enum.map(String);
+  }
+  const single = node.const;
+  if (single !== undefined && single !== null && typeof single !== 'object') {
+    return [String(single)];
+  }
+  return [];
+}
+
+/**
+ * Per-value metadata published on `node` or on any node its `$ref` chain
+ * passes through.
+ *
+ * Pydantic publishes an annotation inline for an inlined type but as a
+ * *sibling of `$ref`* for a type hoisted into `$defs`, so both the raw node
+ * and the resolved target have to be consulted — the same walk
+ * `ConfigOptions.getDataTypeLink` performs for `x-has-data-type`. Nearest wins:
+ * a sibling on the referring node overrides the shared component.
+ */
+function collectMetadata(root: unknown, node: unknown): SchemaNode {
+  const merged: SchemaNode = {};
+  let current = node;
+  for (let hop = 0; hop < MAX_REF_HOPS && isObject(current); hop++) {
+    const schema = current as SchemaNode;
+    if (merged['x-mergify-enum'] === undefined && Array.isArray(schema['x-mergify-enum'])) {
+      merged['x-mergify-enum'] = schema['x-mergify-enum'];
+    }
+    if (merged['x-enum-descriptions'] === undefined && isObject(schema['x-enum-descriptions'])) {
+      merged['x-enum-descriptions'] = schema['x-enum-descriptions'];
+    }
+    const ref = schema.$ref;
+    if (typeof ref !== 'string' || !ref.startsWith('#/')) {
+      break;
+    }
+    let next: unknown;
+    try {
+      next = jsonpointer.get(root as object, ref.slice(1));
+    } catch {
+      break;
+    }
+    if (next === undefined || next === null) {
+      break;
+    }
+    current = next;
+  }
+  return merged;
+}
+
+/**
+ * The documented choices of `node` (which may be a `$ref` into `root`).
+ * Returns [] for anything that is not a choice set.
+ *
+ * Branch unions are flattened by concatenation, and each branch supplies the
+ * metadata for its own values — so a hoisted enum keeps its descriptions
+ * whether the `$ref` sits at the top of the node or inside one of its
+ * branches.
+ */
+export function readEnumChoices(root: unknown, node: unknown): EnumChoice[] {
+  return read(root, node, {});
+}
+
+function read(root: unknown, node: unknown, inherited: SchemaNode): EnumChoice[] {
+  const resolved = resolveRef(root, node);
+  if (!isObject(resolved)) {
+    return [];
+  }
+
+  // Metadata on this node wins over anything inherited from an enclosing
+  // union. The engine publishes the annotations at the top of an optional
+  // node while the values sit in its non-null branch, so a branch with no
+  // metadata of its own must still see the parent's.
+  const own = collectMetadata(root, node);
+  const meta: SchemaNode = {
+    'x-mergify-enum': own['x-mergify-enum'] ?? inherited['x-mergify-enum'],
+    'x-enum-descriptions': own['x-enum-descriptions'] ?? inherited['x-enum-descriptions'],
+  };
+
+  const values = ownValues(resolved as SchemaNode);
+  if (values.length === 0) {
+    const branches = (resolved as SchemaNode).anyOf ?? (resolved as SchemaNode).oneOf;
+    if (Array.isArray(branches)) {
+      return branches.flatMap((branch) => read(root, branch, meta));
+    }
+    return [];
+  }
+
+  const entries = meta['x-mergify-enum'];
+  // `x-mergify-enum` is positional, so a length mismatch means every entry
+  // after the first divergence describes the wrong value. Publishing 40 subtly
+  // wrong sentences is worse than publishing none, and the misalignment is
+  // otherwise undetectable — the map shape this replaced could not drift.
+  const aligned = Array.isArray(entries) && entries.length === values.length ? entries : undefined;
+
+  const legacy = meta['x-enum-descriptions'];
+  const descriptions = isObject(legacy) ? legacy : {};
+
+  return values.map((value, index) => {
+    const entry = aligned?.[index];
+    const positional = isObject(entry) ? entry : {};
+    const fallback = descriptions[value];
+    return {
+      value,
+      title: typeof positional.title === 'string' ? positional.title : undefined,
+      description:
+        typeof positional.description === 'string' && positional.description !== ''
+          ? positional.description
+          : typeof fallback === 'string'
+            ? fallback
+            : '',
+      deprecated: positional.deprecated === true,
+    };
+  });
+}


### PR DESCRIPTION
The engine is renaming its documented-data-type flag from
`x-has-data-type` to `x-mergify-has-data-type`, matching the namespacing
already used for `x-mergify-enum`. An unprefixed `x-` key is a claim on a
name nobody owns, which is how `x-enum-descriptions` ended up meaning a
positional array of strings to openapi-generator and a map to us.

Read both spellings. Schema syncs land as direct pushes to main, so the
docs repo cannot assume the two sides move together: whichever order the
repos merge in, a synced schema can carry either key, and a reader that
knew only one would take the anchor gate offline without failing
anything. The fallback can go once no synced schema publishes the old
key.

Only `isDataType` reads the flag directly — the anchor collector, both
config tables and the build gate all go through it — so accepting both is
one predicate, not a sweep.

This lands before the schemas that carry the new key, so the gate never
sees a marker it cannot read.

Part of MRGFY-8330

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Depends-On: #12304