### PR TITLE
docs(skills): fix the capture-screenshots image root and identity guidance

### DIFF
--- a/.claude/skills/capture-screenshots/SKILL.md
+++ b/.claude/skills/capture-screenshots/SKILL.md
@@ -17,10 +17,10 @@ Produce clean, consistent screenshots of the Mergify dashboard
 
 ## Two ways to capture
 
-**Prefer the internal Playwright tool for batch or unattended captures.** The
-capture tool in the **`Mergifyio/skills`** repo runs headless Chromium at
-`deviceScaleFactor: 2` and writes PNG bytes straight to disk. It owns the
-session/auth handling, which is intentionally kept out of this public repo.
+**Prefer the internal Playwright tool for batch or unattended captures.** It
+runs headless Chromium at `deviceScaleFactor: 2` and writes PNG bytes straight
+to disk. It also owns the session/auth handling, which — like the tool itself —
+is intentionally kept out of this public repo.
 
 **Use the interactive Chrome path below when you are working alongside the user**
 — exploring the dashboard, framing a one-off shot, or capturing a state that is
@@ -29,6 +29,14 @@ against the user's own logged-in session.
 
 Either way, the docs-side conventions are the same: framing, directory/naming,
 and the `<Image>` wiring snippet — see `references/conventions.md`.
+
+**Prefer a capture that carries no account identity at all.** This repo is
+public, so every shot is published. A capture taken from a live logged-in
+account puts that org name, user name, avatar and repository names into the
+docs — it has happened before. A dashboard dev build can be rendered from
+seeded mock data with no session at all; ask for that path when the shot only
+needs to show the UI. When a shot must come from a real session, crop to the
+content pane so the sidebar's org/user header stays out of frame.
 
 ## Prerequisite (interactive path)
 
@@ -69,7 +77,7 @@ ToolSearch select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome_
 5. **Capture** — take the screenshot with the `computer` tool. Frame the relevant
    region; capture the specific panel rather than the whole chrome when possible.
 6. **Save** — write the image to
-   `src/content/docs/images/<section>/<page>/<kebab-name>.png` following the
+   `src/content/images/<section>/<page>/<kebab-name>.png` following the
    naming convention.
 7. **Emit the snippet** — output the ready-to-paste import + `<Image>` tag with
    drafted alt text (see below). Hand it back so it can be dropped into the MDX

--- a/.claude/skills/capture-screenshots/references/conventions.md
+++ b/.claude/skills/capture-screenshots/references/conventions.md
@@ -29,9 +29,9 @@ than a cramped window — never upscale a small capture.
 Capture at **2× (retina)**. The existing docs screenshots are all 2× — a 1×
 capture renders visibly softer next to them. How you get 2× depends on the path:
 
-- **Internal Playwright tool** (`Mergifyio/skills`) — sets
-  `deviceScaleFactor: 2` explicitly alongside `viewport 1440×900` and writes
-  `page.screenshot()` bytes straight to disk, so 2× is captured natively.
+- **Internal Playwright tool** — sets `deviceScaleFactor: 2` explicitly
+  alongside `viewport 1440×900` and writes `page.screenshot()` bytes straight to
+  disk, so 2× is captured natively.
 - **Interactive claude-in-chrome capture** — there is no `deviceScaleFactor`
   knob. Capture on a **2×/retina display at 100% browser zoom**; anything else
   yields a soft 1× shot. Check the PNG's pixel dimensions against its CSS region
@@ -49,7 +49,7 @@ side by side with matching framing.
 Save to:
 
 ```
-src/content/docs/images/<section>/<page>/<kebab-name>.png
+src/content/images/<section>/<page>/<kebab-name>.png
 ```
 
 - `<section>` mirrors the docs section (`merge-queue`, `integrations`,
@@ -59,7 +59,7 @@ src/content/docs/images/<section>/<page>/<kebab-name>.png
 - `<kebab-name>` describes the content: `queue-view-batched-prs.png`, not
   `screenshot-1.png`.
 
-Match the existing layout under `src/content/docs/images/` — look before you
+Match the existing layout under `src/content/images/` — look before you
 create a new subfolder.
 
 ## Overlay dismissal
@@ -113,3 +113,9 @@ the resulting URL with `read_page` rather than guessing.
   keeps the reader focused and survives unrelated UI changes.
 - Avoid capturing personal account names or other customers' data — use the
   user's own org or a demo org.
+- **Crop out the sidebar unless the navigation is the point.** It carries the
+  org name, the signed-in user's name and their avatar, and it is also the part
+  of the dashboard that changes most often — a shot framed around it goes stale
+  every time a nav item is renamed or added, even when the feature it documents
+  has not changed at all. The content pane starts at x=280 in the standard
+  1440-wide viewport.


### PR DESCRIPTION
Two things in the capture skill helped a stale, identity-carrying screenshot
live in the docs for two years.

- **The documented image root was wrong.** It said
  `src/content/docs/images/`; the real one is `src/content/images/` — every
  page imports `../../images/...` and the collection reads nothing under
  `docs/images/`. Anyone following the skill wrote to a directory the site does
  not serve. It was flagged as a follow-up a fortnight ago and never fixed.
- **Neither capture path said anything about account identity, and this repo
  is public.** Shots taken from a live logged-in session have already published
  real org, user and repository names. The skill now says to prefer a capture
  that carries no account identity, and to crop the sidebar out when a live
  session is unavoidable.

The sidebar rule is the durable half: it carries the org name, the signed-in
user's name and their avatar, and it is also the fastest-changing part of the
dashboard, so a shot framed around it goes stale every time a nav item is
renamed even when the documented feature has not moved.

Also drops the internal repository name from both files. This repo is public
and that repository is not, so naming it disclosed something the instructions
never needed — the tool is described by what it does instead.

Refs MRGFY-8272

Depends-On: #12303