### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,11 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Check workflow files
-        uses: docker://rhysd/actionlint:1.7.8
+        # yamllint disable-line rule:line-length
+        uses: docker://rhysd/actionlint@sha256:96d4a8c87dbbfb3bdd324f8fdc285fc3df5261e2decc619a4dd7e8ee52bbfd46  # 1.7.8
         with:
           args: -color
 
@@ -28,13 +29,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup pnpm 📦
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
 
       - name: Setup Node 🔧
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           cache: pnpm
           node-version-file: .node-version
@@ -49,13 +50,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup pnpm 📦
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
 
       - name: Setup Node 🔧
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           cache: pnpm
           node-version-file: .node-version
@@ -70,13 +71,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup pnpm 📦
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
 
       - name: Setup Node 🔧
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           cache: pnpm
           node-version-file: .node-version
@@ -91,10 +92,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node 🔧
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version-file: .node-version
 
@@ -108,13 +109,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup pnpm 📦
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
 
       - name: Setup Node 🔧
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           cache: pnpm
           node-version-file: .node-version
@@ -125,7 +126,7 @@ jobs:
           pnpm build
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: dist
           path: dist/
@@ -136,19 +137,19 @@ jobs:
     needs: build
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup pnpm 📦
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
 
       - name: Setup Node 🔧
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           cache: pnpm
           node-version-file: .node-version
 
       - name: Download build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
A tag is a mutable pointer. Anyone who can move `v7.0.1` (an upstream
compromise, a maintainer force-pushing a tag) silently changes what runs
in our CI, with our secrets in scope. Pin every third-party `uses:` to a
full 40-character commit SHA with the human-readable version in a
trailing comment, matching the convention already used in the monorepo.
Dependabot preserves that format and keeps bumping both the SHA and the
comment.

No version changes: every SHA is the commit the ref already resolved to.
Two of them were floating major tags rather than exact ones, so
`upload-artifact@v7` and `download-artifact@v8` now read `# v7.0.1` and
`# v8.0.1`, the releases those majors currently point at. Nothing moves
today, but Dependabot will start opening the patch and minor bumps it
used to absorb silently inside the major tag.

`docker://rhysd/actionlint:1.7.8` was a mutable tag too, and carries
exactly the same risk, so it moves to its digest with the version in the
comment. Dependabot has never bumped this ref (last touched by hand in
"ci: upgrade actionlint"), so pinning the digest freezes nothing that was
not already frozen.

`Mergifyio/gha-slack-notification@main` is deliberately left floating.
The threat this commit addresses is a third party moving a tag under us;
that action is ours, so it is not in that threat model, and pinning it
would cost a manual SHA bump forever (it publishes no tags, and this repo
runs Dependabot rather than Renovate, so nothing would refresh it).

Verified against the GitHub and Docker registry APIs; actionlint passes.