### PR TITLE
fix(docs): link documented data types from the API reference

### DIFF
--- a/src/components/ApiReference/openapi.test.ts
+++ b/src/components/ApiReference/openapi.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import apiSchema from '../../../public/api-schemas.json';
-import { getTypeLabel, resolveRef } from './openapi';
+import { getTypeLabel, renderSchemaHtml, resolveRef } from './openapi';
 
 type Spec = Parameters<typeof getTypeLabel>[1];
 type Node = Parameters<typeof getTypeLabel>[0];
@@ -46,5 +46,67 @@ describe('resolveRef', () => {
   it('returns the node it was given for a dangling ref', () => {
     const node = { $ref: '#/components/schemas/Nope' } as RefNode;
     expect(resolveRef(node, { components: { schemas: {} } } as unknown as Spec)).toEqual(node);
+  });
+});
+
+// The engine marks a schema node as a documented data type; on the config side
+// `ConfigOptions` turns that into a link. The API reference publishes the same
+// marker, so it has to resolve too — otherwise the docs build enforces an
+// anchor for a link nothing renders.
+describe('documented data type links', () => {
+  it('links a marked enum to its data-types section, keeping the values', () => {
+    const html = renderSchemaHtml(
+      {
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+            enum: ['running', 'frozen'],
+            title: 'Batch Status',
+            'x-mergify-has-data-type': true,
+          },
+        },
+      } as never,
+      { components: { schemas: {} } } as never
+    );
+    expect(html).toContain('/configuration/data-types#batch-status');
+    expect(html).toContain('Batch Status');
+    expect(html).toContain('<code>running</code>');
+  });
+
+  it('leaves an unmarked enum alone', () => {
+    const html = renderSchemaHtml(
+      {
+        type: 'object',
+        properties: { code: { type: 'string', enum: ['a', 'b'], title: 'Code' } },
+      } as never,
+      { components: { schemas: {} } } as never
+    );
+    expect(html).toContain('<code>a</code>');
+    expect(html).not.toContain('/configuration/data-types');
+  });
+
+  it('finds the marker on a $ref sibling as well as on the target', () => {
+    const root = {
+      components: {
+        schemas: { BatchStatusCode: { type: 'string', enum: ['running'], title: 'Batch Status' } },
+      },
+    };
+    const html = renderSchemaHtml(
+      {
+        type: 'object',
+        properties: {
+          code: { $ref: '#/components/schemas/BatchStatusCode', 'x-mergify-has-data-type': true },
+        },
+      } as never,
+      root as never
+    );
+    expect(html).toContain('/configuration/data-types#batch-status');
+  });
+
+  it("renders the real spec's batch status link", () => {
+    const spec = apiSchema as never as { components: { schemas: Record<string, unknown> } };
+    const html = renderSchemaHtml(spec.components.schemas.BatchStatus as never, apiSchema as never);
+    expect(html).toContain('/configuration/data-types#batch-status');
   });
 });

--- a/src/components/ApiReference/openapi.ts
+++ b/src/components/ApiReference/openapi.ts
@@ -1,3 +1,4 @@
+import { getDataTypeHref, isDataType } from '~/util/dataType';
 import { slugify } from '~/util/slugify';
 
 export interface OpenAPISpec {
@@ -112,6 +113,29 @@ export function resolveRef(schema: SchemaObject, root: OpenAPISpec): SchemaObjec
     result = result[key] as Record<string, unknown>;
   }
   return (result ?? schema) as unknown as SchemaObject;
+}
+
+/**
+ * A "see <data type>" link for a node the engine flags as a documented data
+ * type, or '' for anything else.
+ *
+ * The values themselves stay rendered beside it: an API consumer needs to know
+ * what the field accepts, and the marker only says the meaning of those values
+ * is written up elsewhere. That is also why the type label is left alone —
+ * swapping the accepted values for a title there is exactly the regression that
+ * hoisting shared enums into components already caused once.
+ *
+ * The flag can sit on the referring node or on the `$ref` target, since
+ * pydantic publishes it inline for an inlined type and as a `$ref` sibling for
+ * a hoisted one, so both are checked. The title is what the anchor derives
+ * from, and the docs build fails when a marked title has no matching heading —
+ * so a link built here cannot point at a section that does not exist.
+ */
+function dataTypeLinkHtml(node: SchemaObject, resolved: SchemaObject): string {
+  if (!isDataType(node) && !isDataType(resolved)) return '';
+  const title = resolved.title ?? node.title;
+  if (!title) return '';
+  return ` <span class="schema-enum-doc">see <a href="${getDataTypeHref(title)}">${escapeHtml(title)}</a></span>`;
 }
 
 export function getRefName(schema: SchemaObject): string | null {
@@ -470,7 +494,7 @@ export function renderSchemaHtml(
         if (description)
           html += `<p class="schema-property-description">${escapeHtml(description)}</p>`;
         if (resolved.enum) {
-          html += `<div class="schema-enum">Enum: ${resolved.enum.map((v: unknown) => `<code>${escapeHtml(String(v))}</code>`).join(' ')}</div>`;
+          html += `<div class="schema-enum">Enum: ${resolved.enum.map((v: unknown) => `<code>${escapeHtml(String(v))}</code>`).join(' ')}${dataTypeLinkHtml(propSchema, resolved)}</div>`;
         }
         html += renderConstraintsHtml(resolved);
         html += '</div>';


### PR DESCRIPTION
The engine flags a schema node as a documented data type, and on the
configuration side `ConfigOptions` turns that flag into a link to the
matching section of the data-types page. The API reference publishes the
same flag and did nothing with it: `BatchStatus.code` rendered its twelve
values with no explanation and no pointer to the section that explains
them — the state documenting it was meant to fix, on the page a reader
most likely arrives from.

That left the convention enforcing something nobody consumed. The build
fails when a marked title has no matching heading, so the anchor was
being maintained for a link the API side never rendered.

Render "see <data type>" beside the values. The values stay: an API
consumer needs to know what a field accepts, and the marker only says
their meaning is written up elsewhere.

The type label is deliberately left alone. Substituting a title for the
accepted values there is exactly the regression that hoisting shared
enums into components caused for fifteen query parameters, and a marked
type used as a parameter would reintroduce it.

The flag is read from the referring node as well as the `$ref` target,
because pydantic publishes it inline for an inlined type and as a `$ref`
sibling for a hoisted one.

Part of MRGFY-8330

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>